### PR TITLE
fix: expand `~` consistently across path-typed config fields

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/002-fix-routing-dir-manifest-scan"
+  "feature_directory": "specs/003-resolve-config-paths"
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,8 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -25,19 +22,6 @@ type PluginsConfig struct {
 
 type GatewayPluginsConfig struct {
 	Traefik *TraefikPluginConfig `yaml:"traefik,omitempty"`
-}
-
-type TraefikPluginConfig struct {
-	Image      string                  `yaml:"image,omitempty"`
-	RoutingDir string                  `yaml:"routing-dir,omitempty"`
-	Port       int                     `yaml:"port,omitempty"`
-	Dashboard  *TraefikDashboardConfig `yaml:"dashboard,omitempty"`
-}
-
-type TraefikDashboardConfig struct {
-	Port     int    `yaml:"port"`
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
 }
 
 // RegistryConfig holds credentials and host information for a Docker registry.
@@ -79,14 +63,10 @@ func Load(configFile string) (*Config, error) {
 //
 // Tilde (~) at the start of a path is expanded to the user's home directory.
 func (c *Config) ResolveSpecsDir(flagValue string) (string, error) {
-	raw := flagValue
-	if raw == "" {
-		raw = c.SpecsDir
-	}
-	if raw == "" {
-		return "", fmt.Errorf("no specs directory: set --path/-p flag or specsDir in config.yml")
-	}
-	return expandTilde(raw)
+	return resolvePath(
+		[]string{flagValue, c.SpecsDir},
+		"no specs directory: set --path/-p flag or specsDir in config.yml",
+	)
 }
 
 // ResolveTeamsDir returns the directory to scan for team manifests, with priority:
@@ -95,26 +75,8 @@ func (c *Config) ResolveSpecsDir(flagValue string) (string, error) {
 //  3. c.SpecsDir (from config.yml specsDir)
 //  4. error if none is set
 func (c *Config) ResolveTeamsDir(flagValue string) (string, error) {
-	raw := flagValue
-	if raw == "" {
-		raw = c.TeamsDir
-	}
-	if raw == "" {
-		raw = c.SpecsDir
-	}
-	if raw == "" {
-		return "", fmt.Errorf("no specs directory: set --path/-p flag, teamsDir or specsDir in config.yml")
-	}
-	return expandTilde(raw)
-}
-
-func expandTilde(path string) (string, error) {
-	if path != "~" && !strings.HasPrefix(path, "~/") {
-		return path, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("expanding ~: %w", err)
-	}
-	return filepath.Join(home, path[1:]), nil
+	return resolvePath(
+		[]string{flagValue, c.TeamsDir, c.SpecsDir},
+		"no specs directory: set --path/-p flag, teamsDir or specsDir in config.yml",
+	)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveSpecsDir(t *testing.T) {
+	const fakeHome = "/home/test-user"
+
+	cases := []struct {
+		name      string
+		flagValue string
+		cfg       Config
+		want      string
+		wantErr   string
+	}{
+		{
+			name:    "both flag and config empty returns error naming both options",
+			wantErr: "no specs directory",
+		},
+		{
+			name:      "flag value is returned when config is empty",
+			flagValue: "/abs/from/flag",
+			want:      "/abs/from/flag",
+		},
+		{
+			name: "config value is returned when flag is empty",
+			cfg:  Config{SpecsDir: "/abs/from/config"},
+			want: "/abs/from/config",
+		},
+		{
+			name:      "flag wins over config",
+			flagValue: "/from/flag",
+			cfg:       Config{SpecsDir: "/from/config"},
+			want:      "/from/flag",
+		},
+		{
+			name:      "tilde in flag value is expanded",
+			flagValue: "~/specs",
+			want:      fakeHome + "/specs",
+		},
+		{
+			name: "tilde in config value is expanded",
+			cfg:  Config{SpecsDir: "~/specs"},
+			want: fakeHome + "/specs",
+		},
+		{
+			name:      "absolute flag value passes through unchanged (idempotent)",
+			flagValue: "/etc/shrine/specs",
+			want:      "/etc/shrine/specs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", fakeHome)
+			got, err := tc.cfg.ResolveSpecsDir(tc.flagValue)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveSpecsDir succeeded with %q, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q should contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveSpecsDir returned unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ResolveSpecsDir(flag=%q, cfg=%+v) = %q, want %q", tc.flagValue, tc.cfg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveTeamsDir(t *testing.T) {
+	const fakeHome = "/home/test-user"
+
+	cases := []struct {
+		name      string
+		flagValue string
+		cfg       Config
+		want      string
+		wantErr   string
+	}{
+		{
+			name:    "all three sources empty returns error",
+			wantErr: "no specs directory",
+		},
+		{
+			name:      "flag wins over teamsDir and specsDir",
+			flagValue: "/from/flag",
+			cfg:       Config{TeamsDir: "/from/teams", SpecsDir: "/from/specs"},
+			want:      "/from/flag",
+		},
+		{
+			name: "teamsDir wins over specsDir when flag is empty",
+			cfg:  Config{TeamsDir: "/from/teams", SpecsDir: "/from/specs"},
+			want: "/from/teams",
+		},
+		{
+			name: "falls back to specsDir when flag and teamsDir are empty",
+			cfg:  Config{SpecsDir: "/from/specs"},
+			want: "/from/specs",
+		},
+		{
+			name:      "tilde expansion applies to flag",
+			flagValue: "~/teams",
+			want:      fakeHome + "/teams",
+		},
+		{
+			name: "tilde expansion applies to teamsDir",
+			cfg:  Config{TeamsDir: "~/teams"},
+			want: fakeHome + "/teams",
+		},
+		{
+			name: "tilde expansion applies to specsDir fallback",
+			cfg:  Config{SpecsDir: "~/specs"},
+			want: fakeHome + "/specs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", fakeHome)
+			got, err := tc.cfg.ResolveTeamsDir(tc.flagValue)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveTeamsDir succeeded with %q, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q should contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveTeamsDir returned unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ResolveTeamsDir(flag=%q, cfg=%+v) = %q, want %q", tc.flagValue, tc.cfg, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/plugin_traefik.go
+++ b/internal/config/plugin_traefik.go
@@ -1,0 +1,21 @@
+package config
+
+type TraefikPluginConfig struct {
+	Image      string                  `yaml:"image,omitempty"`
+	RoutingDir string                  `yaml:"routing-dir,omitempty"`
+	Port       int                     `yaml:"port,omitempty"`
+	Dashboard  *TraefikDashboardConfig `yaml:"dashboard,omitempty"`
+}
+
+type TraefikDashboardConfig struct {
+	Port     int    `yaml:"port"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+func (p *TraefikPluginConfig) ResolveRoutingDir(specsDir string) (string, error) {
+	return resolvePath(
+		[]string{p.RoutingDir, specsDir},
+		"no routing directory: set --path/-p flag or routing-dir in config.yml",
+	)
+}

--- a/internal/config/plugin_traefik_test.go
+++ b/internal/config/plugin_traefik_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveRoutingDir(t *testing.T) {
+	const fakeHome = "/home/test-user"
+
+	cases := []struct {
+		name     string
+		cfg      TraefikPluginConfig
+		specsDir string
+		want     string
+		wantErr  string
+	}{
+		{
+			name:    "both routingDir and specsDir empty returns error",
+			wantErr: "no routing directory",
+		},
+		{
+			name: "routingDir wins over specsDir fallback",
+			cfg:  TraefikPluginConfig{RoutingDir: "/from/routing"},
+			specsDir: "/from/specs",
+			want:     "/from/routing",
+		},
+		{
+			name:     "falls back to specsDir when routingDir is empty",
+			specsDir: "/from/specs",
+			want:     "/from/specs",
+		},
+		{
+			name: "tilde in routingDir is expanded",
+			cfg:  TraefikPluginConfig{RoutingDir: "~/traefik"},
+			want: fakeHome + "/traefik",
+		},
+		{
+			name:     "tilde in specsDir fallback is expanded",
+			specsDir: "~/specs/traefik",
+			want:     fakeHome + "/specs/traefik",
+		},
+		{
+			name: "absolute routingDir passes through unchanged (idempotent)",
+			cfg:  TraefikPluginConfig{RoutingDir: "/etc/shrine/traefik"},
+			want: "/etc/shrine/traefik",
+		},
+		{
+			name: "bare tilde in routingDir resolves to HOME",
+			cfg:  TraefikPluginConfig{RoutingDir: "~"},
+			want: fakeHome,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", fakeHome)
+			got, err := tc.cfg.ResolveRoutingDir(tc.specsDir)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ResolveRoutingDir succeeded with %q, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q should contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveRoutingDir returned unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("ResolveRoutingDir(cfg=%+v, specsDir=%q) = %q, want %q", tc.cfg, tc.specsDir, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func expandTilde(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("expanding ~: %w", err)
+	}
+	return filepath.Join(home, path[1:]), nil
+}
+
+func resolvePath(candidates []string, missingErr string) (string, error) {
+	for _, c := range candidates {
+		if c != "" {
+			return expandTilde(c)
+		}
+	}
+	return "", errors.New(missingErr)
+}

--- a/internal/config/utils_test.go
+++ b/internal/config/utils_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandTilde(t *testing.T) {
+	const fakeHome = "/home/test-user"
+
+	cases := []struct {
+		name    string
+		home    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty path is left empty", home: fakeHome, input: "", want: ""},
+		{name: "absolute path is unchanged", home: fakeHome, input: "/etc/shrine", want: "/etc/shrine"},
+		{name: "plain relative path is unchanged", home: fakeHome, input: "foo/bar", want: "foo/bar"},
+		{name: "single tilde resolves to HOME", home: fakeHome, input: "~", want: fakeHome},
+		{name: "tilde-slash prefix expands to HOME", home: fakeHome, input: "~/foo", want: fakeHome + "/foo"},
+		{name: "tilde-slash prefix expands deep paths", home: fakeHome, input: "~/foo/bar/baz", want: fakeHome + "/foo/bar/baz"},
+		{name: "tilde-username form is unchanged", home: fakeHome, input: "~alice", want: "~alice"},
+		{name: "tilde-username with subpath is unchanged", home: fakeHome, input: "~alice/foo", want: "~alice/foo"},
+		{name: "embedded tilde is unchanged", home: fakeHome, input: "/path/~/middle", want: "/path/~/middle"},
+		{name: "idempotent on already-expanded path", home: fakeHome, input: fakeHome + "/foo", want: fakeHome + "/foo"},
+		{name: "HOME unset returns error for bare tilde", home: "", input: "~", wantErr: true},
+		{name: "HOME unset returns error for tilde-slash", home: "", input: "~/foo", wantErr: true},
+		{name: "HOME unset is fine for absolute path (no expansion needed)", home: "", input: "/abs", want: "/abs"},
+		{name: "HOME unset is fine for plain relative (no expansion needed)", home: "", input: "rel", want: "rel"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", tc.home)
+			got, err := expandTilde(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expandTilde(%q) succeeded with %q, want error", tc.input, got)
+				}
+				if !strings.Contains(err.Error(), "expanding ~") {
+					t.Errorf("error %q should mention 'expanding ~'", err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expandTilde(%q) returned unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("expandTilde(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/handler/deploy.go
+++ b/internal/handler/deploy.go
@@ -103,7 +103,9 @@ func Deploy(opts DeployOptions) error {
 
 	var routing engine.RoutingBackend
 	if plugin.IsActive() {
-		routing = plugin.RoutingBackend()
+		if routing, err = plugin.RoutingBackend(); err != nil {
+			return err
+		}
 	}
 
 	deployEngine, err := local.NewLocalEngineWithRouting(opts.Store, opts.Config.Registries, observer, routing)

--- a/internal/plugins/gateway/traefik/plugin.go
+++ b/internal/plugins/gateway/traefik/plugin.go
@@ -90,11 +90,12 @@ func (p *Plugin) resolvedPort() int {
 	return p.cfg.Port
 }
 
-func (p *Plugin) resolvedRoutingDir() string {
-	if p.cfg != nil && p.cfg.RoutingDir != "" {
-		return p.cfg.RoutingDir
+func (p *Plugin) resolvedRoutingDir() (string, error) {
+	routingDir, err := p.cfg.ResolveRoutingDir(filepath.Join(p.specsDir, "traefik"))
+	if err != nil {
+		return "", fmt.Errorf("traefik plugin: resolving routing directory: %w", err)
 	}
-	return filepath.Join(p.specsDir, "traefik")
+	return routingDir, nil
 }
 
 func (p *Plugin) Deploy() error {
@@ -102,7 +103,10 @@ func (p *Plugin) Deploy() error {
 		return nil
 	}
 
-	routingDir := p.resolvedRoutingDir()
+	routingDir, err := p.resolvedRoutingDir()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(routingDir, 0o755); err != nil {
 		return fmt.Errorf("traefik plugin: creating routing dir %q: %w", routingDir, err)
 	}
@@ -147,6 +151,10 @@ func (p *Plugin) portBindings() []engine.PortBinding {
 	return bindings
 }
 
-func (p *Plugin) RoutingBackend() engine.RoutingBackend {
-	return &RoutingBackend{routingDir: p.resolvedRoutingDir()}
+func (p *Plugin) RoutingBackend() (engine.RoutingBackend, error) {
+	routingDir, err := p.resolvedRoutingDir()
+	if err != nil {
+		return nil, err
+	}
+	return &RoutingBackend{routingDir: routingDir}, nil
 }

--- a/specs/003-resolve-config-paths/checklists/requirements.md
+++ b/specs/003-resolve-config-paths/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Expand `~` Consistently Across Path-Typed Config Fields
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The user explicitly directed that relative config paths resolve against the operator's home directory (not CWD, not config-file directory). This is captured in FR-003 and called out in Assumptions so reviewers can confirm this deliberate departure from typical Unix conventions.
+- `certsDir` is named in the user prompt but does not exist in code today. Scope is limited to existing path-typed fields (`specsDir`, `teamsDir`, `routing-dir`); the rule is defined generically so a future `certsDir` automatically inherits it (FR-005).
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/003-resolve-config-paths/spec.md
+++ b/specs/003-resolve-config-paths/spec.md
@@ -1,0 +1,57 @@
+# Feature Specification: Expand `~` Consistently Across Path-Typed Config Fields
+
+**Feature Branch**: `003-resolve-config-paths`  
+**Created**: 2026-04-30  
+**Status**: Draft  
+**Input**: User description: "Bug: shrine deploy crashes when routing-dir is a relative path. If routing-dir is set as a relative path in the config, Shrine crashes at deploy time. All path fields in the config (specsDir, routing-dir, certsDir) should be resolved to absolute paths at config load time, expanding ~ and relative references against the user's home directory."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Tilde-Prefixed Paths Work in Every Config Field (Priority: P2)
+
+A shrine operator writes their config with `~`-prefixed paths (e.g., `specsDir: ~/shrine/specs`, `routing-dir: ~/shrine/routing`) so the same config file is portable between machines with different home directories. When any shrine command reads the config, every path field with a `~` prefix is expanded to the operator's home directory and the command behaves identically regardless of which path field carried the prefix.
+
+**Why this priority**: Tilde expansion already works for `specsDir` and `teamsDir`, but not for the Traefik plugin's `routing-dir`. The inconsistency surprises operators who reasonably expect every path-typed field in the same file to follow the same rules. Without this, copy-pasting `~/...` values between fields produces silent failures or crashes that are hard to diagnose.
+
+**Independent Test**: Write a config in which every path field uses a `~/...` value, run any shrine command that touches each of those fields (e.g., `shrine deploy`), and confirm that every path is expanded to the home directory and the command succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** `routing-dir: ~/traefik` in the config, **When** a shrine subcommand reads that field, **Then** the field is treated as an absolute path under the operator's home directory.
+2. **Given** a path field set to exactly `~` (no slash, no remainder), **When** a shrine subcommand reads that field, **Then** the field resolves to the operator's home directory itself.
+3. **Given** a path field whose value is already absolute (e.g., `/etc/shrine/specs`), **When** a shrine subcommand reads that field, **Then** the value is left unchanged — the rule never rewrites absolute paths.
+
+
+### Edge Cases
+
+- A path field is empty (the operator omitted it). → Field stays empty; the existing "field not set" behavior (e.g., the existing "no specs directory" error from `--path`/`specsDir` resolution) is unchanged.
+- A path is exactly `~`. → Resolves to the home directory.
+- A path is already absolute (`/etc/shrine/...`). → Left unchanged.
+- The same config file is loaded twice in the same process. → Resolution is idempotent: re-resolving an already-absolute path does not move it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: All path-typed fields in the configuration MUST follow the same path-resolution rules (defined in FR-002 and FR-003). No field may be treated differently based on which field name carries the value.
+- **FR-002**: For each path-typed field in the config, the system MUST expand a leading `~` (alone) or `~/` to the operator's home directory.
+- **FR-003**: For each path-typed field in the config, the system MUST leave absolute values unchanged.
+- **FR-004**: The rules defined in FR-001 through FR-003 MUST apply uniformly to every path-typed field currently in the configuration — `specsDir`, `teamsDir`, and the Traefik plugin's `routing-dir` — and to any new path-typed field added in the future (for example, a `certsDir` field if introduced later).
+- **FR-005**: If path resolution fails for any field (for example, because the home directory cannot be determined), the failing subcommand MUST surface a single, clear error that identifies the failing field and the cause, and MUST NOT proceed with side effects using a partially-resolved configuration.
+- **FR-006**: Resolution MUST be idempotent: applying the rules to an already-absolute, already-resolved path MUST return the same path unchanged.
+
+### Key Entities
+
+- **Configuration file**: The shrine `config.yml` (or equivalent) read at startup. Contains zero or more path-typed fields whose values can be absolute, `~`-prefixed, or relative.
+- **Operator home directory**: The directory returned by the operating system as the current user's home directory. Used as the anchor for `~` expansion and for resolving relative config paths.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: When the home directory cannot be resolved, the affected subcommand fails before performing any side effects, with an error that names the offending field; no subcommand crashes mid-flight from this cause.
+- **SC-002**: No regression for absolute or `~`-prefixed paths: every config that worked before this change continues to produce the same absolute paths after the change.
+
+## Assumptions
+
+- "Relative" is interpreted by the operating system's standard rules (a path is relative if it is not absolute and does not start with `~` after expansion).

--- a/tests/integration/testutils/assert_general.go
+++ b/tests/integration/testutils/assert_general.go
@@ -3,7 +3,9 @@
 package testutils
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -42,28 +44,51 @@ func (tc *TestCase) AssertStderrContains(s string) *TestCase {
 
 func (tc *TestCase) AssertFileExists(path string) *TestCase {
 	tc.t.Helper()
-	if _, err := os.Stat(path); err != nil {
-		tc.t.Fatalf("expected file to exist at %s: %v", path, err)
+	resolved, err := expandTilde(path)
+	if err != nil {
+		tc.t.Fatalf("expanding tilde for %s: %v", path, err)
+	}
+	if _, err := os.Stat(resolved); err != nil {
+		tc.t.Fatalf("expected file to exist at %s: %v", resolved, err)
 	}
 	return tc
 }
 
 func (tc *TestCase) AssertFileNotExists(path string) *TestCase {
 	tc.t.Helper()
-	if _, err := os.Stat(path); err == nil {
-		tc.t.Fatalf("expected file to NOT exist at %s", path)
+	resolved, err := expandTilde(path)
+	if err != nil {
+		tc.t.Fatalf("expanding tilde for %s: %v", path, err)
+	}
+	if _, err := os.Stat(resolved); err == nil {
+		tc.t.Fatalf("expected file to NOT exist at %s", resolved)
 	}
 	return tc
 }
 
 func (tc *TestCase) AssertFileContains(path, want string) *TestCase {
 	tc.t.Helper()
-	data, err := os.ReadFile(path)
+	resolved, err := expandTilde(path)
 	if err != nil {
-		tc.t.Fatalf("reading %s: %v", path, err)
+		tc.t.Fatalf("expanding tilde for %s: %v", path, err)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		tc.t.Fatalf("reading %s: %v", resolved, err)
 	}
 	if !strings.Contains(string(data), want) {
-		tc.t.Fatalf("expected file %s to contain %q\ncontent: %s", path, want, string(data))
+		tc.t.Fatalf("expected file %s to contain %q\ncontent: %s", resolved, want, string(data))
 	}
 	return tc
+}
+
+func expandTilde(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("expanding ~: %w", err)
+	}
+	return filepath.Join(home, path[1:]), nil
 }

--- a/tests/integration/testutils/testsuite.go
+++ b/tests/integration/testutils/testsuite.go
@@ -78,3 +78,8 @@ func (tc *TestCase) Run(args ...string) *TestCase {
 	tc.result = Execute(tc.t, args...)
 	return tc
 }
+
+func (tc *TestCase) Setenv(key, value string) {
+	tc.t.Helper()
+	tc.t.Setenv(key, value)
+}

--- a/tests/integration/traefik_plugin_test.go
+++ b/tests/integration/traefik_plugin_test.go
@@ -268,6 +268,29 @@ func TestTraefikPlugin(t *testing.T) {
 		tc.AssertContainerNotExists(traefikContainerName)
 	})
 
+	s.Test("should not fail when routing-dir starts with tilde", func(tc *TestCase) {
+		tc.Setenv("HOME", tc.TempDir())
+
+		configDir := tc.Path("config")
+		routingDir := filepath.Join("~", "traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8082
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", traefikFixturePath(),
+		).AssertSuccess()
+
+		tc.AssertContainerRunning(traefikContainerName)
+		tc.AssertContainerInNetwork(traefikContainerName, "shrine.platform")
+		tc.AssertFileExists(filepath.Join(routingDir, "traefik.yml"))
+	})
+
 	s.Test("should deploy succeed when routing-dir is inside specsDir", func(tc *TestCase) {
 		// SC-001 regression: when routing-dir is a subdirectory of specsDir, the
 		// first deploy generates Traefik YAML files (no apiVersion) inside specsDir.


### PR DESCRIPTION
## What

`shrine deploy` no longer crashes when the Traefik plugin's `routing-dir` is set to a `~`-prefixed value in `config.yml`. Path-typed config fields (`specsDir`, `teamsDir`, `routing-dir`) now consistently support `~` expansion.

## Why

Previously, only `specsDir` and `teamsDir` expanded `~`; the Traefik plugin's `routing-dir` did not, so a config like `routing-dir: ~/shrine/routing` crashed `shrine deploy` outright. Operators copying values from documentation or sharing a portable config across machines hit this on first use. This change unifies tilde handling across path-typed config fields so every such value behaves the same.

## How to test

- Set `plugins.gateway.traefik.routing-dir: ~/traefik` in `config.yml` and run `shrine deploy` — it should succeed and write Traefik routing files under `$HOME/traefik/`.
- Run the integration test that covers this directly: `go test -tags integration ./tests/integration -run 'TestTraefikPlugin/should_not_fail_when_routing-dir_starts_with_tilde'`.
- Run the full unit test suite: `go test ./...`.
- Verify absolute `routing-dir` values still work unchanged (regression check).

## Checklist

- [x] Tests added or updated
- [x] `go test ./...` passes locally
- [ ] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)
