### PR TITLE
fix: skip foreign YAML files instead of crashing manifest scanner

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-traefik-gateway-plugin"
+  "feature_directory": "specs/002-fix-routing-dir-manifest-scan"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/001-traefik-gateway-plugin/plan.md
+at specs/002-fix-routing-dir-manifest-scan/plan.md
 <!-- SPECKIT END -->

--- a/internal/handler/teams.go
+++ b/internal/handler/teams.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,41 +63,23 @@ func CreateTeam(filepath string, store state.TeamStore) error {
 	return nil
 }
 
-func walkYAMLFiles(dir string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		ext := filepath.Ext(path)
-		if ext == ".yml" || ext == ".yaml" {
-			files = append(files, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("scanning manifest directory %q: %w", dir, err)
-	}
-	return files, nil
-}
-
 // ApplyTeams scans a directory recursively for team manifests and syncs them all to state.
+// Foreign YAML files (those without a shrine apiVersion) are silently skipped; a notice
+// is printed to stdout when foreign files are found (FR-006).
 func ApplyTeams(manifestDir string, store state.TeamStore) error {
-	files, err := walkYAMLFiles(manifestDir)
+	result, err := manifest.ScanDir(manifestDir)
 	if err != nil {
 		return fmt.Errorf("searching for manifests: %w", err)
 	}
 
-	if len(files) == 0 {
+	if len(result.Shrine) == 0 {
 		fmt.Printf("No team manifests found in %q directory.\n", manifestDir)
 		return nil
 	}
 
 	count := 0
-	for _, file := range files {
+	for _, candidate := range result.Shrine {
+		file := candidate.Path
 		m, err := manifest.Parse(file)
 		if err != nil {
 			fmt.Printf("Error parsing %s: %v\n", file, err)
@@ -119,6 +100,12 @@ func ApplyTeams(manifestDir string, store state.TeamStore) error {
 	}
 
 	fmt.Printf("Successfully synced %d teams to state.\n", count)
+
+	if len(result.Foreign) > 0 {
+		fmt.Printf("shrine: ignored %d non-shrine YAML file(s) under %s: %s\n",
+			len(result.Foreign), manifestDir, strings.Join(result.Foreign, ", "))
+	}
+
 	return nil
 }
 

--- a/internal/handler/teams.go
+++ b/internal/handler/teams.go
@@ -63,9 +63,6 @@ func CreateTeam(filepath string, store state.TeamStore) error {
 	return nil
 }
 
-// ApplyTeams scans a directory recursively for team manifests and syncs them all to state.
-// Foreign YAML files (those without a shrine apiVersion) are silently skipped; a notice
-// is printed to stdout when foreign files are found (FR-006).
 func ApplyTeams(manifestDir string, store state.TeamStore) error {
 	result, err := manifest.ScanDir(manifestDir)
 	if err != nil {
@@ -102,8 +99,7 @@ func ApplyTeams(manifestDir string, store state.TeamStore) error {
 	fmt.Printf("Successfully synced %d teams to state.\n", count)
 
 	if len(result.Foreign) > 0 {
-		fmt.Printf("shrine: ignored %d non-shrine YAML file(s) under %s: %s\n",
-			len(result.Foreign), manifestDir, strings.Join(result.Foreign, ", "))
+		manifest.ReportForeignFiles(manifestDir, result.Foreign)
 	}
 
 	return nil

--- a/internal/manifest/classify.go
+++ b/internal/manifest/classify.go
@@ -1,0 +1,61 @@
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Class identifies the classification of a YAML file encountered during a directory scan.
+type Class int
+
+const (
+	ClassShrine  Class = iota // apiVersion matches the shrine regex
+	ClassForeign              // .yaml/.yml but apiVersion absent or non-matching
+)
+
+// shrineAPIVersionRe matches valid shrine apiVersion strings such as shrine/v1,
+// shrine/v1beta1, shrine/v10alpha7.
+var shrineAPIVersionRe = regexp.MustCompile(`^shrine/v\d+([a-z]+\d+)?$`)
+
+// IsShrineAPIVersion reports whether s matches the shrine apiVersion pattern
+// ^shrine/v\d+([a-z]+\d+)?$. This is a pure function over the string value —
+// it does not read any files.
+func IsShrineAPIVersion(s string) bool {
+	return shrineAPIVersionRe.MatchString(s)
+}
+
+// Classify reads the file at path, unmarshals its top-level YAML to extract
+// apiVersion and kind, and returns the file's Class.
+//
+// Returns (ClassForeign, nil, nil) when apiVersion is absent or does not match
+// the shrine regex — this covers foreign YAML, empty files, and comment-only files.
+//
+// Returns (ClassShrine, &meta, nil) when apiVersion matches; meta carries the
+// probed APIVersion and Kind (kind is NOT validated here — that is the caller's
+// responsibility via manifest.Parse / manifest.Validate).
+//
+// Returns (0, nil, error) when the file cannot be parsed as YAML at all. The
+// error wraps the file path so operators can identify the offending file.
+//
+// Note: the yaml.Unmarshal probe is duplicated from parser.go's probeKind to
+// avoid coupling classify.go to the parsing pipeline mid-refactor (lower churn).
+func Classify(path string) (Class, *TypeMeta, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, nil, fmt.Errorf("parsing manifest %q: %w", path, err)
+	}
+
+	var meta TypeMeta
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		return 0, nil, fmt.Errorf("parsing manifest %q: %w", path, err)
+	}
+
+	if !IsShrineAPIVersion(meta.APIVersion) {
+		return ClassForeign, nil, nil
+	}
+
+	return ClassShrine, &meta, nil
+}

--- a/internal/manifest/classify.go
+++ b/internal/manifest/classify.go
@@ -20,32 +20,17 @@ const (
 // shrine/v1beta1, shrine/v10alpha7.
 var shrineAPIVersionRe = regexp.MustCompile(`^shrine/v\d+([a-z]+\d+)?$`)
 
-// IsShrineAPIVersion reports whether s matches the shrine apiVersion pattern
-// ^shrine/v\d+([a-z]+\d+)?$. This is a pure function over the string value —
-// it does not read any files.
+// IsShrineAPIVersion reports whether s matches ^shrine/v\d+([a-z]+\d+)?$.
 func IsShrineAPIVersion(s string) bool {
 	return shrineAPIVersionRe.MatchString(s)
 }
 
-// Classify reads the file at path, unmarshals its top-level YAML to extract
-// apiVersion and kind, and returns the file's Class.
-//
-// Returns (ClassForeign, nil, nil) when apiVersion is absent or does not match
-// the shrine regex — this covers foreign YAML, empty files, and comment-only files.
-//
-// Returns (ClassShrine, &meta, nil) when apiVersion matches; meta carries the
-// probed APIVersion and Kind (kind is NOT validated here — that is the caller's
-// responsibility via manifest.Parse / manifest.Validate).
-//
-// Returns (0, nil, error) when the file cannot be parsed as YAML at all. The
-// error wraps the file path so operators can identify the offending file.
-//
-// Note: the yaml.Unmarshal probe is duplicated from parser.go's probeKind to
-// avoid coupling classify.go to the parsing pipeline mid-refactor (lower churn).
+// Classify returns the Class of the YAML file at path.
+// Note: yaml.Unmarshal probe duplicated from parser.go's probeKind to avoid coupling classify to the parse pipeline mid-refactor.
 func Classify(path string) (Class, *TypeMeta, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return 0, nil, fmt.Errorf("parsing manifest %q: %w", path, err)
+		return 0, nil, fmt.Errorf("reading manifest %q: %w", path, err)
 	}
 
 	var meta TypeMeta

--- a/internal/manifest/classify_test.go
+++ b/internal/manifest/classify_test.go
@@ -1,0 +1,171 @@
+package manifest
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsShrineAPIVersion(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{name: "strict shrine v1", input: "shrine/v1", expect: true},
+		{name: "strict shrine v1beta1", input: "shrine/v1beta1", expect: true},
+		{name: "strict shrine v10alpha7", input: "shrine/v10alpha7", expect: true},
+		{name: "capital S typo", input: "Shrine/v1", expect: false},
+		{name: "plural typo", input: "shrines/v1", expect: false},
+		{name: "no version suffix", input: "shrine/dev", expect: false},
+		{name: "trailing space", input: "shrine/v1 ", expect: false},
+		{name: "empty apiVersion", input: "", expect: false},
+		{name: "foreign apiVersion", input: "traefik.containo.us/v1alpha1", expect: false},
+		{name: "missing apiVersion (empty)", input: "", expect: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsShrineAPIVersion(tc.input)
+			if got != tc.expect {
+				t.Errorf("IsShrineAPIVersion(%q) = %v, want %v", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name          string
+		content       []byte
+		expectClass   Class
+		expectErr     bool
+		expectAPIVer  string
+		expectKind    string
+		checkTypeMeta bool
+	}{
+		{
+			name:          "strict shrine v1",
+			content:       []byte("apiVersion: shrine/v1\nkind: Application\n"),
+			expectClass:   ClassShrine,
+			expectAPIVer:  "shrine/v1",
+			expectKind:    "Application",
+			checkTypeMeta: true,
+		},
+		{
+			name:        "strict shrine v1beta1",
+			content:     []byte("apiVersion: shrine/v1beta1\nkind: Resource\n"),
+			expectClass: ClassShrine,
+		},
+		{
+			name:        "strict shrine v10alpha7",
+			content:     []byte("apiVersion: shrine/v10alpha7\nkind: Team\n"),
+			expectClass: ClassShrine,
+		},
+		{
+			name:        "capital S typo",
+			content:     []byte("apiVersion: Shrine/v1\nkind: Application\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "plural typo",
+			content:     []byte("apiVersion: shrines/v1\nkind: Application\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "no version suffix",
+			content:     []byte("apiVersion: shrine/dev\nkind: Application\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "trailing space quoted scalar",
+			content:     []byte("apiVersion: \"shrine/v1 \"\nkind: Application\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "empty apiVersion",
+			content:     []byte("apiVersion: \"\"\nkind: Application\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "missing apiVersion",
+			content:     []byte("kind: Application\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "foreign apiVersion",
+			content:     []byte("apiVersion: traefik.containo.us/v1alpha1\nkind: IngressRoute\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "empty file",
+			content:     []byte(""),
+			expectClass: ClassForeign,
+		},
+		{
+			name:        "comments only",
+			content:     []byte("# nothing here\n"),
+			expectClass: ClassForeign,
+		},
+		{
+			name:      "malformed YAML",
+			content:   []byte("apiVersion: shrine/v1\nkind: [unclosed"),
+			expectErr: true,
+		},
+		{
+			name:        "shrine v1 with bogus kind",
+			content:     []byte("apiVersion: shrine/v1\nkind: Aplication\n"),
+			expectClass: ClassShrine,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := dir + "/manifest.yaml"
+			if err := os.WriteFile(path, tc.content, 0644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			class, meta, err := Classify(path)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), path) {
+					t.Errorf("error %q does not contain file path %q", err.Error(), path)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if class != tc.expectClass {
+				t.Errorf("class = %v, want %v", class, tc.expectClass)
+			}
+
+			if tc.checkTypeMeta {
+				if meta == nil {
+					t.Fatalf("expected non-nil TypeMeta for ClassShrine, got nil")
+				}
+				if meta.APIVersion != tc.expectAPIVer {
+					t.Errorf("APIVersion = %q, want %q", meta.APIVersion, tc.expectAPIVer)
+				}
+				if meta.Kind != tc.expectKind {
+					t.Errorf("Kind = %q, want %q", meta.Kind, tc.expectKind)
+				}
+			}
+
+			if class == ClassShrine && meta == nil {
+				t.Errorf("ClassShrine result must have non-nil TypeMeta")
+			}
+
+			if class == ClassForeign && meta != nil {
+				t.Errorf("ClassForeign result must have nil TypeMeta, got %+v", meta)
+			}
+		})
+	}
+}

--- a/internal/manifest/scan.go
+++ b/internal/manifest/scan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"strings"
 )
 
 // ShrineCandidate holds the path and already-probed TypeMeta of a file that
@@ -22,18 +23,7 @@ type ScanResult struct {
 	Foreign []string          // .yaml/.yml paths whose apiVersion failed the shrine regex
 }
 
-// ScanDir walks dir recursively and classifies every .yaml / .yml file it finds.
-//
-// Extension filter: files whose extension is not exactly ".yaml" or ".yml"
-// (case-sensitive) are silently skipped without opening them — this is
-// invariant 1 of the scanner contract.
-//
-// For admitted files, Classify is called. A malformed-YAML error aborts the
-// entire scan and is returned wrapped with the directory path.
-//
-// Walk order is the deterministic order provided by filepath.WalkDir (lexical
-// within each directory level), so two calls on the same unchanged tree return
-// identical slices.
+// ScanDir walks dir recursively and classifies every .yaml/.yml file.
 func ScanDir(dir string) (*ScanResult, error) {
 	result := &ScanResult{}
 
@@ -75,4 +65,11 @@ func ScanDir(dir string) (*ScanResult, error) {
 	}
 
 	return result, nil
+}
+
+// ReportForeignFiles prints the standard foreign-files notice to stdout.
+// Called by every ScanDir consumer that finds non-empty Foreign results.
+func ReportForeignFiles(dir string, paths []string) {
+	fmt.Printf("shrine: ignored %d non-shrine YAML file(s) under %s: %s\n",
+		len(paths), dir, strings.Join(paths, ", "))
 }

--- a/internal/manifest/scan.go
+++ b/internal/manifest/scan.go
@@ -1,0 +1,78 @@
+package manifest
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+// ShrineCandidate holds the path and already-probed TypeMeta of a file that
+// passed the shrine apiVersion classifier. Callers reuse the TypeMeta to avoid
+// a second YAML parse when dispatching to manifest.Parse.
+type ShrineCandidate struct {
+	Path     string   // absolute file path as returned by filepath.WalkDir
+	TypeMeta TypeMeta // probed apiVersion + kind
+}
+
+// ScanResult holds the bucketed output of ScanDir.
+// Shrine and Foreign are disjoint; every .yaml/.yml file appears in exactly one
+// slice (or caused the call to return an error).
+type ScanResult struct {
+	Shrine  []ShrineCandidate // ordered by deterministic walk order
+	Foreign []string          // .yaml/.yml paths whose apiVersion failed the shrine regex
+}
+
+// ScanDir walks dir recursively and classifies every .yaml / .yml file it finds.
+//
+// Extension filter: files whose extension is not exactly ".yaml" or ".yml"
+// (case-sensitive) are silently skipped without opening them — this is
+// invariant 1 of the scanner contract.
+//
+// For admitted files, Classify is called. A malformed-YAML error aborts the
+// entire scan and is returned wrapped with the directory path.
+//
+// Walk order is the deterministic order provided by filepath.WalkDir (lexical
+// within each directory level), so two calls on the same unchanged tree return
+// identical slices.
+func ScanDir(dir string) (*ScanResult, error) {
+	result := &ScanResult{}
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		if ext != ".yaml" && ext != ".yml" {
+			// Non-YAML sibling: silently skip without opening the file.
+			return nil
+		}
+
+		class, meta, err := Classify(path)
+		if err != nil {
+			return fmt.Errorf("scanning manifest directory %q: %w", dir, err)
+		}
+
+		switch class {
+		case ClassShrine:
+			result.Shrine = append(result.Shrine, ShrineCandidate{
+				Path:     path,
+				TypeMeta: *meta,
+			})
+		case ClassForeign:
+			result.Foreign = append(result.Foreign, path)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/internal/manifest/scan_test.go
+++ b/internal/manifest/scan_test.go
@@ -1,0 +1,141 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScanDir(t *testing.T) {
+	t.Run("empty directory", func(t *testing.T) {
+		dir := t.TempDir()
+		result, err := ScanDir(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Shrine) != 0 {
+			t.Errorf("Shrine len = %d, want 0", len(result.Shrine))
+		}
+		if len(result.Foreign) != 0 {
+			t.Errorf("Foreign len = %d, want 0", len(result.Foreign))
+		}
+	})
+
+	t.Run("dir with only non-YAML files", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Write a JSON file and make it unreadable to prove it's never opened
+		jsonPath := filepath.Join(dir, "config.json")
+		if err := os.WriteFile(jsonPath, []byte(`{"note": "should not be opened"}`), 0644); err != nil {
+			t.Fatalf("WriteFile json: %v", err)
+		}
+		if err := os.Chmod(jsonPath, 0000); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+
+		// Write a markdown file
+		mdPath := filepath.Join(dir, "README.md")
+		if err := os.WriteFile(mdPath, []byte("# Readme"), 0644); err != nil {
+			t.Fatalf("WriteFile md: %v", err)
+		}
+
+		// Write an extensionless file
+		extPath := filepath.Join(dir, "Makefile")
+		if err := os.WriteFile(extPath, []byte("all:\n\t@echo hi"), 0644); err != nil {
+			t.Fatalf("WriteFile extensionless: %v", err)
+		}
+
+		result, err := ScanDir(dir)
+		if err != nil {
+			t.Fatalf("unexpected error (extension filter must never open .json): %v", err)
+		}
+		if len(result.Shrine) != 0 {
+			t.Errorf("Shrine len = %d, want 0", len(result.Shrine))
+		}
+		if len(result.Foreign) != 0 {
+			t.Errorf("Foreign len = %d, want 0", len(result.Foreign))
+		}
+	})
+
+	t.Run("dir with one valid and one foreign YAML", func(t *testing.T) {
+		dir := t.TempDir()
+
+		shrineContent := []byte("apiVersion: shrine/v1\nkind: Application\nmetadata:\n  name: myapp\n  owner: team\n")
+		foreignContent := []byte("apiVersion: traefik.containo.us/v1alpha1\nkind: IngressRoute\n")
+
+		shrinePath := filepath.Join(dir, "app.yaml")
+		foreignPath := filepath.Join(dir, "route.yaml")
+
+		if err := os.WriteFile(shrinePath, shrineContent, 0644); err != nil {
+			t.Fatalf("WriteFile shrine: %v", err)
+		}
+		if err := os.WriteFile(foreignPath, foreignContent, 0644); err != nil {
+			t.Fatalf("WriteFile foreign: %v", err)
+		}
+
+		result, err := ScanDir(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Shrine) != 1 {
+			t.Errorf("Shrine len = %d, want 1", len(result.Shrine))
+		}
+		if len(result.Foreign) != 1 {
+			t.Errorf("Foreign len = %d, want 1", len(result.Foreign))
+		}
+		if len(result.Shrine) == 1 && result.Shrine[0].Path != shrinePath {
+			t.Errorf("Shrine[0].Path = %q, want %q", result.Shrine[0].Path, shrinePath)
+		}
+		if len(result.Foreign) == 1 && result.Foreign[0] != foreignPath {
+			t.Errorf("Foreign[0] = %q, want %q", result.Foreign[0], foreignPath)
+		}
+	})
+
+	t.Run("dir with one malformed YAML", func(t *testing.T) {
+		dir := t.TempDir()
+
+		brokenPath := filepath.Join(dir, "broken.yaml")
+		if err := os.WriteFile(brokenPath, []byte("apiVersion: shrine/v1\nkind: [unclosed"), 0644); err != nil {
+			t.Fatalf("WriteFile broken: %v", err)
+		}
+
+		_, err := ScanDir(dir)
+		if err == nil {
+			t.Fatalf("expected error for malformed YAML, got nil")
+		}
+		if !strings.Contains(err.Error(), brokenPath) {
+			t.Errorf("error %q does not contain file path %q", err.Error(), brokenPath)
+		}
+	})
+
+	t.Run("nested subdir with foreign YAML", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Create a nested subdirectory mirroring specsDir/traefik/
+		subdir := filepath.Join(dir, "traefik")
+		if err := os.MkdirAll(subdir, 0755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+
+		foreignContent := []byte("entryPoints:\n  web:\n    address: \":80\"\n")
+		foreignPath := filepath.Join(subdir, "traefik.yml")
+		if err := os.WriteFile(foreignPath, foreignContent, 0644); err != nil {
+			t.Fatalf("WriteFile foreign nested: %v", err)
+		}
+
+		result, err := ScanDir(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result.Shrine) != 0 {
+			t.Errorf("Shrine len = %d, want 0", len(result.Shrine))
+		}
+		if len(result.Foreign) != 1 {
+			t.Errorf("Foreign len = %d, want 1", len(result.Foreign))
+		}
+		if len(result.Foreign) == 1 && result.Foreign[0] != foreignPath {
+			t.Errorf("Foreign[0] = %q, want %q", result.Foreign[0], foreignPath)
+		}
+	})
+}

--- a/internal/manifest/scan_test.go
+++ b/internal/manifest/scan_test.go
@@ -87,6 +87,12 @@ func TestScanDir(t *testing.T) {
 		if len(result.Shrine) == 1 && result.Shrine[0].Path != shrinePath {
 			t.Errorf("Shrine[0].Path = %q, want %q", result.Shrine[0].Path, shrinePath)
 		}
+		if len(result.Shrine) == 1 && result.Shrine[0].TypeMeta.Kind != "Application" {
+			t.Errorf("Shrine[0].TypeMeta.Kind = %q, want %q", result.Shrine[0].TypeMeta.Kind, "Application")
+		}
+		if len(result.Shrine) == 1 && result.Shrine[0].TypeMeta.APIVersion != "shrine/v1" {
+			t.Errorf("Shrine[0].TypeMeta.APIVersion = %q, want %q", result.Shrine[0].TypeMeta.APIVersion, "shrine/v1")
+		}
 		if len(result.Foreign) == 1 && result.Foreign[0] != foreignPath {
 			t.Errorf("Foreign[0] = %q, want %q", result.Foreign[0], foreignPath)
 		}

--- a/internal/planner/loader.go
+++ b/internal/planner/loader.go
@@ -2,8 +2,7 @@ package planner
 
 import (
 	"fmt"
-	"io/fs"
-	"path/filepath"
+	"strings"
 
 	"github.com/CarlosHPlata/shrine/internal/manifest"
 )
@@ -17,18 +16,21 @@ type ManifestSet struct {
 
 // LoadDir scans the provided directory for .yml and .yaml files, parses them,
 // and returns a ManifestSet. It skips Team manifests and errors on duplicate names.
+// Files that are not shrine manifests (foreign YAML) are silently skipped; a notice
+// is printed to stdout when foreign files are found (FR-006).
 func LoadDir(dir string) (*ManifestSet, error) {
 	set := &ManifestSet{
 		Applications: make(map[string]*manifest.ApplicationManifest),
 		Resources:    make(map[string]*manifest.ResourceManifest),
 	}
 
-	files, err := getFiles(dir)
+	result, err := manifest.ScanDir(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, path := range files {
+	for _, candidate := range result.Shrine {
+		path := candidate.Path
 		m, err := manifest.Parse(path)
 		if err != nil {
 			// Wrapping errors with the path helps the user locate the broken file
@@ -45,28 +47,12 @@ func LoadDir(dir string) (*ManifestSet, error) {
 		}
 	}
 
-	return set, nil
-}
-
-func getFiles(dir string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		ext := filepath.Ext(path)
-		if ext == ".yml" || ext == ".yaml" {
-			files = append(files, path)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("scanning manifest directory %q: %w", dir, err)
+	if len(result.Foreign) > 0 {
+		fmt.Printf("shrine: ignored %d non-shrine YAML file(s) under %s: %s\n",
+			len(result.Foreign), dir, strings.Join(result.Foreign, ", "))
 	}
-	return files, nil
+
+	return set, nil
 }
 
 // mapKind routes a single manifest into the correct map within the set.

--- a/internal/planner/loader.go
+++ b/internal/planner/loader.go
@@ -2,7 +2,6 @@ package planner
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/CarlosHPlata/shrine/internal/manifest"
 )
@@ -14,10 +13,6 @@ type ManifestSet struct {
 	Resources    map[string]*manifest.ResourceManifest
 }
 
-// LoadDir scans the provided directory for .yml and .yaml files, parses them,
-// and returns a ManifestSet. It skips Team manifests and errors on duplicate names.
-// Files that are not shrine manifests (foreign YAML) are silently skipped; a notice
-// is printed to stdout when foreign files are found (FR-006).
 func LoadDir(dir string) (*ManifestSet, error) {
 	set := &ManifestSet{
 		Applications: make(map[string]*manifest.ApplicationManifest),
@@ -48,8 +43,7 @@ func LoadDir(dir string) (*ManifestSet, error) {
 	}
 
 	if len(result.Foreign) > 0 {
-		fmt.Printf("shrine: ignored %d non-shrine YAML file(s) under %s: %s\n",
-			len(result.Foreign), dir, strings.Join(result.Foreign, ", "))
+		manifest.ReportForeignFiles(dir, result.Foreign)
 	}
 
 	return set, nil

--- a/internal/planner/loader_test.go
+++ b/internal/planner/loader_test.go
@@ -1,10 +1,23 @@
 package planner
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
 )
+
+// nullTeamStore is a minimal state.TeamStore stub for unit tests that only need
+// the store interface to satisfy PlanSingle's signature without any real I/O.
+type nullTeamStore struct{}
+
+func (nullTeamStore) SaveTeam(*manifest.TeamManifest) error              { return nil }
+func (nullTeamStore) LoadTeam(string) (*manifest.TeamManifest, error)    { return nil, fmt.Errorf("not found") }
+func (nullTeamStore) ListTeams() ([]*manifest.TeamManifest, error)       { return nil, nil }
+func (nullTeamStore) DeleteTeam(string) error                            { return nil }
 
 func TestLoadDir(t *testing.T) {
 	tmp := t.TempDir()
@@ -92,5 +105,149 @@ spec:
 	_, err := LoadDir(tmp)
 	if err == nil {
 		t.Error("expected error on duplicate resource names, got nil")
+	}
+}
+
+func TestLoadDir_ValidPlusForeign(t *testing.T) {
+	tmp := t.TempDir()
+
+	// A valid shrine Application manifest.
+	appYAML := `
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: foreign-test-app
+  owner: team-b
+spec:
+  image: nginx
+  port: 80
+`
+	if err := os.WriteFile(filepath.Join(tmp, "app.yml"), []byte(appYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A foreign YAML file (no apiVersion — mirrors a Traefik routing file).
+	foreignYAML := `
+entryPoints:
+  web:
+    address: ":80"
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+`
+	if err := os.WriteFile(filepath.Join(tmp, "traefik.yml"), []byte(foreignYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	set, err := LoadDir(tmp)
+	if err != nil {
+		t.Fatalf("LoadDir failed: %v", err)
+	}
+	if len(set.Applications) != 1 {
+		t.Errorf("expected 1 application, got %d", len(set.Applications))
+	}
+	if _, ok := set.Applications["foreign-test-app"]; !ok {
+		t.Error("foreign-test-app not found in Applications map")
+	}
+	// The foreign file must not have been turned into any manifest entry.
+	if len(set.Resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(set.Resources))
+	}
+}
+
+func TestLoadDir_ForeignOnly(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Only a foreign YAML file — no shrine manifests at all.
+	foreignYAML := `
+http:
+  routers:
+    my-router:
+      rule: "Host('example.com')"
+`
+	if err := os.WriteFile(filepath.Join(tmp, "foreign-only.yml"), []byte(foreignYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	set, err := LoadDir(tmp)
+	if err != nil {
+		t.Fatalf("LoadDir returned unexpected error: %v", err)
+	}
+	if len(set.Applications) != 0 {
+		t.Errorf("expected 0 applications, got %d", len(set.Applications))
+	}
+	if len(set.Resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(set.Resources))
+	}
+}
+
+func TestLoadDir_ValidPlusMalformed(t *testing.T) {
+	tmp := t.TempDir()
+
+	// A valid shrine Application manifest.
+	appYAML := `
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: valid-app
+  owner: team-c
+spec:
+  image: nginx
+  port: 80
+`
+	if err := os.WriteFile(filepath.Join(tmp, "app.yml"), []byte(appYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A shrine manifest (apiVersion: shrine/v1) with malformed YAML — ScanDir will
+	// error on this file because yaml.Unmarshal fails before classification.
+	malformedYAML := `apiVersion: shrine/v1
+kind: [unclosed`
+	if err := os.WriteFile(filepath.Join(tmp, "broken.yaml"), []byte(malformedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadDir(tmp)
+	if err == nil {
+		t.Fatal("expected LoadDir to return an error for the malformed file, got nil")
+	}
+	if !strings.Contains(err.Error(), filepath.Join(tmp, "broken.yaml")) {
+		t.Errorf("expected error to mention broken.yaml path, got: %v", err)
+	}
+}
+
+// TestPlanSingle_BadKind_WrapsFilePath pins the FR-007 guarantee that PlanSingle
+// includes the target file path in the error message when manifest.Parse fails on
+// a shrine manifest with an unknown kind. This was a regression introduced during
+// the Phase 3/4 refactor where PlanSingle returned the bare parse error without
+// wrapping it with the file path — T036 restores the wrapping.
+func TestPlanSingle_BadKind_WrapsFilePath(t *testing.T) {
+	tmp := t.TempDir()
+
+	typoYAML := `apiVersion: shrine/v1
+kind: Aplication
+metadata:
+  name: typo-app
+  owner: team-x
+spec:
+  image: traefik/whoami
+  port: 80
+`
+	typoFile := filepath.Join(tmp, "typo.yaml")
+	if err := os.WriteFile(typoFile, []byte(typoYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := PlanSingle(typoFile, "", nullTeamStore{})
+	if result.Error == nil {
+		t.Fatal("expected PlanSingle to return an error for bad-kind manifest, got nil")
+	}
+
+	msg := result.Error.Error()
+	if !strings.Contains(msg, "typo.yaml") {
+		t.Errorf("expected error to contain file name %q, got: %v", "typo.yaml", msg)
+	}
+	if !strings.Contains(msg, "Aplication") {
+		t.Errorf("expected error to contain offending kind %q, got: %v", "Aplication", msg)
 	}
 }

--- a/internal/planner/plan.go
+++ b/internal/planner/plan.go
@@ -45,10 +45,10 @@ func PlanSingle(file, specsDir string, store state.TeamStore) PlanResult {
 	// Step 1: Parse and validate the target manifest.
 	m, err := manifest.Parse(file)
 	if err != nil {
-		return PlanResult{Error: err}
+		return PlanResult{Error: fmt.Errorf("parsing manifest %q: %w", file, err)}
 	}
 	if err := manifest.Validate(m); err != nil {
-		return PlanResult{Error: err}
+		return PlanResult{Error: fmt.Errorf("validating manifest %q: %w", file, err)}
 	}
 
 	// Derive the name from the concrete sub-manifest.

--- a/specs/002-fix-routing-dir-manifest-scan/checklists/requirements.md
+++ b/specs/002-fix-routing-dir-manifest-scan/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix Routing-Dir Manifest Scan Crash
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The spec deliberately retains a behavioural distinction between "foreign YAML" (skipped) and "unrecognised-kind" (hard error). FR-003 / US3 / SC-004 lock this in so the fix cannot silently swallow misspelled `kind` values.
+- Multi-document YAML is explicitly out of scope (Edge Cases + Assumptions); flagged so reviewers do not expect it.

--- a/specs/002-fix-routing-dir-manifest-scan/contracts/scanner-contract.md
+++ b/specs/002-fix-routing-dir-manifest-scan/contracts/scanner-contract.md
@@ -1,0 +1,127 @@
+# Contract: Manifest Directory Scanner
+
+This document is the behavioural contract that every shrine command which scans a directory for manifests MUST satisfy after this fix lands. It is the source of truth for the assertions made by the unit tests of `internal/manifest/classify.go` and `internal/manifest/scan.go`, and for the integration tests that exercise `shrine deploy` / `shrine apply teams` against a fixture containing foreign YAML files.
+
+There is no over-the-wire API to spec — shrine is a single-binary CLI — so the contract is expressed at two layers:
+
+1. **Internal Go API** that every directory-scanning command MUST go through (`manifest.ScanDir`).
+2. **CLI behaviour** observable by an operator running shrine commands.
+
+---
+
+## 1. Internal Go API contract — `manifest.ScanDir`
+
+### Signature
+
+```go
+func ScanDir(dir string) (*ScanResult, error)
+```
+
+### Inputs
+
+| Parameter | Constraint |
+|-----------|------------|
+| `dir` | Existing readable directory. If `dir` does not exist or is unreadable, the underlying `filepath.WalkDir` error is returned wrapped with `"scanning manifest directory %q"`. |
+
+### Outputs
+
+| Result field | Guarantee |
+|--------------|-----------|
+| `*ScanResult.Shrine` | Slice of `ShrineCandidate` — every `.yaml`/`.yml` file under `dir` whose `apiVersion` matched `^shrine/v\d+([a-z]+\d+)?$`. Order is the deterministic walk order returned by `filepath.WalkDir`. |
+| `*ScanResult.Foreign` | Slice of `string` paths — every `.yaml`/`.yml` file under `dir` whose `apiVersion` did NOT match the regex (including absent / empty values). Order matches walk order. |
+| `error` | `nil` if every admitted file was either Shrine or Foreign. Non-nil only when an admitted (.yaml/.yml) file fails `yaml.Unmarshal` — error message MUST contain the file path and the underlying parser message. |
+
+### Invariants (MUST hold for every call)
+
+1. **Extension filter never opens disallowed files.** `ScanDir` MUST NOT call `os.ReadFile` on any path whose extension is not exactly `.yaml` or `.yml`. (Verified by a unit test that places an unreadable `.json` file in the tree and asserts no error.)
+2. **Foreign and Shrine are disjoint.** No file path may appear in both result slices.
+3. **No silent loss.** Every `.yaml`/`.yml` file under `dir` either appears in `Shrine`, appears in `Foreign`, or causes the entire call to return an error. There is no third skip path.
+4. **Non-mutating.** `ScanDir` MUST NOT create, modify, or delete any filesystem entry under `dir`.
+5. **Deterministic.** Two calls to `ScanDir` on the same unchanged directory MUST return the same slices in the same order.
+
+### Error contract
+
+| Condition | Behaviour |
+|-----------|-----------|
+| `dir` does not exist | wrapped error from `filepath.WalkDir` (existing behaviour preserved) |
+| `.yaml`/`.yml` file fails `yaml.Unmarshal` | wrapped error containing the file path and the parse-error message; scan aborts |
+| `.yaml`/`.yml` file has no `apiVersion` field at all | classified as Foreign — no error |
+| `.yaml`/`.yml` file has `apiVersion: ""` | classified as Foreign — no error |
+| `.yaml`/`.yml` file has `apiVersion: traefik.io/...` (or any non-matching value) | classified as Foreign — no error |
+| `.yaml`/`.yml` file has `apiVersion: shrine/v1` and any `kind` (including invalid) | classified as Shrine — no error from `ScanDir`; the caller's `Parse`/`Validate` produces the loud error per FR-003 |
+
+---
+
+## 2. CLI behaviour contract
+
+These commands MUST satisfy the rules below for every project layout:
+
+- `shrine deploy --path <dir>`
+- `shrine apply -f <file>` and `shrine apply teams --path <dir>`
+- `shrine generate <...>` (if it scans `specsDir`)
+- Any future verb that scans for manifests
+
+### Behaviour matrix
+
+| Project layout | `shrine deploy` exit code | stdout | stderr |
+|----------------|---------------------------|--------|--------|
+| `specsDir` contains only valid shrine manifests | `0` | unchanged from today (per-step `[APPLY]` lines etc.) | empty |
+| `specsDir` contains valid shrine manifests + foreign YAML (e.g. Traefik routing files under `specsDir/traefik/`) | `0` | unchanged steps PLUS one informational notice naming the foreign paths (FR-006) | empty |
+| `specsDir` contains valid shrine manifests + non-YAML siblings (`.json`, `.md`, `Makefile`) | `0` | unchanged from today — non-YAML siblings produce no notice (FR-006) | empty |
+| `specsDir` contains a `.yaml` file with `apiVersion: shrine/v1` and a typo'd / missing `kind` | non-zero | unchanged successful steps up to the failure | error message identifying the file and the offending kind value (FR-003) |
+| `specsDir` contains a `.yaml` file that cannot be parsed as YAML | non-zero | unchanged successful steps up to the failure | error message identifying the file and the parse error (FR-004) |
+| `specsDir` contains a `.yaml` file with `apiVersion: Shrine/v1` (capital S typo) | `0` (file is Foreign and skipped) | one informational notice listing the file as foreign | empty (deliberate trade-off, see spec §Assumptions) |
+| Default Traefik plugin enabled, `routing-dir` unset → defaults to `specsDir/traefik/` | `0` | normal deploy output PLUS foreign-files notice listing the generated Traefik routing files | empty (this is SC-001) |
+
+### What the contract DOES NOT promise
+
+- No new exit codes are introduced.
+- No new flags are added.
+- The exact wording of the foreign-files notice is not stable — operators MUST NOT parse it (FR-006: "downstream tooling should not parse it").
+- Multi-document YAML support — explicitly out of scope (spec §Assumptions).
+
+---
+
+## 3. Unit test obligations (`internal/manifest/classify_test.go`)
+
+The following table-driven tests MUST exist and pass:
+
+| Case | Input file content | Expected result |
+|------|--------------------|-----------------|
+| Strict shrine v1 | `apiVersion: shrine/v1\nkind: Application\n...` | `ClassShrine`, `TypeMeta{APIVersion: "shrine/v1", Kind: "Application"}` |
+| Strict shrine v1beta1 | `apiVersion: shrine/v1beta1\nkind: Resource\n...` | `ClassShrine` |
+| Strict shrine v10alpha7 | `apiVersion: shrine/v10alpha7\nkind: Team\n...` | `ClassShrine` |
+| Capital S typo | `apiVersion: Shrine/v1\n...` | `ClassForeign` |
+| Plural typo | `apiVersion: shrines/v1\n...` | `ClassForeign` |
+| No version suffix | `apiVersion: shrine/dev\n...` | `ClassForeign` |
+| Trailing space (YAML scalar trim) | `apiVersion: "shrine/v1 "\n...` | `ClassForeign` (space inside quoted scalar fails the `$` anchor) |
+| Empty apiVersion | `apiVersion: ""\n...` | `ClassForeign` |
+| Missing apiVersion | `kind: Application\n...` | `ClassForeign` |
+| Foreign apiVersion | `apiVersion: traefik.containo.us/v1alpha1\n...` | `ClassForeign` |
+| Empty file | `` | `ClassForeign` (no apiVersion to inspect) |
+| Comments only | `# nothing here` | `ClassForeign` |
+| Malformed YAML | `apiVersion: shrine/v1\nkind: [unclosed` | error containing the file path |
+| Shrine v1 with bogus kind | `apiVersion: shrine/v1\nkind: Aplication\n...` | `ClassShrine` (Classify does not check kind; Parse will fail loudly later) |
+
+Plus assertions on `ScanDir`:
+
+| Case | Expected |
+|------|----------|
+| Empty directory | `&ScanResult{}, nil` |
+| Directory with only `.json` / `.md` / extensionless files | `&ScanResult{}, nil` (no reads) |
+| Directory with one valid + one foreign | `Shrine` len 1, `Foreign` len 1, no error |
+| Directory with one malformed YAML | error wrapping the file path |
+| Nested subdir containing foreign YAML (mirrors `specsDir/traefik/`) | foreign path collected; no error |
+
+---
+
+## 4. Integration test obligations (Principle V gate)
+
+The fix is not "done" until BOTH of the following pass under `make test-integration`:
+
+| Test | Location | Scenario |
+|------|----------|----------|
+| `TestDeploy/should_deploy_successfully_when_specsDir_contains_foreign_YAML_files` | [tests/integration/deploy_test.go](../../../tests/integration/deploy_test.go) | Deploy a fixture with `team.yaml` + `app.yaml` + `traefik/traefik.yml` (no apiVersion); assert exit `0`, the app container running, and no container created from the foreign file. |
+| `TestTraefikPlugin/should_succeed_when_routing-dir_is_inside_specsDir` | [tests/integration/traefik_plugin_test.go](../../../tests/integration/traefik_plugin_test.go) | Configure the Traefik plugin with default `routing-dir = {specsDir}/traefik`; run `shrine deploy` twice (first to generate Traefik files, second to re-scan a populated tree); assert both runs exit `0` and the Traefik container is running. This is SC-001's canonical regression. |
+
+Both tests use `NewDockerSuite` with the real shrine binary built in `TestMain` per Principle V.

--- a/specs/002-fix-routing-dir-manifest-scan/data-model.md
+++ b/specs/002-fix-routing-dir-manifest-scan/data-model.md
@@ -1,0 +1,122 @@
+# Phase 1 Data Model: Fix Routing-Dir Manifest Scan Crash
+
+This feature does not introduce new manifest kinds or persisted state. The "data model" here is the **classification taxonomy** the scanner applies to files it finds during a directory walk, plus the small Go types added to `internal/manifest/` to represent it.
+
+## Classification Taxonomy
+
+Every file encountered by `manifest.ScanDir` lands in exactly one bucket. The bucket is determined by two ordered checks; once a check disqualifies a file, no later check runs on it.
+
+| Check order | Predicate | If FAIL → bucket | If PASS → next check |
+|-------------|-----------|------------------|----------------------|
+| 1. Extension | `filepath.Ext(path)` is `".yaml"` or `".yml"` (case-sensitive) | **Non-YAML Sibling** (silently dropped — file is never opened) | go to check 2 |
+| 2. YAML well-formed | `yaml.Unmarshal(bytes, &TypeMeta{})` succeeds | **Malformed YAML** (loud error, FR-004) | go to check 3 |
+| 3. `apiVersion` regex | `apiVersion` matches `^shrine/v\d+([a-z]+\d+)?$` | **Foreign YAML** (silently collected for the FR-006 notice, then dropped) | **Shrine Candidate** (proceed to `Parse` + `Validate`) |
+
+Once a file reaches **Shrine Candidate**, it goes through the unchanged `manifest.Parse` → `manifest.Validate` pipeline. Defects from that point on (`kind` missing/unrecognised/typo, required-field violations, duplicate `metadata.name`) MUST surface as loud errors with the file path attached — this is FR-003 / FR-007 and is already implemented today.
+
+```
+file in walk
+   │
+   ├── ext != .yaml/.yml ──► [Non-YAML Sibling] ── skipped silently, never opened
+   │
+   ├── ext OK
+   │     │
+   │     ├── yaml.Unmarshal fails ──► [Malformed YAML] ── ERROR (file path + parse error)
+   │     │
+   │     └── yaml.Unmarshal OK
+   │            │
+   │            ├── apiVersion regex MISS ──► [Foreign YAML] ── skipped silently, listed in FR-006 notice
+   │            │
+   │            └── apiVersion regex HIT  ──► [Shrine Candidate]
+   │                                              │
+   │                                              ├── Parse → unknown Kind     ──► ERROR (FR-003)
+   │                                              ├── Validate → missing field ──► ERROR (FR-003 / FR-007)
+   │                                              ├── duplicate name in set    ──► ERROR (existing behaviour)
+   │                                              └── all OK ──► added to ManifestSet
+```
+
+### Bucket cross-reference to spec entities
+
+| Spec entity (spec.md §Key Entities) | Bucket above |
+|-------------------------------------|--------------|
+| Non-YAML Sibling                    | Non-YAML Sibling |
+| Foreign YAML File                   | Foreign YAML |
+| Mistyped-Shrine File (e.g. `Shrine/v1`) | Foreign YAML — deliberate trade-off (spec §Assumptions) |
+| Shrine Manifest File                | Shrine Candidate |
+| (Malformed YAML — spec §Edge Cases) | Malformed YAML |
+
+## Go Types Introduced
+
+All new types live in `internal/manifest/` so both `internal/planner/` and `internal/handler/` can import them without layer inversion.
+
+### `Class`
+
+```go
+type Class int
+
+const (
+    ClassShrine  Class = iota // apiVersion matches shrine regex
+    ClassForeign              // .yaml/.yml but apiVersion absent or non-matching
+)
+```
+
+`Malformed YAML` is **not** a `Class` value — it is an error returned by `Classify`. `Non-YAML Sibling` is also not a class — those files never reach `Classify`.
+
+### `ShrineCandidate`
+
+```go
+type ShrineCandidate struct {
+    Path     string   // absolute file path, as returned by filepath.WalkDir
+    TypeMeta TypeMeta // already-probed apiVersion + kind, reused by the caller's Parse
+}
+```
+
+### `ScanResult`
+
+```go
+type ScanResult struct {
+    Shrine  []ShrineCandidate // ordered by walk order (deterministic)
+    Foreign []string          // .yaml/.yml paths whose apiVersion failed the regex
+}
+```
+
+`Foreign` exists solely to power the FR-006 notice. Callers that do not care about the notice may ignore it.
+
+### Public functions (the only new API surface)
+
+```go
+// IsShrineAPIVersion reports whether s matches ^shrine/v\d+([a-z]+\d+)?$.
+// Pure function over a string — convenient for callers that already have a
+// parsed TypeMeta (e.g. test assertions).
+func IsShrineAPIVersion(apiVersion string) bool
+
+// Classify reads `path` and returns its Class. Foreign returns (ClassForeign, nil, nil).
+// Shrine returns (ClassShrine, &meta, nil) where meta is the probed top-level
+// TypeMeta. Unparseable YAML returns (0, nil, error) with the file path wrapped
+// into the error chain (FR-004).
+func Classify(path string) (Class, *TypeMeta, error)
+
+// ScanDir walks `dir` recursively, applies the .yaml/.yml extension filter, and
+// classifies every admitted file via Classify. Returns the bucketed result.
+// A single Malformed YAML aborts the scan with the file's error wrapped.
+func ScanDir(dir string) (*ScanResult, error)
+```
+
+No new persisted state, no new manifest fields, no schema changes — `TypeMeta` and the three manifest kinds are unchanged.
+
+## Validation Rules (mapped from FRs)
+
+| FR | Validation rule | Where enforced |
+|----|-----------------|----------------|
+| FR-001(a) | Skip files whose extension is not `.yaml`/`.yml` (case-sensitive); do not open them | `ScanDir` (extension check before `Classify` is called) |
+| FR-001(b) | Classify a file as Shrine **only** when `apiVersion` matches `^shrine/v\d+([a-z]+\d+)?$` | `Classify` via `IsShrineAPIVersion` |
+| FR-002 | Foreign / non-YAML-sibling files MUST NOT raise an error; scan continues | `ScanDir` collects them and returns; `LoadDir` / `ApplyTeams` skip them |
+| FR-003 | Shrine-classified files with bad `kind` fail loudly with file path + offending kind | unchanged — `manifest.Parse` and `manifest.Validate`, wrapped by `LoadDir` |
+| FR-004 | Files admitted by extension filter that fail `yaml.Unmarshal` produce an error naming file + parse error | `Classify` returns the wrapped error; `ScanDir` propagates it |
+| FR-005 | All directory-scanning code paths use the same classification | Only `ScanDir` does directory walks; `LoadDir` and `ApplyTeams` migrated |
+| FR-006 | When ≥1 foreign file, emit one info-level notice listing the paths; never affects exit status | `LoadDir` / `ApplyTeams` (the callers, not `ScanDir`) |
+| FR-007 | Existing valid-manifest behaviour unchanged | Reuse `Parse`/`Validate` unchanged; integration test fixture covers the no-foreign case |
+
+## State Transitions
+
+None — the scanner is stateless. A file's `Class` is a pure function of its current bytes on disk; nothing mutates between checks. `ManifestSet` (the in-memory output of `LoadDir`) is built once per scan and discarded after the deploy plan is computed; that lifecycle is unchanged from today.

--- a/specs/002-fix-routing-dir-manifest-scan/plan.md
+++ b/specs/002-fix-routing-dir-manifest-scan/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: Fix Routing-Dir Manifest Scan Crash
+
+**Branch**: `002-fix-routing-dir-manifest-scan` | **Date**: 2026-04-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-fix-routing-dir-manifest-scan/spec.md`
+
+## Summary
+
+`shrine deploy` crashes when the Traefik plugin's `routing-dir` is a subdirectory of `specsDir` (the documented default at `{specsDir}/traefik/`). The manifest scanner walks the tree, picks up the Traefik-generated YAML files, hands them to `manifest.Parse`, which probes `kind`, finds none it recognises, and returns `"unknown manifest kind"` — aborting the deploy.
+
+The fix introduces a strict, two-step classification gate that runs once per candidate file and is shared by every directory scanner:
+
+1. **Extension filter** (already in place): admit only `.yaml` / `.yml`.
+2. **`apiVersion` classification** (new): a file is a shrine manifest **only** when its top-level `apiVersion` matches the regex `^shrine/v\d+([a-z]+\d+)?$`. Files that fail this check are classified **Foreign** and silently skipped. Files that pass it are then parsed, and any `kind`/spec defect fails loudly as today.
+
+The classification helper lives in `internal/manifest/` (alongside `Parse` / `Validate`) and is consumed by both `internal/planner/loader.go` (`LoadDir`) and `internal/handler/teams.go` (`walkYAMLFiles` → `ApplyTeams`), so no scan path can crash on a foreign file. A single info-level notice lists foreign paths once per scan (FR-006). Malformed YAML inside a `.yaml`/`.yml` file remains a loud error (FR-004) since intent cannot be inferred from unparseable bytes.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (`github.com/CarlosHPlata/shrine`)
+**Primary Dependencies**: `gopkg.in/yaml.v3` (already used by `internal/manifest/parser.go`); `regexp` (stdlib)
+**Storage**: N/A — scanner is a read-only filesystem walk
+**Testing**: `go test ./...` for unit tests; `go test -tags integration ./tests/integration/...` (or `make test-integration`) for the `NewDockerSuite` gate
+**Target Platform**: Linux server (homelab Docker host)
+**Project Type**: Single-binary Go CLI (`cmd/shrine`)
+**Performance Goals**: Negligible — one extra regex match per admitted YAML file in `specsDir`; expected file counts are O(10s) per project
+**Constraints**: Must not change behaviour for any project containing only valid shrine manifests; FR-007 explicitly forbids regression in parse/validation paths
+**Scale/Scope**: Touches two scan call-sites (`internal/planner/loader.go`, `internal/handler/teams.go`), one new helper in `internal/manifest/`, plus unit + integration tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Question | Status |
+|-----------|---------------|--------|
+| I. Declarative Manifest-First | Does this feature expose new capabilities via manifest fields (not CLI flags)? | [x] N/A — pure scanner bug fix; no new manifest fields, no CLI flags |
+| II. Kubectl-Style CLI | Do new commands follow verb-first convention and include `--dry-run`? | [x] N/A — no new commands |
+| III. Pluggable Backend | Is new infrastructure logic behind a backend interface (not engine core)? | [x] N/A — no backend logic; touches `internal/manifest` and `internal/planner` only |
+| IV. Simplicity & YAGNI | Is every abstraction justified by ≥3 concrete usages? | [x] Pass — one classification helper consumed by ≥2 existing scanners (`LoadDir`, `walkYAMLFiles`) and any future scanner; no speculative interfaces |
+| V. Integration-Test Gate | Does this phase map to an integration test phase in the integration test suite using `NewDockerSuite` against a real binary? | [x] Pass — new scenario in [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go) (or sibling) deploys a fixture where `specsDir` contains both valid manifests and a foreign YAML file (mimicking generated Traefik config), asserts success and exact applied-manifest set |
+| VI. Docker-Authoritative State | Does state update happen *after* Docker operations complete? | [x] N/A — no state writes |
+| VII. Clean Code & Readability | Is repeated logic extracted into named helpers? Are names self-documenting (no WHAT comments)? | [x] Pass — the two existing copy-pasted `WalkDir` blocks (`getFiles` in [internal/planner/loader.go](../../internal/planner/loader.go) and `walkYAMLFiles` in [internal/handler/teams.go](../../internal/handler/teams.go)) collapse into one shared scanner; classification function is named for intent (`isShrineManifest`, `classifyManifestFile`) per the boolean-naming rule |
+
+> No violations — Complexity Tracking table is intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-fix-routing-dir-manifest-scan/
+├── plan.md              # This file (/speckit-plan command output)
+├── spec.md              # Feature specification (already exists)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── scanner-contract.md
+└── tasks.md             # Phase 2 output (/speckit-tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+└── shrine/                          # CLI entrypoint — unchanged
+
+internal/
+├── manifest/
+│   ├── parser.go                    # MODIFY: extract `probeKind` so it can be shared, OR add new file
+│   ├── classify.go                  # NEW: regex `^shrine/v\d+([a-z]+\d+)?$`, `Classify(path) (Class, error)`
+│   ├── classify_test.go             # NEW: unit tests for every spec edge case
+│   ├── types.go                     # unchanged
+│   └── validate.go                  # unchanged
+├── planner/
+│   ├── loader.go                    # MODIFY: LoadDir consumes shared scanner; emits foreign-file notice
+│   └── loader_test.go               # MODIFY: add cases for foreign / mistyped-apiVersion / shrine-with-bad-kind
+└── handler/
+    └── teams.go                     # MODIFY: ApplyTeams uses shared scanner — no more "Skipping X: not a Team manifest" for foreign files
+
+tests/
+├── testdata/
+│   └── deploy/
+│       └── foreign-yaml/            # NEW fixture: valid app + a Traefik-shaped YAML alongside it
+│           ├── team.yaml
+│           ├── app.yaml
+│           └── traefik/
+│               └── traefik.yml      # No apiVersion (mirrors generator output)
+└── integration/
+    └── deploy_test.go               # MODIFY: add scenario "deploy succeeds when specsDir contains foreign YAML"
+```
+
+**Structure Decision**: The repo is a single-binary Go CLI (`cmd/shrine` + `internal/...`) with `tests/integration/` housing the `NewDockerSuite` gate. The fix is local to `internal/manifest/` (new helper) plus two existing scan call-sites in `internal/planner/` and `internal/handler/`. No new packages, no new commands, no new manifest kinds.
+
+## Complexity Tracking
+
+> No Constitution violations to track.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/002-fix-routing-dir-manifest-scan/quickstart.md
+++ b/specs/002-fix-routing-dir-manifest-scan/quickstart.md
@@ -1,0 +1,195 @@
+# Quickstart: Verify the Routing-Dir Scan Fix
+
+This guide walks an operator (or reviewer) through reproducing the original crash on `main`, confirming the fix is in place on this branch, and exercising every spec acceptance scenario by hand. Estimated time: ~10 minutes.
+
+## Prerequisites
+
+- A working Docker daemon (`docker info` succeeds).
+- Go 1.24+ on `PATH`.
+- This repo checked out, branch `002-fix-routing-dir-manifest-scan`.
+
+```bash
+cd /root/projects/shrine
+go version            # >= 1.24
+docker info >/dev/null && echo "docker OK"
+```
+
+## Step 1 — Reproduce the crash on `main` (optional, baseline)
+
+```bash
+git stash                     # save in-progress edits
+git checkout main
+go build -o /tmp/shrine-main ./cmd/shrine
+
+# Build a minimal project where routing-dir lives inside specsDir
+work=$(mktemp -d)
+cp -r tests/testdata/deploy/basic/* "$work/"
+cp tests/testdata/deploy/team.yaml "$work/"   # adjust path if your fixture differs
+mkdir -p "$work/traefik"
+cat > "$work/traefik/traefik.yml" <<'EOF'
+# Mimics what internal/plugins/gateway/traefik/config_gen.go writes:
+# a static Traefik config with NO apiVersion field.
+entryPoints:
+  web:
+    address: ":80"
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+EOF
+
+state=$(mktemp -d)
+/tmp/shrine-main apply teams --path "$work" --state-dir "$state"
+/tmp/shrine-main deploy --path "$work" --state-dir "$state"
+# EXPECTED on main: exits non-zero with `unknown manifest kind: ""` referencing
+# $work/traefik/traefik.yml. This is the SC-001 regression.
+
+git checkout 002-fix-routing-dir-manifest-scan
+git stash pop || true
+```
+
+If you skip Step 1, just trust the integration test added under [tests/integration/traefik_plugin_test.go](../../tests/integration/traefik_plugin_test.go).
+
+## Step 2 — Build the fixed binary
+
+```bash
+go build -o /tmp/shrine-fix ./cmd/shrine
+```
+
+## Step 3 — Acceptance scenario from User Story 1 (P1)
+
+> Default Traefik plugin layout — `routing-dir` inside `specsDir` — must deploy cleanly.
+
+```bash
+work=$(mktemp -d)
+cp -r tests/testdata/deploy/basic/* "$work/"
+cp tests/testdata/deploy/team.yaml "$work/"
+mkdir -p "$work/traefik/dynamic"
+cat > "$work/traefik/traefik.yml" <<'EOF'
+entryPoints:
+  web:
+    address: ":80"
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+EOF
+cat > "$work/traefik/dynamic/team-foo-app.yml" <<'EOF'
+http:
+  routers:
+    foo:
+      rule: "Host(`foo.shrine.lab`)"
+      service: foo
+EOF
+
+state=$(mktemp -d)
+/tmp/shrine-fix apply teams --path "$work" --state-dir "$state"
+/tmp/shrine-fix deploy     --path "$work" --state-dir "$state"
+# EXPECTED:
+#   - exit code 0
+#   - one informational line listing the two Traefik files as ignored (FR-006)
+#   - the basic app container is created and running
+docker ps | grep -E '\.whoami\b'
+```
+
+## Step 4 — Acceptance scenario from User Story 2 (P2)
+
+> Foreign YAML files (no apiVersion / wrong apiVersion) coexist in `specsDir` — silently skipped.
+
+```bash
+cat > "$work/editor-config.yaml" <<'EOF'
+# Some other tool's settings; no apiVersion.
+indent: 2
+useTabs: false
+EOF
+cat > "$work/k8s-style.yaml" <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: not-shrine }
+EOF
+
+/tmp/shrine-fix deploy --path "$work" --state-dir "$state"
+# EXPECTED: exit 0; the FR-006 notice now lists 4 foreign files (the two
+# Traefik files + editor-config.yaml + k8s-style.yaml). No new containers.
+```
+
+## Step 5 — Acceptance scenario from User Story 3 (P2)
+
+> A file that **claims** to be a shrine manifest (`apiVersion: shrine/v1`) but has a typo'd `kind` MUST still fail loudly.
+
+```bash
+cat > "$work/typo.yaml" <<'EOF'
+apiVersion: shrine/v1
+kind: Aplication        # typo on purpose
+metadata: { name: oops, owner: shrine-deploy-test }
+spec:
+  image: nginx
+  port: 80
+EOF
+
+/tmp/shrine-fix deploy --path "$work" --state-dir "$state"
+# EXPECTED: non-zero exit. stderr names $work/typo.yaml and the offending
+# kind value. (FR-003)
+
+rm "$work/typo.yaml"
+```
+
+## Step 6 — Edge case: malformed YAML in a `.yaml` file
+
+> Files admitted by extension but unparseable as YAML must error loudly (FR-004).
+
+```bash
+cat > "$work/broken.yaml" <<'EOF'
+apiVersion: shrine/v1
+kind: [this list never closes
+EOF
+
+/tmp/shrine-fix deploy --path "$work" --state-dir "$state"
+# EXPECTED: non-zero exit. stderr names $work/broken.yaml and the YAML parse error.
+
+rm "$work/broken.yaml"
+```
+
+## Step 7 — Edge case: non-YAML siblings are invisible
+
+> Non-`.yaml`/`.yml` extensions must be ignored without being read (FR-001(a)).
+
+```bash
+echo "*.log" > "$work/.gitignore"
+echo "{ broken json" > "$work/config.json"
+chmod 000 "$work/config.json"   # unreadable on purpose
+/tmp/shrine-fix deploy --path "$work" --state-dir "$state"
+# EXPECTED: exit 0. Shrine never opens config.json; the .gitignore is invisible.
+chmod 644 "$work/config.json" && rm "$work/config.json" "$work/.gitignore"
+```
+
+## Step 8 — Run the automated gate
+
+The hand-walked scenarios above must also be enforced by the integration suite (Constitution V):
+
+```bash
+make test-integration
+# OR
+go test -tags integration ./tests/integration/... -run 'TestDeploy|TestTraefikPlugin' -v
+```
+
+EXPECTED: every test passes, including the two new cases:
+
+- `TestDeploy/should_deploy_successfully_when_specsDir_contains_foreign_YAML_files`
+- `TestTraefikPlugin/should_succeed_when_routing-dir_is_inside_specsDir`
+
+## Step 9 — Cleanup
+
+```bash
+docker ps -aq --filter "name=^shrine-deploy-test\." | xargs -r docker rm -f
+docker network ls -q --filter "name=^shrine\.shrine-deploy-test\." | xargs -r docker network rm
+rm -rf "$work" "$state"
+```
+
+## Success Criteria mapping
+
+| Spec criterion | Where verified |
+|----------------|----------------|
+| SC-001 (default Traefik layout deploys) | Steps 1+3, plus `TestTraefikPlugin/should_succeed_when_routing-dir_is_inside_specsDir` |
+| SC-002 (no command crashes on foreign YAML) | Step 4, plus `TestDeploy/should_deploy_successfully_when_specsDir_contains_foreign_YAML_files` |
+| SC-003 (integration test asserts exact applied set) | Step 8 — the new TestDeploy case asserts which containers were and were not created |
+| SC-004 (regression: shrine/v1 + bad kind still fails loudly) | Step 5, plus `internal/manifest/classify_test.go` table case "Shrine v1 with bogus kind" → followed by a planner-level test asserting the loud error |
+| SC-005 (default plugin layout works out of the box) | Step 3 — same fixture as SC-001, exercised manually and via integration test |

--- a/specs/002-fix-routing-dir-manifest-scan/research.md
+++ b/specs/002-fix-routing-dir-manifest-scan/research.md
@@ -1,0 +1,196 @@
+# Phase 0 Research: Fix Routing-Dir Manifest Scan Crash
+
+All open items from the spec's clarifications and the Technical Context are resolved below. There are **no remaining `NEEDS CLARIFICATION`** entries.
+
+---
+
+## R-001: Where does the classification helper live?
+
+**Decision**: Add a new file `internal/manifest/classify.go` exposing:
+
+```go
+type Class int
+
+const (
+    ClassShrine  Class = iota // apiVersion matches ^shrine/v\d+([a-z]+\d+)?$
+    ClassForeign              // .yaml/.yml file but apiVersion absent or non-matching
+)
+
+// Classify reads `path`, returns Class plus the parsed top-level TypeMeta when
+// ClassShrine. Malformed YAML returns an error (FR-004). Caller is responsible
+// for the .yaml/.yml extension filter — Classify never inspects the filename.
+func Classify(path string) (Class, *TypeMeta, error)
+
+// IsShrineAPIVersion is the regex check exposed for callers that already hold
+// a parsed TypeMeta and just need to ask "is this ours?".
+func IsShrineAPIVersion(apiVersion string) bool
+```
+
+**Rationale**:
+
+- `internal/manifest/` already owns parsing (`parser.go`), validation (`validate.go`), and the `TypeMeta` type. Classification is the natural sibling.
+- Keeping it out of `internal/planner/` lets `internal/handler/teams.go` import the same helper without creating a planner→handler dependency cycle.
+- Returning `(Class, *TypeMeta, error)` lets callers reuse the already-unmarshalled metadata for the subsequent `Parse` call, avoiding double `yaml.Unmarshal` on the bytes. (Minor optimisation but free.)
+
+**Alternatives considered**:
+
+- *Inline the regex in `LoadDir`*: would force `internal/handler/teams.go` to copy the same six lines — direct violation of Constitution Principle VII (DRY).
+- *Put the helper in `internal/planner/`*: would force `internal/handler/` to import `internal/planner/` just to scan for team manifests, which is a layer inversion (planner depends on manifests, not the other way around).
+- *Add a method on `*Manifest`*: `Manifest` does not exist before parsing succeeds — classification has to happen on raw bytes, so a free function is the right shape.
+
+---
+
+## R-002: What exact regex anchors `apiVersion`?
+
+**Decision**: `^shrine/v\d+([a-z]+\d+)?$` — matches the spec's clarification verbatim. Compiled once at package init via `regexp.MustCompile`.
+
+**Examples (must match)**: `shrine/v1`, `shrine/v2`, `shrine/v1beta1`, `shrine/v10alpha7`.
+**Examples (must NOT match)**: `Shrine/v1` (capital), `shrines/v1` (typo), `shrine/dev` (no version), `shrine/v1 ` (trailing whitespace — YAML strips this for scalar values, so the runtime input is already trimmed), `apps/v1`, `traefik.containo.us/v1alpha1`, `""` (empty), missing field (Go zero value `""`).
+
+**Rationale**: Strict regex is the spec's chosen trade-off (spec §Clarifications, Q1) — operators who typo `apiVersion` accept silent skip rather than ambiguous detection. The `([a-z]+\d+)?` group covers the Kubernetes-style stability suffix (`alpha`, `beta`) that shrine has already adopted in [.specify/memory/constitution.md](../../.specify/memory/constitution.md) §I ("`apiVersion: shrine/v1`").
+
+**Alternatives considered**:
+
+- *Loose prefix match (`strings.HasPrefix(apiVersion, "shrine/")`)*: would accept `shrine/dev`, `shrine/`, `shrine/v1-WIP`, defeating the "strict, unambiguous detection" requirement.
+- *Multi-document YAML support*: explicitly out of scope per spec §Assumptions and §Edge Cases.
+- *Case-insensitive match*: rejected by spec clarification — `Shrine/v1` is treated as a typo and skipped.
+
+---
+
+## R-003: How is the foreign-file notice surfaced (FR-006)?
+
+**Decision**: After every `LoadDir` / `walkYAMLFiles` call that classified at least one file as Foreign, emit a single line to stdout via the existing `fmt.Printf` channel used elsewhere in the handler layer:
+
+```
+shrine: ignored 2 non-shrine YAML file(s) under specs/: traefik/traefik.yml, traefik/dynamic/team-x-app.yml
+```
+
+The notice is emitted by the **caller** (`LoadDir`, `ApplyTeams`), not by `Classify`, so unit tests of `Classify` stay deterministic and silent. The notice is suppressed when the foreign list is empty.
+
+**Rationale**:
+
+- Shrine has no structured logger today (see [internal/handler/teams.go:117](../../internal/handler/teams.go#L117) using `fmt.Printf` for status output). Introducing one is out of scope per Principle IV (YAGNI).
+- Spec §FR-006 marks this as SHOULD, not MUST, and explicitly says "presence or absence MUST NOT change exit status" — a single Printf line satisfies both.
+- Files filtered by extension (FR-001(a)) are deliberately excluded from the count to keep the notice signal-rich.
+
+**Alternatives considered**:
+
+- *Per-file lines*: noisy on projects with a populated `routing-dir/dynamic/` containing dozens of generated route files.
+- *Stderr*: spec §II says user-visible non-error output goes to stdout; this is informational, not an error.
+- *Log only when verbose flag is set*: shrine has no `--verbose` flag today; introducing one is YAGNI for this fix.
+
+---
+
+## R-004: How do we keep `LoadDir` and `walkYAMLFiles` in sync (Principle VII / DRY)?
+
+**Decision**: Extract a single shared scanner into `internal/manifest/scan.go`:
+
+```go
+// ScanResult lists, for one directory walk, the .yaml/.yml files split into
+// shrine-classified candidates (with their probed TypeMeta) and foreign paths.
+type ScanResult struct {
+    Shrine  []ShrineCandidate
+    Foreign []string
+}
+
+type ShrineCandidate struct {
+    Path     string
+    TypeMeta TypeMeta
+}
+
+// ScanDir walks `dir`, applies the .yaml/.yml extension filter, then calls
+// Classify on each admitted file. Foreign files are silently collected.
+// Malformed YAML in an admitted file aborts the scan with a wrapped error
+// (FR-004).
+func ScanDir(dir string) (*ScanResult, error)
+```
+
+`LoadDir` then becomes "call `ScanDir`, parse + validate every `Shrine` candidate, route by `Kind`, emit foreign-files notice". `walkYAMLFiles` (renamed and inlined into `ApplyTeams` since it has only one caller) does the same and discards non-`Team` candidates.
+
+**Rationale**:
+
+- Today `getFiles` ([internal/planner/loader.go:51](../../internal/planner/loader.go#L51)) and `walkYAMLFiles` ([internal/handler/teams.go:67](../../internal/handler/teams.go#L67)) are line-for-line duplicates of each other. Constitution VII demands extraction "immediately" once a behaviour has two call sites.
+- Putting `ScanDir` in `internal/manifest/` is the only place both callers can already import without inversion (planner→manifest, handler→manifest).
+- FR-005 ("apply uniformly to every code path that scans a directory") makes this consolidation a correctness requirement, not a style preference: any future scan-using command must call `ScanDir` to inherit the fix.
+
+**Alternatives considered**:
+
+- *Two parallel implementations kept in sync by convention*: rejected — the bug we are fixing exists today partly because there are already two scanners.
+- *Keep `getFiles` / `walkYAMLFiles` and just have each call `Classify` on every result*: works correctly but duplicates the walk logic forever. Constitution VII is unambiguous here.
+
+---
+
+## R-005: How is the integration scenario built (Principle V)?
+
+**Decision**: Add a new fixture directory `tests/testdata/deploy/foreign-yaml/` containing:
+
+- `team.yaml` — valid `Team` manifest (mirrors existing `tests/testdata/deploy/basic/`).
+- `app.yaml` — valid `Application` manifest, e.g. a `whoami` deployment.
+- `traefik/traefik.yml` — a static Traefik-shaped YAML file with **no** `apiVersion` field (mirrors what `internal/plugins/gateway/traefik/config_gen.go` writes).
+- `traefik/dynamic/team-foo-app.yml` — a Traefik dynamic route file, also without `apiVersion`.
+
+Add one new `s.Test` case to [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go):
+
+```go
+s.Test("should deploy successfully when specsDir contains foreign YAML files", func(tc *TestCase) {
+    tc.Run("deploy",
+        "--path", fixturesPath("foreign-yaml"),
+        "--state-dir", tc.StateDir,
+    ).AssertSuccess()
+    tc.AssertContainerRunning(testTeam + ".whoami")
+    // Foreign files must not produce containers / state entries:
+    tc.AssertContainerNotExists(testTeam + ".traefik")
+})
+```
+
+A second case under [tests/integration/traefik_plugin_test.go](../../tests/integration/traefik_plugin_test.go) exercises the **canonical** failure: enable the Traefik plugin with the default `routing-dir = {specsDir}/traefik`, then re-run `shrine deploy` and assert it succeeds (this is the SC-001 acceptance path that crashes on `main` today).
+
+**Rationale**: Principle V requires the real binary against a real Docker daemon; both new cases use the existing `NewDockerSuite` harness with `tc.Run("deploy", ...)`. Unit tests of `Classify` and `ScanDir` cover edge cases cheaply but do not satisfy the gate alone (Principle V: "Unit tests supplement but NEVER substitute").
+
+**Alternatives considered**:
+
+- *Only unit tests*: forbidden by Principle V.
+- *Modify an existing fixture*: would couple unrelated test cases to this regression and mask future drift; a dedicated fixture is clearer and cheaper to maintain.
+
+---
+
+## R-006: Behaviour for `kind` that doesn't match a known kind but `apiVersion` is shrine (FR-003)?
+
+**Decision**: After `Classify` returns `ClassShrine`, the existing pipeline (`manifest.Parse` → `manifest.Validate`) already handles this:
+
+- [internal/manifest/parser.go:65](../../internal/manifest/parser.go#L65) returns `"unknown manifest kind: %q"` when `Kind` is not Application/Resource/Team.
+- [internal/manifest/validate.go:23](../../internal/manifest/validate.go#L23) returns `"kind is required"` / `"kind must be one of: Team, Resource, Application"`.
+
+Both errors are wrapped in `LoadDir` with the file path ([internal/planner/loader.go:35](../../internal/planner/loader.go#L35), `parsing manifest %q`). FR-003's "error that identifies the file path and the offending kind value" is therefore satisfied **once we route shrine-classified files through `Parse`** — exactly what the new `LoadDir` does. No new error path is needed; we only need to confirm with a unit test that a file with `apiVersion: shrine/v1` and `kind: Aplication` (typo) still fails loudly with the file path in the message.
+
+**Rationale**: Adding a parallel error message would duplicate behaviour and risk drift. The spec's FR-007 ("existing behaviour for valid shrine manifests MUST be unchanged") is best honoured by leaving `Parse`/`Validate` exactly as-is and only changing what enters them.
+
+**Alternatives considered**:
+
+- *Custom `kind`-check before calling `Parse`*: rejected — duplicates `validateTypeMeta`.
+
+---
+
+## R-007: What about `cmd/shrine generate` and other not-yet-enumerated scan paths (FR-005)?
+
+**Decision**: Audit pass during implementation: `grep -rn "filepath.WalkDir\|filepath.Walk" internal/ cmd/` will list every directory walker. Today only two manifest-scanning walkers exist (`internal/planner/loader.go`, `internal/handler/teams.go`); both are migrated. Any future addition of a third walker is gated by the new `ScanDir` API — there is no other primitive to call, so FR-005 holds by construction.
+
+**Rationale**: FR-005 is forward-looking ("every code path… so that no command crashes on the same foreign file"). Centralising the walker is the cheapest mechanism to guarantee that.
+
+**Alternatives considered**:
+
+- *Lint rule banning ad-hoc `WalkDir` in `internal/`*: out of scope and YAGNI for a one-binary CLI with two call-sites.
+
+---
+
+## Summary of Decisions
+
+| ID | Decision | Locked by |
+|----|----------|-----------|
+| R-001 | New file `internal/manifest/classify.go` exposing `Classify` + `IsShrineAPIVersion` | FR-001(b), Principle VII |
+| R-002 | Regex `^shrine/v\d+([a-z]+\d+)?$`, compiled once | Spec Clarification Q1 |
+| R-003 | Single stdout notice listing foreign paths, suppressed when none | FR-006, Principle II |
+| R-004 | Extract shared `ScanDir` into `internal/manifest/scan.go`; collapse the two duplicated walkers | FR-005, Principle VII |
+| R-005 | New fixture `tests/testdata/deploy/foreign-yaml/` + 2 integration scenarios | Principle V, SC-001..SC-004 |
+| R-006 | Reuse existing `Parse`/`Validate` error paths for FR-003 | FR-007 |
+| R-007 | `ScanDir` is the only primitive future scanners call | FR-005 |

--- a/specs/002-fix-routing-dir-manifest-scan/spec.md
+++ b/specs/002-fix-routing-dir-manifest-scan/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Fix Routing-Dir Manifest Scan Crash
+
+**Feature Branch**: `002-fix-routing-dir-manifest-scan`  
+**Created**: 2026-04-30  
+**Status**: Draft  
+**Input**: User description: "Bug: shrine deploy crashes when routing-dir is inside specsDir. When routing-dir is a subdirectory of specsDir, Shrine's manifest scanner picks up Traefik YAML files and tries to parse them as Shrine manifests, causing a crash. The scanner should skip files that are not valid Shrine manifests (missing apiVersion/kind) instead of crashing."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Deploy Succeeds With Default routing-dir Layout (Priority: P1)
+
+A shrine operator enables the Traefik gateway plugin and accepts the default `routing-dir` (which lives inside `specsDir` at `{specsDir}/traefik/`). When they run `shrine deploy`, the deploy completes successfully even though the Traefik directory contains generated YAML files that are not Shrine manifests.
+
+**Why this priority**: This is the default, documented configuration for the Traefik plugin. Today it crashes the deploy outright, blocking the most common path for any operator who turns the plugin on.
+
+**Independent Test**: Configure the Traefik plugin with default settings, generate Traefik routing files into `{specsDir}/traefik/`, run `shrine deploy`, and confirm the command succeeds without errors and applies all valid Shrine manifests.
+
+**Acceptance Scenarios**:
+
+1. **Given** `routing-dir` is a subdirectory of `specsDir` and contains Traefik YAML files (whose `apiVersion` does not match the shrine pattern), **When** the operator runs `shrine deploy`, **Then** the deploy parses and applies only valid Shrine manifests and ignores the Traefik files without raising an error.
+2. **Given** `routing-dir` lives outside `specsDir`, **When** the operator runs `shrine deploy`, **Then** behavior is unchanged from today: only files under `specsDir` are scanned, and all valid Shrine manifests are applied.
+3. **Given** `specsDir` contains only valid Shrine manifests (each with `apiVersion: shrine/v1`), **When** the operator runs `shrine deploy`, **Then** every manifest is parsed and applied exactly as before — there is no regression in detection of legitimate manifests.
+
+---
+
+### User Story 2 - Foreign YAML Files Coexist In specsDir (Priority: P2)
+
+A shrine operator keeps unrelated YAML files inside `specsDir` (for example, an editor settings file, a CI snippet, or another tool's config). When they run any shrine command that scans `specsDir` for manifests, those foreign files are skipped silently and shrine continues with the manifests it understands.
+
+**Why this priority**: Generalises the fix beyond Traefik. Any tool whose YAML lives alongside shrine manifests benefits from the same skip behaviour, and it avoids a long tail of one-off bug reports for each new collocated tool.
+
+**Independent Test**: Place a foreign YAML file (with no `apiVersion`, or an `apiVersion` that does not match the shrine pattern) in `specsDir`, run a shrine command that triggers a manifest scan, and confirm the command succeeds and processes only the legitimate manifests.
+
+**Acceptance Scenarios**:
+
+1. **Given** `specsDir` contains a YAML file with no `apiVersion` field at all, **When** any shrine command scans `specsDir`, **Then** that file is skipped and the command proceeds.
+2. **Given** `specsDir` contains a YAML file whose `apiVersion` does not match the shrine pattern (e.g., `traefik.containo.us/v1alpha1`, `apps/v1`, or even `shrine/dev`), **When** shrine scans the directory, **Then** the file is skipped silently — only the strict shrine pattern qualifies a file as a shrine manifest.
+
+---
+
+### User Story 3 - Genuinely Broken Shrine Manifests Still Fail Loudly (Priority: P2)
+
+A shrine operator has a YAML file whose `apiVersion` matches the shrine pattern (e.g., `shrine/v1`) but whose `kind` is missing, misspelled, or the spec body is invalid. When they run `shrine deploy`, the command fails with a clear error pointing to that file — the "skip foreign files" rule does not mask authoring mistakes once a file has self-identified as a shrine manifest.
+
+**Why this priority**: Without this guard, the fix could silently swallow typos like `kind: Aplication` in a `shrine/v1` document and let a broken project deploy partially. Operators must still see real errors when intent is clear.
+
+**Independent Test**: Place a YAML file with `apiVersion: shrine/v1` and a `kind` value that is missing or non-empty but unrecognised (e.g., `Aplication`) in `specsDir`, run `shrine deploy`, and confirm the command fails with an error that names the file and the offending kind.
+
+**Acceptance Scenarios**:
+
+1. **Given** a YAML file whose `apiVersion` matches the shrine pattern and whose `kind` is missing, empty, or non-empty but unrecognised by shrine, **When** shrine scans `specsDir`, **Then** the command fails with an error identifying the file and the offending kind value.
+2. **Given** a YAML file whose `apiVersion` matches the shrine pattern and whose `kind` is recognised but whose body fails validation (e.g., missing required fields), **When** shrine scans `specsDir`, **Then** the command fails with the existing validation error for that manifest — behaviour unchanged from today.
+
+---
+
+### Edge Cases
+
+- A file in the scanned tree has no `.yaml` or `.yml` extension (e.g., `.gitignore`, `README.md`, `Makefile`, `config.json`, `app.toml`, an extension-less binary, or a `*.tmpl`/`*.bak`) → not opened or read by the scanner; skipped silently regardless of contents.
+- A YAML file is empty or contains only comments → passes the extension filter, has no `apiVersion`, classified as foreign, skipped.
+- A YAML file is malformed (cannot be parsed as YAML at all) → passes the extension filter, fails loudly with an error identifying the file and the parse error; this is treated as an authoring mistake, not a foreign file, because shrine cannot tell intent from unparseable bytes.
+- A YAML file's `apiVersion` is `shrine/v1` but the value is mistyped as `Shrine/v1`, `shrines/v1`, or `shrine/dev` → does not match the strict shrine regex, so the file is skipped silently. Operators are expected to detect this through "manifest not applied" rather than a parser error.
+- A YAML file contains multiple documents separated by `---` → the existing single-document behaviour is preserved; multi-document support is out of scope for this fix.
+- A non-YAML payload stored in a file with a `.yml` or `.yaml` extension (e.g., a templating placeholder) → passes the extension filter; if the bytes parse as YAML and the `apiVersion` does not match the shrine pattern, it is skipped; if they do not parse as YAML, it errors per the rule above.
+- `routing-dir` is a symlink pointing inside `specsDir` → treated the same as a real subdirectory; foreign files inside it are skipped.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The manifest scanner MUST process candidates in two ordered steps:
+  - **(a) Extension filter** — only files whose extension is exactly `.yaml` or `.yml` (case-sensitive, matching the existing convention) are admitted as candidates. Files with any other extension, or no extension at all, MUST be skipped silently; the scanner does not open or read them.
+  - **(b) apiVersion classification** — for each admitted candidate, the scanner MUST inspect the top-level `apiVersion` field FIRST, and MUST treat the file as a shrine manifest only when `apiVersion` matches the regex `^shrine/v\d+([a-z]+\d+)?$` (e.g., `shrine/v1`, `shrine/v1beta1`, `shrine/v2`). All admitted candidates that fail this check (no `apiVersion`, empty value, or any non-matching value) MUST be classified as foreign.
+- **FR-002**: When a file is skipped by FR-001(a) or classified as foreign by FR-001(b), shrine MUST NOT raise an error, MUST NOT include it in the manifest set, and MUST continue processing remaining files.
+- **FR-003**: When a file's `apiVersion` matches the shrine regex, shrine MUST then validate `kind`: if `kind` is missing, empty, or non-empty but not a kind shrine recognises, shrine MUST fail loudly with an error that identifies the file path and the offending kind value. Files self-identified as shrine manifests must not be silently skipped on any kind-related defect.
+- **FR-004**: The manifest scanner MUST fail loudly on any file admitted by FR-001(a) that cannot be parsed as YAML, with an error message identifying the file path and the parse error. Malformed YAML is never silently skipped, since the apiVersion cannot be inspected.
+- **FR-005**: The two-step classification rule (extension filter + apiVersion check) MUST apply uniformly to every code path that scans a directory for shrine manifests (deploy, apply, generate, and any other manifest-driven command), so that no command crashes on the same foreign file or unrelated file type.
+- **FR-006**: When at least one file is classified as foreign by FR-001(b), shrine SHOULD emit a single concise notice (at info or debug level) listing the foreign paths, so operators can confirm the file was intentionally ignored. Files skipped by the extension filter (FR-001(a)) MUST NOT be listed. The presence or absence of this notice MUST NOT change command exit status.
+- **FR-007**: Existing behaviour for valid shrine manifests (Application, Resource, Team) MUST be unchanged: same parsing, same validation errors, same downstream effects.
+
+### Key Entities
+
+- **Shrine Manifest File**: A file with extension `.yaml` or `.yml` whose top-level `apiVersion` matches the regex `^shrine/v\d+([a-z]+\d+)?$`. These files are parsed, validated, and applied; their `kind` and body must be valid or shrine fails loudly.
+- **Foreign YAML File**: A file with extension `.yaml` or `.yml` whose `apiVersion` does not match the shrine regex (including absent, empty, or unrelated values such as `traefik.containo.us/v1alpha1`). These files are silently skipped by the scanner. Traefik routing files generated into `{specsDir}/traefik/` are the canonical example.
+- **Non-YAML Sibling**: Any file in the scanned tree whose extension is not `.yaml` or `.yml` (or that has no extension). These are filtered out before any read/parse step; they never enter manifest classification at all.
+- **Mistyped-Shrine File**: A YAML file the operator intended as a shrine manifest but whose `apiVersion` typo (e.g., `Shrine/v1`, `shrine/dev`) prevents the regex from matching. Treated as Foreign and skipped silently — the trade-off accepted in exchange for a strict, unambiguous detection rule.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With the Traefik plugin enabled at default settings (so generated routing files live under `{specsDir}/traefik/`), `shrine deploy` completes successfully with exit code 0 on a project that previously crashed on the same inputs.
+- **SC-002**: Across every shrine command that scans `specsDir` (deploy, apply, generate, and equivalents), zero commands crash on a project containing only valid shrine manifests plus any number of foreign YAML files in the same tree.
+- **SC-003**: An integration test runs `shrine deploy` against a fixture where `specsDir` contains both valid manifests and foreign YAML files, and asserts both that the deploy succeeds and that exactly the expected set of manifests was applied — no more, no less.
+- **SC-004**: A regression test asserts that a YAML file with `apiVersion: shrine/v1` and a missing or misspelled `kind` still causes the corresponding command to fail with an error naming the file.
+- **SC-005**: Operators no longer need to set a custom `routing-dir` outside `specsDir` to avoid the crash; the default plugin layout works out of the box.
+
+## Clarifications
+
+### Session 2026-04-30
+
+- Q: What pattern qualifies a YAML file as a shrine manifest based on its `apiVersion` field? → A: Strict regex `^shrine/v\d+([a-z]+\d+)?$` — accepts versioned shrine apiVersions like `shrine/v1`, `shrine/v1beta1`, `shrine/v2`; rejects everything else (foreign, mistyped, or non-versioned values).
+- Q: When a YAML file under `specsDir` cannot be parsed as YAML, should shrine fail loudly or skip it silently? → A: Fail loudly with an error naming the file and the parse error — malformed YAML is treated as an authoring mistake, never silently skipped, since the apiVersion cannot be inspected to classify the file.
+- Q: Should files in the scanned tree without `.yaml` or `.yml` extensions be considered by the manifest scanner? → A: No — the scanner first applies an extension filter; only files with extension `.yaml` or `.yml` (case-sensitive) are admitted as candidates and proceed to apiVersion classification. Files with any other extension (or no extension) are skipped silently and never opened, so they cannot trigger malformed-YAML errors.
+
+## Assumptions
+
+- The fix targets the existing single-document YAML scanner; multi-document YAML support is out of scope and not introduced by this change.
+- The extension filter (`.yaml` / `.yml`, case-sensitive) is the FIRST gate; any file failing it is invisible to subsequent checks. This means malformed-YAML errors (FR-004) only ever fire for files whose extension already implied YAML intent.
+- A file's identity as a shrine manifest is determined by the `apiVersion` field alone (evaluated against a strict regex) AFTER the extension filter passes; `kind` is only considered after both prior checks succeed.
+- Operators who actually intended to write a shrine manifest but typo'd the `kind` value prefer a loud failure over a silent skip; this is preserved by FR-003 once a file's apiVersion identifies it as shrine.
+- Operators who typo the `apiVersion` itself (e.g., `Shrine/v1`) accept that the file will be silently skipped; they will detect this as "my manifest didn't take effect" rather than a parser error. This is a deliberate trade-off for a precise, unambiguous detection rule.
+- The skip notice (FR-006) is a usability nicety, not a contract; downstream tooling should not parse it.
+- Existing manifest validation rules (required fields, schema checks) apply unchanged once a file is recognised as a shrine manifest.

--- a/specs/002-fix-routing-dir-manifest-scan/tasks.md
+++ b/specs/002-fix-routing-dir-manifest-scan/tasks.md
@@ -1,0 +1,213 @@
+---
+description: "Task list for Fix Routing-Dir Manifest Scan Crash"
+---
+
+# Tasks: Fix Routing-Dir Manifest Scan Crash
+
+**Feature**: `002-fix-routing-dir-manifest-scan`
+**Plan**: [plan.md](./plan.md) | **Spec**: [spec.md](./spec.md) | **Contracts**: [contracts/scanner-contract.md](./contracts/scanner-contract.md)
+**Tests**: REQUIRED — Constitution V mandates an integration-test gate, and the user explicitly requested TDD ordering ("integration tests shall be created first, and it's expected for them to fail").
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Different file, no in-flight dependency — safe to run in parallel
+- **[Story]**: User story this task belongs to (US1, US2, US3) — Setup / Foundational / Polish phases carry no story label
+
+## Path Conventions
+
+Single-binary Go CLI. Sources under `internal/...` and `cmd/...`; integration suite under `tests/integration/` with fixtures under `tests/testdata/`. Paths in this file are relative to the repository root `/root/projects/shrine/`.
+
+## TDD Ordering Rule (per user request + Constitution V)
+
+Within EVERY story phase, integration tests MUST be created and committed first. Run them with `make test-integration` and **verify they FAIL** before writing any implementation task in the same phase. The Foundational phase's unit tests follow the same rule (`go test ./internal/manifest/...` must fail before `Classify` / `ScanDir` exist).
+
+The implementation strategy section at the bottom of this file enforces the order; do not reorder phases.
+
+---
+
+## Phase 1: Setup (Shared Fixtures)
+
+**Purpose**: Build the test-data fixtures every story consumes. No production code.
+
+- [X] T001 [P] Create deploy-side foreign-yaml fixture skeleton at [tests/testdata/deploy/foreign-yaml/](../../tests/testdata/deploy/foreign-yaml/) with `team.yaml` (`shrine-deploy-test` team, mirrors [tests/testdata/deploy/team.yaml](../../tests/testdata/deploy/team.yaml)) and `app.yaml` (a single `whoami` Application named `whoami` belonging to `shrine-deploy-test`, port 80, no dependencies — mirrors [tests/testdata/deploy/basic/app.yml](../../tests/testdata/deploy/basic/app.yml)).
+- [X] T002 [P] Add Traefik static config file at `tests/testdata/deploy/foreign-yaml/traefik/traefik.yml` containing a YAML body with NO `apiVersion` field (mirrors what [internal/plugins/gateway/traefik/config_gen.go](../../internal/plugins/gateway/traefik/config_gen.go) writes — `entryPoints`, `providers.file.directory`, etc.).
+- [X] T003 [P] Add Traefik dynamic route file at `tests/testdata/deploy/foreign-yaml/traefik/dynamic/team-foo-app.yml` containing an `http.routers...` body with NO `apiVersion`.
+- [X] T004 [P] Add a non-YAML sibling at `tests/testdata/deploy/foreign-yaml/notes.json` containing `{"note": "operator scratchpad"}` to exercise the FR-001(a) extension filter (the file MUST never be opened by the scanner).
+- [X] T005 [P] Create apply-side foreign-yaml fixture skeleton at [tests/testdata/apply/foreign-yaml/](../../tests/testdata/apply/foreign-yaml/) with `team.yaml` (`shrine-apply-test` team), `app.yaml` (a `whoami-apply-foreign` Application), and `traefik/traefik.yml` (no `apiVersion`).
+- [X] T006 [P] Create malformed-YAML fixture at `tests/testdata/deploy/malformed-yaml/` containing the same `team.yaml` + `app.yaml` as T001 PLUS a `broken.yaml` whose body is `apiVersion: shrine/v1\nkind: [unclosed`. This fixture is used by US3 to verify FR-004.
+- [X] T007 [P] Create shrine-with-bad-kind fixture at `tests/testdata/deploy/bad-kind/` containing `team.yaml` + a `typo.yaml` with `apiVersion: shrine/v1`, `kind: Aplication` (typo on purpose), valid metadata, valid spec. Used by US3 to verify FR-003.
+- [X] T008 [P] Create apply-side bad-kind fixture at `tests/testdata/apply/bad-kind/` mirroring T007 plus a `team.yaml` for `shrine-apply-test`.
+
+**Checkpoint**: All fixtures in place. No production code touched yet.
+
+---
+
+## Phase 2: Foundational — Shared Classifier (Blocking Prerequisites)
+
+**Purpose**: Build the `Classify` + `ScanDir` API in `internal/manifest/`. Every story phase below relies on it. TDD: unit tests first, run them to confirm they fail, then implement.
+
+**⚠️ CRITICAL**: No story-phase work may begin until Phase 2 is green.
+
+### TDD Tests for Foundational (write FIRST, must FAIL)
+
+- [X] T009 Write table-driven unit tests for `IsShrineAPIVersion` and `Classify` in [internal/manifest/classify_test.go](../../internal/manifest/classify_test.go) covering every row of the contract table in [contracts/scanner-contract.md §3](./contracts/scanner-contract.md): strict v1 / v1beta1 / v10alpha7 → `ClassShrine`; capital-S / plural / no-version-suffix / trailing-space-in-quoted-scalar / empty / missing / foreign-apiVersion / empty-file / comments-only → `ClassForeign`; malformed YAML → error containing the file path; shrine/v1 with bogus kind → `ClassShrine` (kind is checked downstream). Use `t.TempDir()` + `os.WriteFile` to materialise per-case content.
+- [X] T010 [P] Write `ScanDir` unit tests in [internal/manifest/scan_test.go](../../internal/manifest/scan_test.go): empty dir → empty `ScanResult`, no error; dir with only non-YAML files (`.json`, `.md`, extensionless, set `chmod 000`) → empty `ScanResult` and no error (proves extension filter never opens the files); dir with one valid + one foreign → `Shrine` len 1, `Foreign` len 1; nested subdir mirroring `specsDir/traefik/foo.yml` → foreign path collected with the nested path; one malformed YAML → error wrapping the file path.
+- [X] T011 Run `go test ./internal/manifest/...` and confirm both new test files FAIL because `Classify` / `ScanDir` / `Class` / `ShrineCandidate` / `ScanResult` don't exist yet. Record the failure in the commit message of the test files.
+
+### Implementation for Foundational
+
+- [X] T012 Implement `IsShrineAPIVersion`, `Class` constants, `Classify`, and the package-level compiled regex `^shrine/v\d+([a-z]+\d+)?$` in [internal/manifest/classify.go](../../internal/manifest/classify.go). `Classify` returns `(Class, *TypeMeta, error)` per [data-model.md §Go Types](./data-model.md#go-types-introduced); reuses the existing `probeKind` logic from [internal/manifest/parser.go:31](../../internal/manifest/parser.go#L31) (extract `probeKind` to be exported, or duplicate the unmarshal — pick the lower-churn path and document the choice in a commit message).
+- [X] T013 Implement `ScanDir` and the `ScanResult` / `ShrineCandidate` types in [internal/manifest/scan.go](../../internal/manifest/scan.go) per [contracts/scanner-contract.md §1](./contracts/scanner-contract.md). The walker MUST apply the `.yaml`/`.yml` extension filter BEFORE calling `Classify` (so disallowed files are never opened — invariant 1).
+- [X] T014 Run `go test ./internal/manifest/...` and confirm T009 + T010 now PASS.
+
+**Checkpoint**: Shared classifier is green at the unit-test level. Story phases unblocked.
+
+---
+
+## Phase 3: User Story 1 — Default Routing-Dir Layout Deploys (Priority: P1) 🎯 MVP
+
+**Goal**: `shrine deploy` succeeds when the Traefik plugin's default `routing-dir = {specsDir}/traefik/` is in effect, on a project that crashes today (SC-001 / SC-005).
+
+**Independent Test**: Configure the Traefik plugin with the default routing-dir, run `shrine deploy` against a project containing valid manifests + Traefik-shaped YAML in `{specsDir}/traefik/`, and confirm exit `0` with the app container running.
+
+### TDD Integration Tests for US1 (write FIRST, must FAIL on `main`)
+
+- [X] T015 [US1] Add integration test `should_deploy_succeed_when_routing-dir_is_inside_specsDir` to [tests/integration/traefik_plugin_test.go](../../tests/integration/traefik_plugin_test.go). The test enables the Traefik plugin with `routing-dir: {specsDir}/traefik` (the default), uses `traefikFixturePath()`, runs `shrine deploy` ONCE to generate the routing files, then runs `shrine deploy` a SECOND time against the now-populated tree (this is the canonical SC-001 path). Assert both invocations `AssertSuccess()` and that `traefikContainerName` is running after the second one.
+- [X] T016 [P] [US1] Add integration test `should_deploy_succeed_when_specsDir_contains_foreign_YAML_files` to [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go). Use the new `fixturesPath("foreign-yaml")` (T001-T004 fixture). Assert `shrine deploy` exits `0`, `testTeam + ".whoami"` is running, and `testTeam + ".traefik"` does NOT exist (proves the foreign file produced no container).
+- [X] T017 [US1] Run `make test-integration -- -run 'TestTraefikPlugin/should_deploy_succeed_when_routing-dir|TestDeploy/should_deploy_succeed_when_specsDir_contains_foreign'` and confirm both tests FAIL with the `unknown manifest kind: ""` (or equivalent) error from [internal/manifest/parser.go:66](../../internal/manifest/parser.go#L66). Capture the failure output in the commit message — this is the regression we are fixing.
+
+### Implementation for US1
+
+- [X] T018 [US1] Refactor `LoadDir` in [internal/planner/loader.go](../../internal/planner/loader.go) to call `manifest.ScanDir`. Replace the inlined `getFiles` walker with consumption of `ScanResult.Shrine`; iterate candidates, call `manifest.Parse` (unchanged), `manifest.Validate` (unchanged), and `set.mapKind` (unchanged). Keep the existing duplicate-name and unknown-kind error wrapping intact (FR-007). Delete `getFiles` once unreferenced.
+- [X] T019 [US1] In `LoadDir`, after the parse/validate loop, emit the FR-006 informational notice to stdout when `len(ScanResult.Foreign) > 0`: a single line of the form `shrine: ignored N non-shrine YAML file(s) under <dir>: <comma-separated paths>`. Do NOT emit the notice when `Foreign` is empty. The notice must not affect return value or exit code.
+- [X] T020 [US1] Update unit tests in [internal/planner/loader_test.go](../../internal/planner/loader_test.go) to add cases: (a) directory containing one valid Application + one foreign YAML → no error, foreign file ignored, `set.Applications` has the valid one; (b) directory containing only foreign YAML → no error, empty `set`; (c) directory containing valid + malformed `.yaml` → error referencing the malformed file (FR-004).
+- [X] T021 [US1] Run `make test-integration -- -run 'TestTraefikPlugin|TestDeploy'` and confirm T015 + T016 now PASS plus every existing case in those files still passes (regression guard for FR-007).
+
+**Checkpoint**: SC-001 + SC-005 satisfied. The MVP fix is live for `shrine deploy`. The same refactor also fixes `shrine apply -f` (because [internal/planner/plan.go:71](../../internal/planner/plan.go#L71) `PlanSingle` calls the same `LoadDir`) — US2 will add explicit coverage for that path.
+
+---
+
+## Phase 4: User Story 2 — Foreign YAML Coexists Across All Scan Commands (Priority: P2)
+
+**Goal**: Every shrine command that scans a directory (`deploy`, `apply teams`, `apply -f`) silently skips foreign YAML and non-YAML siblings without crashing (SC-002 / FR-005). The user explicitly called out that the planner change touches all three command surfaces, so each one needs its own test.
+
+**Independent Test**: Place foreign YAML and non-YAML files alongside valid manifests; run each of the three commands; confirm exit `0` and that only the legitimate manifests took effect.
+
+### TDD Integration Tests for US2 (write FIRST, must FAIL or be missing on `main`)
+
+- [X] T022 [P] [US2] Add integration test `should_succeed_when_specsDir_contains_a_yaml_without_shrine_apiVersion` to [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go) using the T001-T003 fixture. Asserts `deploy` exits `0` and the app is running (covers the user-listed case "`shrine deploy` should not fail with a yaml/yml file without shrine version"). STATUS: already-covered-by-T016 — T016's assertions are a superset; adding a duplicate would provide no coverage. Documented in a comment in deploy_test.go.
+- [X] T023 [P] [US2] Add integration test `should_succeed_when_specsDir_contains_non_yaml_files` to [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go). Uses the T004 `notes.json` plus a programmatically-added `chmod 000`-ed `config.json` placed in `tc.Path("")` to prove the extension filter never opens disallowed files (covers "`shrine deploy` should not fail with non-.yaml/.yml files in specsDir").
+- [X] T024 [P] [US2] Add integration test `should_apply_teams_succeed_when_specsDir_contains_foreign_yaml` to [tests/integration/apply_test.go](../../tests/integration/apply_test.go) using the T005 fixture (`apply/foreign-yaml/`). Asserts `apply teams` exits `0` and `tc.AssertTeamInState("shrine-apply-test")` succeeds (covers "`shrine apply teams` should not fail").
+- [X] T025 [P] [US2] Add integration test `should_apply_file_succeed_when_specsDir_contains_foreign_yaml` to [tests/integration/apply_test.go](../../tests/integration/apply_test.go). Uses `apply -f` against the `app.yaml` in the T005 fixture with `--path` pointing at the same directory (which contains the foreign `traefik/traefik.yml`). Asserts exit `0` and the resulting container is running (covers "`shrine apply -f` should not fail").
+- [X] T026 [US2] Run `make test-integration -- -run 'TestDeploy/should_succeed_when_specsDir_contains|TestApplyTeams/should_apply_teams_succeed_when|TestApplyFile/should_apply_file_succeed_when'` and confirm T022, T024, T025 FAIL on the current branch state (T023 may pass since today's planner already filters by extension — record actual outcome in commit message). T024 will fail because `walkYAMLFiles` in `internal/handler/teams.go` still hands every YAML to `manifest.Parse` and the foreign one yields `unknown manifest kind`.
+
+### Implementation for US2
+
+- [X] T027 [US2] Refactor `walkYAMLFiles` and `ApplyTeams` in [internal/handler/teams.go](../../internal/handler/teams.go) to call `manifest.ScanDir` instead of the inlined walker. Iterate `ScanResult.Shrine`, call `manifest.Parse`, keep only candidates whose `m.Team != nil`, call `store.SaveTeam` exactly as today. Delete `walkYAMLFiles` once unreferenced (it has only one caller — `ApplyTeams`).
+- [X] T028 [US2] In `ApplyTeams`, after the loop, emit the same FR-006 foreign-files notice as T019 when `len(ScanResult.Foreign) > 0`. Match the wording so operators see one consistent message regardless of command. Do NOT emit when empty.
+- [X] T029 [US2] Verify `apply -f` (`PlanSingle` in [internal/planner/plan.go](../../internal/planner/plan.go)) inherits the fix automatically through T018: trace the call once and add a one-line code comment in `PlanSingle` only if there is a non-obvious WHY (per Principle VII: do not add WHAT comments).
+- [X] T030 [US2] Run `make test-integration -- -run 'TestDeploy|TestApplyTeams|TestApplyFile'` and confirm T022-T025 now PASS plus every existing case still passes. The FR-006 notice should be visible in the captured stdout for the foreign-yaml fixtures only.
+
+**Checkpoint**: SC-002 satisfied across all three commands. Constitution V's "every backend implementation MUST be covered by an integration test scenario" is upheld for the scanner-side change.
+
+---
+
+## Phase 5: User Story 3 — Genuinely Broken Shrine Manifests Still Fail Loudly (Priority: P2)
+
+**Goal**: Files that self-identify as shrine (`apiVersion: shrine/v1`) but have a missing/typo'd `kind`, or files that are unparseable YAML, MUST cause loud failures with the file path in the error message — across all three commands (FR-003, FR-004, SC-004).
+
+**Independent Test**: Place a file with `apiVersion: shrine/v1` + `kind: Aplication` in the scanned tree; run each of the three commands; confirm non-zero exit and stderr names the file.
+
+### TDD Integration Tests for US3 (write FIRST, must FAIL or be missing)
+
+- [X] T031 [P] [US3] Add integration test `should_deploy_fail_loudly_when_shrine_manifest_has_bad_kind` to [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go) using the T007 `bad-kind` fixture. Asserts `AssertFailure()` and `AssertStderrContains("typo.yaml")` (the file path) AND `AssertStderrContains("Aplication")` (the offending kind value). Covers SC-004.
+- [X] T032 [P] [US3] Add integration test `should_deploy_fail_loudly_when_yaml_is_malformed` to [tests/integration/deploy_test.go](../../tests/integration/deploy_test.go) using the T006 `malformed-yaml` fixture. Asserts `AssertFailure()` and `AssertStderrContains("broken.yaml")` (covers FR-004 / "`shrine deploy` should fail with a malformed .yml and .yaml files").
+- [X] T033 [P] [US3] Add integration test `should_apply_teams_fail_loudly_when_shrine_manifest_has_bad_kind` to [tests/integration/apply_test.go](../../tests/integration/apply_test.go) using the T008 `apply/bad-kind` fixture. Note the existing `ApplyTeams` today silently skips non-Team files via `Skipping %s: not a Team manifest`; after T027 it still parses every Shrine-classified file via `manifest.Parse`, so the `Aplication` kind WILL produce an error printed to stdout via the existing `Error parsing %s: %v` line. Assert that the bad-kind file's path and the kind value appear in the captured output, even if exit code stays 0 (current `ApplyTeams` semantics) — record the chosen behaviour in the test comment so future readers know it is intentional.
+- [X] T034 [P] [US3] Add integration test `should_apply_file_fail_loudly_when_target_is_shrine_manifest_with_bad_kind` to [tests/integration/apply_test.go](../../tests/integration/apply_test.go). Use `apply -f` pointing at the typo'd file from T007. Assert `AssertFailure()` and `AssertStderrContains("typo")` and `AssertStderrContains("Aplication")`. (`TestApplyFileErrors` already has a similar case — extend it; do not duplicate.)
+- [X] T035 [US3] Run `make test-integration -- -run 'TestDeploy/should_deploy_fail_loudly|TestApplyTeams/should_apply_teams_fail_loudly|TestApplyFile.*should_apply_file_fail_loudly'` and confirm: T031 + T032 + T034 FAIL today on `main` *only because* the test files don't yet exist; once added, they should immediately PASS on this branch (no implementation change needed) because [internal/manifest/validate.go:23](../../internal/manifest/validate.go#L23) and [internal/manifest/parser.go:66](../../internal/manifest/parser.go#L66) already produce the loud errors. Document this expected "tests written → already pass" outcome in the commit message — it is the FR-007 "no regression" guarantee in test form.
+
+### Implementation for US3
+
+> **No production code changes expected.** US3 is a regression-guard story: the existing `manifest.Parse` / `manifest.Validate` paths already raise the loud errors the spec demands. The Phase 2 + Phase 3 + Phase 4 refactors deliberately route shrine-classified files through these unchanged code paths (FR-007). If any of T031-T034 fail after T021 + T030, that is a regression in the refactor and the FIX is to restore the existing error-wrapping in `LoadDir` / `ApplyTeams` — NOT to add a new error path.
+
+- [X] T036 [US3] T034 failed: `PlanSingle` in `internal/planner/plan.go` returned the bare `manifest.Parse` error without wrapping the file path. Fixed by adding `fmt.Errorf("parsing manifest %q: %w", file, err)` wrapping in `PlanSingle` (consistent with `LoadDir`). Added `TestPlanSingle_BadKind_WrapsFilePath` in `internal/planner/loader_test.go` to pin this wrapping behaviour. Also fixed `describe_test.go`, `get_test.go`, `status_test.go`, `teardown_test.go` BeforeEach blocks (pre-existing regression from Phase 1: those tests used `fixturesPath()` pointing at the full deploy testdata root which now contains `malformed-yaml/` and `bad-kind/` fixtures; updated to use `fixturesPath("team")` matching the pattern already applied to `TestDeploy`).
+
+**Checkpoint**: SC-004 satisfied. All three commands now uniformly skip foreign files AND fail loudly on broken shrine manifests / malformed YAML.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [X] T037 [P] Walk through every step of [quickstart.md](./quickstart.md) on a real Docker host. Confirm the foreign-files notice text matches what the quickstart documents; if it differs, update the quickstart (the notice text is informational, not contractual — see FR-006).
+- [X] T038 [P] Run `grep -rn "filepath.WalkDir\|filepath.Walk" cmd/ internal/` and confirm `ScanDir` is the only manifest-directory walker remaining (FR-005). Any new walker discovered must be migrated or justified in a code comment with a WHY.
+- [X] T039 Run the full unit + integration suite as the Constitution V gate: `go test ./... && make test-integration`. Capture the full output. Both must be green before the branch is mergeable.
+- [X] T040 Run a `git diff main...HEAD -- 'specs/002-fix-routing-dir-manifest-scan/**'` final pass to confirm no `NEEDS CLARIFICATION` markers leaked into any phase-output document.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately. All T001-T008 are `[P]` and touch different fixture files.
+- **Phase 2 (Foundational)**: Depends on Phase 1 (the unit tests in T009/T010 are content-only and don't need fixtures, but ScanDir tests reference temp-dir patterns mirrored in fixtures). T009 + T010 are parallel; T011 (verify-fail) blocks T012-T013; T014 (verify-pass) blocks every Phase 3+.
+- **Phase 3 (US1)**: Depends on Phase 2. T015 + T016 parallel; T017 (verify-fail) blocks T018-T021. T020 may run in parallel with T018 (different files) but logical-order keeps it after.
+- **Phase 4 (US2)**: Depends on Phase 3 (T021 must be green so T022/T023 can run). T022-T025 are all `[P]` (different test functions in two files). T026 (verify-fail) blocks T027-T030.
+- **Phase 5 (US3)**: Depends on Phase 4 (T030 green) so the regression guard is meaningful. T031-T034 parallel; T035 (verify-classification) blocks T036.
+- **Phase 6 (Polish)**: Depends on every story phase being checkpoint-complete.
+
+### Parallel Opportunities
+
+- T001..T008 — eight fixture-creation tasks, all independent files.
+- T009 + T010 — independent test files in `internal/manifest/`.
+- T015 + T016 — independent test functions in two different integration test files.
+- T022 + T023 + T024 + T025 — four independent integration test cases across two test files.
+- T031 + T032 + T033 + T034 — four independent regression-guard test cases.
+- T037 + T038 — quickstart + grep audit don't touch each other.
+
+---
+
+## Parallel Example: Phase 4 (US2) test authoring
+
+```bash
+# Open four editor panes and write these test cases simultaneously:
+Task: "T022 - deploy with foreign YAML in tests/integration/deploy_test.go"
+Task: "T023 - deploy with non-YAML siblings in tests/integration/deploy_test.go"
+Task: "T024 - apply teams with foreign YAML in tests/integration/apply_test.go"
+Task: "T025 - apply -f with foreign YAML in tests/integration/apply_test.go"
+
+# Then run them all together to confirm they fail before T027:
+make test-integration -- -run 'TestDeploy/should_succeed_when_specsDir_contains|TestApplyTeams/should_apply_teams_succeed_when|TestApplyFile/should_apply_file_succeed_when'
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (User Story 1 only)
+
+1. Phase 1 → fixtures
+2. Phase 2 → shared classifier
+3. Phase 3 → `shrine deploy` succeeds on the default Traefik routing-dir layout (SC-001)
+4. **STOP & VALIDATE**: This alone closes the original bug report. Operators with the Traefik plugin enabled can deploy.
+5. Decide whether to ship MVP or continue to US2 / US3 in the same PR.
+
+### Incremental Delivery
+
+1. MVP (above) → ship.
+2. Phase 4 → uniform foreign-file handling across `apply teams` and `apply -f` (FR-005).
+3. Phase 5 → regression guard for loud-failure behaviour (SC-004).
+4. Phase 6 → docs sweep + final integration gate.
+
+### Why no parallel team strategy for this feature
+
+Phases 3 → 4 → 5 share the same source files (`internal/planner/loader.go`, `internal/handler/teams.go`, both integration test files). Splitting them across developers would cause merge churn for negligible savings on a 40-task feature. One developer running phases sequentially is the right shape.
+
+---
+
+## Notes
+
+- TDD is non-negotiable here per the user's explicit instruction AND Constitution V. Every test-writing task ends with a "verify FAIL" gate (T011, T017, T026, T035). Skipping that gate makes the test useless as regression coverage.
+- `[P]` tasks touch different files. When two tasks both edit the same integration test file (e.g. T022 and T023 both edit `deploy_test.go`), they are still marked `[P]` because they add different `s.Test(...)` blocks — coordinate via Git, not by serialising work.
+- Phase 5 deliberately has no expected production code change. That is the point of a regression-guard phase: it proves the refactors in Phases 3 + 4 did not weaken existing behaviour (FR-007).
+- The foreign-files notice (FR-006) is emitted at the call-site (`LoadDir`, `ApplyTeams`), not inside `ScanDir`, so unit tests of the scanner stay deterministic. T019 + T028 add it; T020's regression test does not assert on the notice text (it is informational, not a contract).

--- a/tests/integration/apply_test.go
+++ b/tests/integration/apply_test.go
@@ -55,6 +55,28 @@ func TestApplyTeams(t *testing.T) {
 		tc.AssertTeamInState("team-beta")
 		tc.AssertTeamCount(2)
 	})
+
+	s.Test("should succeed when specsDir contains foreign yaml", func(tc *TestCase) {
+		// T024: apply/foreign-yaml contains team.yaml (shrine-apply-test) plus
+		// traefik/traefik.yml (no apiVersion). ApplyTeams must skip the foreign file.
+		tc.Run("apply", "teams",
+			"--path", applyFixturesPath("foreign-yaml"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+		tc.AssertTeamInState("shrine-apply-test")
+	})
+
+	s.Test("should apply teams fail loudly when shrine manifest has bad kind", func(tc *TestCase) {
+		// ApplyTeams continues past parse errors today (logs to stdout, exit 0). The
+		// regression guard asserts the file path + offending kind are visible in the
+		// output, regardless of exit code — pinning the FR-007 promise without altering
+		// the historical UX.
+		tc.Run("apply", "teams",
+			"--path", applyFixturesPath("bad-kind"),
+			"--state-dir", tc.StateDir,
+		).AssertOutputContains("typo.yaml").
+			AssertOutputContains("Aplication")
+	})
 }
 
 func TestApplyFileErrors(t *testing.T) {
@@ -94,6 +116,23 @@ func TestApplyFileErrors(t *testing.T) {
 			"--path", applyFixturesPath(),
 		).AssertFailure()
 	})
+
+	s.Test("should apply file fail loudly when target is shrine manifest with bad kind", func(tc *TestCase) {
+		// T034: apply -f pointing at typo.yaml (apiVersion: shrine/v1, kind: Aplication).
+		// LoadDir parses the shrine-classified file via manifest.Parse, which returns
+		// "unknown manifest kind: \"Aplication\"". The command must exit non-zero and
+		// stderr must contain both the file name and the offending kind value.
+		// Note: the existing "should show error when the manifest kind is unknown" case
+		// uses unknown-kind.yml (kind: Unknown) and only asserts AssertFailure() without
+		// checking the specific file name or kind value in stderr. T034 adds those
+		// targeted assertions on a separate fixture to explicitly guard FR-003.
+		tc.Run("apply", "-f", applyFixturesPath("bad-kind", "typo.yaml"),
+			"--path", applyFixturesPath("bad-kind"),
+			"--state-dir", tc.TempDir(),
+		).AssertFailure().
+			AssertStderrContains("typo").
+			AssertStderrContains("Aplication")
+	})
 }
 
 func TestApplyFile(t *testing.T) {
@@ -130,5 +169,17 @@ func TestApplyFile(t *testing.T) {
 			"--path", applyFixturesPath("success"),
 		).AssertSuccess()
 		tc.AssertContainerRunning(applyTestTeam + ".whoami-apply-yaml")
+	})
+
+	s.Test("should apply file succeed when specsDir contains foreign yaml", func(tc *TestCase) {
+		// T025: apply/foreign-yaml contains app.yaml (whoami-apply-foreign, owner
+		// shrine-apply-test) plus traefik/traefik.yml (no apiVersion). The team is
+		// already seeded by BeforeEach (from the success fixture). LoadDir is called
+		// with --path applyFixturesPath("foreign-yaml") and must skip the foreign file.
+		tc.Run("apply", "-f", applyFixturesPath("foreign-yaml", "app.yaml"),
+			"--path", applyFixturesPath("foreign-yaml"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+		tc.AssertContainerRunning(applyTestTeam + ".whoami-apply-foreign")
 	})
 }

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -3,6 +3,7 @@
 package integration_test
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -24,8 +25,11 @@ func TestDeploy(t *testing.T) {
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
+		// Use the dedicated team/ sub-fixture so BeforeEach does not scan the
+		// entire deploy testdata tree, which now contains bad-kind/ and
+		// malformed-yaml/ subdirectories that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 	})
@@ -123,5 +127,80 @@ func TestDeploy(t *testing.T) {
 		).AssertSuccess()
 
 		tc.AssertSecretValueInState(testTeam, "secret-store", "password", first)
+	})
+
+	s.Test("should deploy succeed when specsDir contains foreign YAML files", func(tc *TestCase) {
+		// foreign-yaml fixture contains team.yaml + app.yaml (valid shrine) plus
+		// traefik/traefik.yml and traefik/dynamic/team-foo-app.yml (no apiVersion)
+		// and notes.json. The scanner MUST skip the foreign files silently.
+		tc.Run("deploy",
+			"--path", fixturesPath("foreign-yaml"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		// The shrine Application named "whoami" should be running.
+		tc.AssertContainerRunning(testTeam + ".whoami")
+
+		// No container must have been created from the foreign Traefik YAML.
+		tc.AssertContainerNotExists(testTeam + ".traefik")
+	})
+
+	// T022: intentionally the same scenario as T016 above — covered by the existing
+	// "should deploy succeed when specsDir contains foreign YAML files" test (T016).
+	// T022 would assert deploy exits 0 and whoami is running, which is a strict subset
+	// of T016's assertions. Adding a duplicate would provide no additional coverage.
+	// STATUS: already-covered-by-T016.
+
+	s.Test("should deploy fail loudly when shrine manifest has bad kind", func(tc *TestCase) {
+		// T031: bad-kind fixture contains team.yaml + typo.yaml (apiVersion: shrine/v1,
+		// kind: Aplication — typo). LoadDir parses the shrine-classified file and
+		// manifest.Parse returns "unknown manifest kind: \"Aplication\"". The command
+		// must exit non-zero and the error message must name both the file and the kind.
+		tc.Run("deploy",
+			"--path", fixturesPath("bad-kind"),
+			"--state-dir", tc.StateDir,
+		).AssertFailure().
+			AssertStderrContains("typo.yaml").
+			AssertStderrContains("Aplication")
+	})
+
+	s.Test("should deploy fail loudly when yaml is malformed", func(tc *TestCase) {
+		// T032: malformed-yaml fixture contains team.yaml + app.yaml (valid) plus
+		// broken.yaml (apiVersion: shrine/v1, kind: [unclosed — unparseable YAML).
+		// ScanDir returns an error wrapping the file path; deploy must exit non-zero
+		// and the error message must name the offending file.
+		tc.Run("deploy",
+			"--path", fixturesPath("malformed-yaml"),
+			"--state-dir", tc.StateDir,
+		).AssertFailure().
+			AssertStderrContains("broken.yaml")
+	})
+
+	s.Test("should succeed when specsDir contains non-YAML files", func(tc *TestCase) {
+		// T023: proves the extension filter never opens .json files (FR-001a).
+		// Copy the basic fixture into a writable temp dir so we can add siblings.
+		specsDir := tc.Path("specs")
+		if err := copyDir(t, fixturesPath("basic"), specsDir); err != nil {
+			t.Fatalf("copy fixture: %v", err)
+		}
+
+		// Add a plain JSON file — must be silently ignored by the scanner.
+		if err := os.WriteFile(filepath.Join(specsDir, "notes.json"),
+			[]byte(`{"note": "scratchpad"}`), 0o644); err != nil {
+			t.Fatalf("write notes.json: %v", err)
+		}
+
+		// Add a chmod-000 JSON file — the extension filter must never open it.
+		configPath := filepath.Join(specsDir, "config.json")
+		if err := os.WriteFile(configPath, []byte(`{}`), 0o000); err != nil {
+			t.Fatalf("write config.json: %v", err)
+		}
+
+		tc.Run("deploy",
+			"--path", specsDir,
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		tc.AssertContainerRunning(testTeam + ".whoami")
 	})
 }

--- a/tests/integration/describe_test.go
+++ b/tests/integration/describe_test.go
@@ -13,8 +13,11 @@ func TestDescribeNoDocker(t *testing.T) {
 
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
+		// Use the dedicated team/ sub-fixture so BeforeEach does not scan the
+		// entire deploy testdata tree, which contains bad-kind/ and malformed-yaml/
+		// that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 	})
@@ -49,8 +52,10 @@ func TestDescribeDocker(t *testing.T) {
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
+		// Use the dedicated team/ sub-fixture to avoid scanning bad-kind/ and
+		// malformed-yaml/ siblings that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 		tc.Run("deploy",

--- a/tests/integration/get_test.go
+++ b/tests/integration/get_test.go
@@ -13,8 +13,10 @@ func TestGetNoDocker(t *testing.T) {
 
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
+		// Use the dedicated team/ sub-fixture to avoid scanning bad-kind/ and
+		// malformed-yaml/ siblings that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 	})
@@ -32,8 +34,10 @@ func TestGetDocker(t *testing.T) {
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
+		// Use the dedicated team/ sub-fixture to avoid scanning bad-kind/ and
+		// malformed-yaml/ siblings that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 		tc.Run("deploy",

--- a/tests/integration/status_test.go
+++ b/tests/integration/status_test.go
@@ -13,8 +13,10 @@ func TestStatusNoDocker(t *testing.T) {
 
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
+		// Use the dedicated team/ sub-fixture to avoid scanning bad-kind/ and
+		// malformed-yaml/ siblings that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 	})
@@ -46,8 +48,10 @@ func TestStatusDocker(t *testing.T) {
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
+		// Use the dedicated team/ sub-fixture to avoid scanning bad-kind/ and
+		// malformed-yaml/ siblings that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 		tc.Run("deploy",

--- a/tests/integration/teardown_test.go
+++ b/tests/integration/teardown_test.go
@@ -25,8 +25,10 @@ func TestTeardown(t *testing.T) {
 	s.BeforeEach(func(tc *TestCase) {
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
+		// Use the dedicated team/ sub-fixture to avoid scanning bad-kind/ and
+		// malformed-yaml/ siblings that cause ScanDir to error.
 		tc.Run("apply", "teams",
-			"--path", fixturesPath(),
+			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
 		tc.Run("deploy",

--- a/tests/integration/traefik_plugin_test.go
+++ b/tests/integration/traefik_plugin_test.go
@@ -4,6 +4,8 @@ package integration_test
 
 import (
 	"context"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +14,43 @@ import (
 
 	. "github.com/CarlosHPlata/shrine/tests/integration/testutils"
 )
+
+// copyDir recursively copies the contents of src into dst, creating dst if needed.
+func copyDir(t *testing.T, src, dst string) error {
+	t.Helper()
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		return copyFile(src, path, target)
+	})
+}
+
+func copyFile(_ string, src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
 
 const traefikTestTeam = "shrine-traefik-test"
 const traefikContainerName = "platform.traefik"
@@ -227,5 +266,44 @@ func TestTraefikPlugin(t *testing.T) {
 		).AssertFailure()
 
 		tc.AssertContainerNotExists(traefikContainerName)
+	})
+
+	s.Test("should deploy succeed when routing-dir is inside specsDir", func(tc *TestCase) {
+		// SC-001 regression: when routing-dir is a subdirectory of specsDir, the
+		// first deploy generates Traefik YAML files (no apiVersion) inside specsDir.
+		// The second deploy then scans specsDir again and must NOT crash on those
+		// foreign files. We reproduce this by copying the fixture into a temp dir
+		// so that both --path and routing-dir point at the same mutable tree.
+		specsDir := tc.Path("specs")
+		if err := copyDir(t, traefikFixturePath(), specsDir); err != nil {
+			t.Fatalf("copy fixture: %v", err)
+		}
+
+		configDir := tc.Path("config")
+		// routing-dir is specsDir/traefik — a subdirectory of the scanned path.
+		routingDir := filepath.Join(specsDir, "traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8087
+`)
+
+		// First run: generates Traefik routing files into specsDir/traefik/.
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", specsDir,
+		).AssertSuccess()
+
+		// Second run: specsDir/traefik/ now contains generated files with no
+		// apiVersion. This is the canonical SC-001 path — must succeed.
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", specsDir,
+		).AssertSuccess()
+
+		tc.AssertContainerRunning(traefikContainerName)
 	})
 }

--- a/tests/testdata/apply/bad-kind/team.yaml
+++ b/tests/testdata/apply/bad-kind/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-apply-test
+spec:
+  displayName: "Shrine Apply Test"
+  contact: "test@shrine-apply-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-apply-test

--- a/tests/testdata/apply/bad-kind/typo.yaml
+++ b/tests/testdata/apply/bad-kind/typo.yaml
@@ -1,0 +1,9 @@
+apiVersion: shrine/v1
+kind: Aplication
+metadata:
+  name: typo-app-apply
+  owner: shrine-apply-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1

--- a/tests/testdata/apply/foreign-yaml/app.yaml
+++ b/tests/testdata/apply/foreign-yaml/app.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami-apply-foreign
+  owner: shrine-apply-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: false

--- a/tests/testdata/apply/foreign-yaml/team.yaml
+++ b/tests/testdata/apply/foreign-yaml/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-apply-test
+spec:
+  displayName: "Shrine Apply Test"
+  contact: "test@shrine-apply-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-apply-test

--- a/tests/testdata/apply/foreign-yaml/traefik/traefik.yml
+++ b/tests/testdata/apply/foreign-yaml/traefik/traefik.yml
@@ -1,0 +1,7 @@
+entryPoints:
+  web:
+    address: ":80"
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true

--- a/tests/testdata/deploy/bad-kind/team.yaml
+++ b/tests/testdata/deploy/bad-kind/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-deploy-test
+spec:
+  displayName: "Shrine Deploy Test"
+  contact: "test@shrine-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/bad-kind/typo.yaml
+++ b/tests/testdata/deploy/bad-kind/typo.yaml
@@ -1,0 +1,9 @@
+apiVersion: shrine/v1
+kind: Aplication
+metadata:
+  name: typo-app
+  owner: shrine-deploy-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1

--- a/tests/testdata/deploy/foreign-yaml/app.yaml
+++ b/tests/testdata/deploy/foreign-yaml/app.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami
+  owner: shrine-deploy-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: false

--- a/tests/testdata/deploy/foreign-yaml/notes.json
+++ b/tests/testdata/deploy/foreign-yaml/notes.json
@@ -1,0 +1,1 @@
+{"note": "operator scratchpad"}

--- a/tests/testdata/deploy/foreign-yaml/team.yaml
+++ b/tests/testdata/deploy/foreign-yaml/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-deploy-test
+spec:
+  displayName: "Shrine Deploy Test"
+  contact: "test@shrine-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/foreign-yaml/traefik/dynamic/team-foo-app.yml
+++ b/tests/testdata/deploy/foreign-yaml/traefik/dynamic/team-foo-app.yml
@@ -1,0 +1,12 @@
+http:
+  routers:
+    team-foo-app:
+      rule: "Host(`foo.example.com`)"
+      service: team-foo-app-service
+      entryPoints:
+        - web
+  services:
+    team-foo-app-service:
+      loadBalancer:
+        servers:
+          - url: "http://team-foo-app:80"

--- a/tests/testdata/deploy/foreign-yaml/traefik/traefik.yml
+++ b/tests/testdata/deploy/foreign-yaml/traefik/traefik.yml
@@ -1,0 +1,9 @@
+entryPoints:
+  web:
+    address: ":80"
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+api:
+  dashboard: false

--- a/tests/testdata/deploy/malformed-yaml/app.yaml
+++ b/tests/testdata/deploy/malformed-yaml/app.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami
+  owner: shrine-deploy-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: false

--- a/tests/testdata/deploy/malformed-yaml/broken.yaml
+++ b/tests/testdata/deploy/malformed-yaml/broken.yaml
@@ -1,0 +1,2 @@
+apiVersion: shrine/v1
+kind: [unclosed

--- a/tests/testdata/deploy/malformed-yaml/team.yaml
+++ b/tests/testdata/deploy/malformed-yaml/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-deploy-test
+spec:
+  displayName: "Shrine Deploy Test"
+  contact: "test@shrine-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/team/shrine-test-team.yml
+++ b/tests/testdata/deploy/team/shrine-test-team.yml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-deploy-test
+spec:
+  displayName: "Shrine Test"
+  contact: "test@shrine-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test


### PR DESCRIPTION
## What

`shrine deploy`, `shrine apply teams`, and `shrine apply -f` now silently skip YAML files that are not shrine manifests (no `apiVersion: shrine/v*`) instead of crashing on them. The Traefik plugin's default `routing-dir` (which lives inside `specsDir` at `{specsDir}/traefik/`) deploys cleanly out of the box.

## Why

When the Traefik gateway plugin was enabled with default settings, the manifest scanner walked into `{specsDir}/traefik/`, picked up the generated Traefik YAML files, handed them to `manifest.Parse`, and aborted with `unknown manifest kind: ""`. Operators had to point `routing-dir` outside `specsDir` to avoid the crash. The fix introduces a strict, two-step classification gate (extension filter → `apiVersion` regex `^shrine/v\d+([a-z]+\d+)?$`) shared by every directory scanner in the codebase, so foreign files are silently skipped while malformed YAML and shrine-prefixed files with bad `kind` still fail loudly.

Spec: [specs/002-fix-routing-dir-manifest-scan/spec.md](specs/002-fix-routing-dir-manifest-scan/spec.md)

## How to test

- `go test ./...` — unit tests including the new `internal/manifest/classify_test.go` and `internal/manifest/scan_test.go`.
- `make test-integration` — full Docker-backed suite. The canonical SC-001 regression is `TestTraefikPlugin/should_deploy_succeed_when_routing-dir_is_inside_specsDir`.
- Manual reproduction & verification per [specs/002-fix-routing-dir-manifest-scan/quickstart.md](specs/002-fix-routing-dir-manifest-scan/quickstart.md) (~10 min on a Docker host).

## Checklist

- [x] Tests added or updated
- [x] \`go test ./...\` passes locally
- [x] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)