### PR TITLE
feat: add routing.aliases for multi-hostname application publishing

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/004-preserve-traefik-yml"
+  "feature_directory": "specs/006-routing-aliases"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ spec:
   routing:
     domain: hello-api.home.lab
     pathPrefix: /hello-api
+    aliases:                                   # optional; Traefik-only — silently ignored otherwise
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances                  # required to start with `/`; trailing `/` normalized
+        stripPrefix: true                      # default true when pathPrefix is set; set false to forward unchanged
   dependencies:
     - kind: Resource
       name: hello-db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/004-preserve-traefik-yml/plan.md
+at specs/006-routing-aliases/plan.md
 <!-- SPECKIT END -->

--- a/internal/engine/backends.go
+++ b/internal/engine/backends.go
@@ -51,12 +51,19 @@ type ContainerBackend interface {
 	InspectContainer(containerID string) (ContainerInfo, error)
 }
 
-type WriteRouteOp struct {
-	Team        string
-	Domain      string
-	ServiceName string
-	ServicePort int
+type AliasRoute struct {
+	Host        string
 	PathPrefix  string
+	StripPrefix bool
+}
+
+type WriteRouteOp struct {
+	Team             string
+	Domain           string
+	ServiceName      string
+	ServicePort      int
+	PathPrefix       string
+	AdditionalRoutes []AliasRoute
 }
 
 type RoutingBackend interface {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/CarlosHPlata/shrine/internal/manifest"
 	"github.com/CarlosHPlata/shrine/internal/planner"
@@ -162,20 +163,27 @@ func (engine *Engine) deployApplication(
 
 	// 4. Write Router
 	if application.Spec.Routing.Domain != "" && application.Spec.Networking.ExposeToPlatform && engine.Routing != nil {
+		aliasRoutes := resolveAliasRoutes(application.Spec.Routing.Aliases)
+
+		eventFields := map[string]string{
+			"domain": application.Spec.Routing.Domain,
+			"port":   fmt.Sprintf("%d", application.Spec.Port),
+		}
+		if len(application.Spec.Routing.Aliases) > 0 {
+			eventFields["aliases"] = formatAliasesForLog(aliasRoutes)
+		}
 		engine.Observer.OnEvent(Event{
 			Name:   "routing.configure",
 			Status: StatusInfo,
-			Fields: map[string]string{
-				"domain": application.Spec.Routing.Domain,
-				"port":   fmt.Sprintf("%d", application.Spec.Port),
-			},
+			Fields: eventFields,
 		})
 		routingOp := WriteRouteOp{
-			Team:        application.Metadata.Owner,
-			Domain:      application.Spec.Routing.Domain,
-			ServiceName: application.Metadata.Name,
-			ServicePort: application.Spec.Port,
-			PathPrefix:  application.Spec.Routing.PathPrefix,
+			Team:             application.Metadata.Owner,
+			Domain:           application.Spec.Routing.Domain,
+			ServiceName:      application.Metadata.Name,
+			ServicePort:      application.Spec.Port,
+			PathPrefix:       application.Spec.Routing.PathPrefix,
+			AdditionalRoutes: aliasRoutes,
 		}
 
 		if err := engine.Routing.WriteRoute(routingOp); err != nil {
@@ -292,6 +300,38 @@ func flattenEnv(env map[string]string) []string {
 		out = append(out, k+"="+env[k])
 	}
 	return out
+}
+
+func resolveAliasRoutes(aliases []manifest.RoutingAlias) []AliasRoute {
+	routes := make([]AliasRoute, 0, len(aliases))
+	for _, alias := range aliases {
+		prefix := strings.TrimRight(alias.PathPrefix, "/")
+		var strip bool
+		if alias.StripPrefix != nil {
+			strip = *alias.StripPrefix
+		} else {
+			strip = prefix != ""
+		}
+		routes = append(routes, AliasRoute{
+			Host:        alias.Host,
+			PathPrefix:  prefix,
+			StripPrefix: strip,
+		})
+	}
+	return routes
+}
+
+func formatAliasesForLog(routes []AliasRoute) string {
+	entries := make([]string, 0, len(routes))
+	for _, r := range routes {
+		if r.PathPrefix != "" {
+			entries = append(entries, r.Host+"+"+r.PathPrefix)
+		} else {
+			entries = append(entries, r.Host)
+		}
+	}
+	sort.Strings(entries)
+	return strings.Join(entries, ",")
 }
 
 // flattenOutputs is like flattenEnv but skips built-in keys that aren't part

--- a/internal/engine/engine_aliases_test.go
+++ b/internal/engine/engine_aliases_test.go
@@ -1,0 +1,105 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestResolveAliasRoutes(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       manifest.RoutingAlias
+		wantPrefix  string
+		wantStrip   bool
+	}{
+		{
+			name:      "nil StripPrefix, empty PathPrefix",
+			input:     manifest.RoutingAlias{Host: "h", PathPrefix: "", StripPrefix: nil},
+			wantPrefix: "",
+			wantStrip:  false,
+		},
+		{
+			name:      "nil StripPrefix, non-empty PathPrefix",
+			input:     manifest.RoutingAlias{Host: "h", PathPrefix: "/x", StripPrefix: nil},
+			wantPrefix: "/x",
+			wantStrip:  true,
+		},
+		{
+			name:      "explicit true StripPrefix",
+			input:     manifest.RoutingAlias{Host: "h", PathPrefix: "/x", StripPrefix: boolPtr(true)},
+			wantPrefix: "/x",
+			wantStrip:  true,
+		},
+		{
+			name:      "explicit false StripPrefix",
+			input:     manifest.RoutingAlias{Host: "h", PathPrefix: "/x", StripPrefix: boolPtr(false)},
+			wantPrefix: "/x",
+			wantStrip:  false,
+		},
+		{
+			name:      "trailing slash normalization",
+			input:     manifest.RoutingAlias{Host: "h", PathPrefix: "/x/", StripPrefix: nil},
+			wantPrefix: "/x",
+			wantStrip:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			routes := resolveAliasRoutes([]manifest.RoutingAlias{tc.input})
+			if len(routes) != 1 {
+				t.Fatalf("expected 1 route, got %d", len(routes))
+			}
+			r := routes[0]
+			if r.Host != tc.input.Host {
+				t.Errorf("Host: got %q, want %q", r.Host, tc.input.Host)
+			}
+			if r.PathPrefix != tc.wantPrefix {
+				t.Errorf("PathPrefix: got %q, want %q", r.PathPrefix, tc.wantPrefix)
+			}
+			if r.StripPrefix != tc.wantStrip {
+				t.Errorf("StripPrefix: got %v, want %v", r.StripPrefix, tc.wantStrip)
+			}
+		})
+	}
+}
+
+func TestFormatAliasesForLog(t *testing.T) {
+	tests := []struct {
+		name   string
+		routes []AliasRoute
+		want   string
+	}{
+		{
+			name:   "one alias no prefix",
+			routes: []AliasRoute{{Host: "lan.home.lab", PathPrefix: ""}},
+			want:   "lan.home.lab",
+		},
+		{
+			name:   "one alias with prefix",
+			routes: []AliasRoute{{Host: "gateway.x.y", PathPrefix: "/finances"}},
+			want:   "gateway.x.y+/finances",
+		},
+		{
+			name: "multiple sorted",
+			routes: []AliasRoute{
+				{Host: "z.example.com", PathPrefix: "/z"},
+				{Host: "a.example.com", PathPrefix: ""},
+				{Host: "m.example.com", PathPrefix: "/m"},
+			},
+			want: "a.example.com,m.example.com+/m,z.example.com+/z",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatAliasesForLog(tc.routes)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/handler/deploy.go
+++ b/internal/handler/deploy.go
@@ -108,6 +108,12 @@ func Deploy(opts DeployOptions) error {
 		}
 	}
 
+	if routing != nil {
+		if err := planner.DetectRoutingCollisions(result.ManifestSet); err != nil {
+			return err
+		}
+	}
+
 	deployEngine, err := local.NewLocalEngineWithRouting(opts.Store, opts.Config.Registries, observer, routing)
 	if err != nil {
 		return err

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -82,6 +82,81 @@ func TestParse_ApplicationManifest(t *testing.T) {
 	}
 }
 
+func TestParse_ApplicationManifest_WithAliases(t *testing.T) {
+	m, err := Parse(testdataPath("hello-api-aliased.yml"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if m.Application == nil {
+		t.Fatal("Application is nil")
+	}
+
+	app := m.Application
+	aliases := app.Spec.Routing.Aliases
+
+	if len(aliases) != 1 {
+		t.Fatalf("len(Aliases) = %d, want 1", len(aliases))
+	}
+	if aliases[0].Host != "gateway.tail9a6ddb.ts.net" {
+		t.Errorf("Aliases[0].Host = %q, want %q", aliases[0].Host, "gateway.tail9a6ddb.ts.net")
+	}
+	if aliases[0].PathPrefix != "/finances" {
+		t.Errorf("Aliases[0].PathPrefix = %q, want %q", aliases[0].PathPrefix, "/finances")
+	}
+	if aliases[0].StripPrefix != nil {
+		t.Errorf("Aliases[0].StripPrefix = %v, want nil", aliases[0].StripPrefix)
+	}
+}
+
+func TestParse_ApplicationManifest_MultiAlias(t *testing.T) {
+	m, err := Parse(testdataPath("hello-api-multi-alias.yml"))
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if m.Application == nil {
+		t.Fatal("Application is nil")
+	}
+
+	app := m.Application
+	aliases := app.Spec.Routing.Aliases
+
+	if len(aliases) != 3 {
+		t.Fatalf("len(Aliases) = %d, want 3", len(aliases))
+	}
+	if aliases[0].Host != "lan.home.lab" {
+		t.Errorf("Aliases[0].Host = %q, want %q", aliases[0].Host, "lan.home.lab")
+	}
+	if aliases[0].PathPrefix != "" {
+		t.Errorf("Aliases[0].PathPrefix = %q, want %q", aliases[0].PathPrefix, "")
+	}
+	if aliases[0].StripPrefix != nil {
+		t.Errorf("Aliases[0].StripPrefix = %v, want nil", aliases[0].StripPrefix)
+	}
+
+	if aliases[1].Host != "gateway.tail9a6ddb.ts.net" {
+		t.Errorf("Aliases[1].Host = %q, want %q", aliases[1].Host, "gateway.tail9a6ddb.ts.net")
+	}
+	if aliases[1].PathPrefix != "/notes" {
+		t.Errorf("Aliases[1].PathPrefix = %q, want %q", aliases[1].PathPrefix, "/notes")
+	}
+	if aliases[1].StripPrefix != nil {
+		t.Errorf("Aliases[1].StripPrefix = %v, want nil", aliases[1].StripPrefix)
+	}
+
+	if aliases[2].Host != "gateway.tail9a6ddb.ts.net" {
+		t.Errorf("Aliases[2].Host = %q, want %q", aliases[2].Host, "gateway.tail9a6ddb.ts.net")
+	}
+	if aliases[2].PathPrefix != "/notes-raw" {
+		t.Errorf("Aliases[2].PathPrefix = %q, want %q", aliases[2].PathPrefix, "/notes-raw")
+	}
+	if aliases[2].StripPrefix == nil {
+		t.Fatal("Aliases[2].StripPrefix is nil, want *false")
+	}
+	if *aliases[2].StripPrefix != false {
+		t.Errorf("*Aliases[2].StripPrefix = %v, want false", *aliases[2].StripPrefix)
+	}
+}
+
 func TestParse_TeamManifest(t *testing.T) {
 	m, err := Parse(testdataPath("hello-team.yml"))
 	if err != nil {

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -36,10 +36,17 @@ type EnvVar struct {
 	Template  string `yaml:"template,omitempty" json:"template,omitempty"`
 }
 
+type RoutingAlias struct {
+	Host        string `yaml:"host"`
+	PathPrefix  string `yaml:"pathPrefix,omitempty"`
+	StripPrefix *bool  `yaml:"stripPrefix,omitempty"`
+}
+
 // Used in Application spec
 type Routing struct {
-	Domain     string `yaml:"domain"`
-	PathPrefix string `yaml:"pathPrefix,omitempty"`
+	Domain     string         `yaml:"domain"`
+	PathPrefix string         `yaml:"pathPrefix,omitempty"`
+	Aliases    []RoutingAlias `yaml:"aliases,omitempty"`
 }
 
 // Used in App and Res spec

--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -90,6 +90,8 @@ func validateApplicationSpec(spec ApplicationSpec) []string {
 		errs = append(errs, validateExclusiveFields("spec.env", i, e.Name, "value/valueFrom/template", kinds)...)
 	}
 
+	errs = append(errs, validateRoutingAliases(spec.Routing)...)
+
 	// validate volumes
 	if spec.Volumes != nil {
 		errs = append(errs, validateVolumeMounts(spec.Volumes)...)
@@ -134,6 +136,66 @@ func validateResourceSpec(spec ResourceSpec) []string {
 	// validate volumes
 	if spec.Volumes != nil {
 		errs = append(errs, validateVolumeMounts(spec.Volumes)...)
+	}
+
+	return errs
+}
+
+func hasInvalidChars(s string) bool {
+	for _, r := range s {
+		if r == ' ' || r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePathPrefix(p string) string {
+	return strings.TrimRight(p, "/")
+}
+
+func validateRoutingAliases(routing Routing) []string {
+	if len(routing.Aliases) == 0 {
+		return nil
+	}
+
+	var errs []string
+
+	if routing.Domain == "" {
+		errs = append(errs, "spec.routing.aliases is set but spec.routing.domain is empty")
+	}
+
+	type routeKey struct{ host, path string }
+	seen := make(map[routeKey]bool)
+	seen[routeKey{routing.Domain, normalizePathPrefix(routing.PathPrefix)}] = true
+
+	for i, a := range routing.Aliases {
+		if a.Host == "" {
+			errs = append(errs, fmt.Sprintf("spec.routing.aliases[%d].host is required", i))
+			continue
+		}
+
+		if hasInvalidChars(a.Host) {
+			errs = append(errs, fmt.Sprintf("spec.routing.aliases[%d].host %q contains invalid characters", i, a.Host))
+		}
+
+		if a.PathPrefix != "" {
+			normPath := normalizePathPrefix(a.PathPrefix)
+			if !strings.HasPrefix(a.PathPrefix, "/") {
+				errs = append(errs, fmt.Sprintf("spec.routing.aliases[%d].pathPrefix %q must start with \"/\"", i, a.PathPrefix))
+			} else if normPath == "" {
+				errs = append(errs, fmt.Sprintf("spec.routing.aliases[%d].pathPrefix must not be just \"/\"", i))
+			} else if hasInvalidChars(a.PathPrefix) {
+				errs = append(errs, fmt.Sprintf("spec.routing.aliases[%d].pathPrefix %q contains invalid characters", i, a.PathPrefix))
+			}
+		}
+
+		normPath := normalizePathPrefix(a.PathPrefix)
+		key := routeKey{a.Host, normPath}
+		if seen[key] {
+			errs = append(errs, fmt.Sprintf("spec.routing: duplicate route %s%s declared on alias[%d]", a.Host, normPath, i))
+		}
+		seen[key] = true
 	}
 
 	return errs

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -208,6 +208,128 @@ func TestValidate_ApplicationEnvRules(t *testing.T) {
 	}
 }
 
+func TestValidate_RoutingAliasRules(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	validBase := func(routing Routing) *Manifest {
+		return &Manifest{
+			TypeMeta: TypeMeta{Kind: ApplicationKind, APIVersion: "shrine/v1"},
+			Application: &ApplicationManifest{
+				Metadata: Metadata{Name: "a", Owner: "team-a"},
+				Spec:     ApplicationSpec{Image: "img", Port: 80, Routing: routing},
+			},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		routing Routing
+		wantErr string
+	}{
+		{
+			name: "V1: aliases set but domain empty",
+			routing: Routing{
+				Domain:  "",
+				Aliases: []RoutingAlias{{Host: "x.example.com"}},
+			},
+			wantErr: "aliases is set but spec.routing.domain is empty",
+		},
+		{
+			name: "V2: alias with empty host",
+			routing: Routing{
+				Domain:  "app.home.lab",
+				Aliases: []RoutingAlias{{Host: ""}},
+			},
+			wantErr: "aliases[0].host is required",
+		},
+		{
+			name: "V3: alias host containing a space",
+			routing: Routing{
+				Domain:  "app.home.lab",
+				Aliases: []RoutingAlias{{Host: "bad host"}},
+			},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name: "V4: alias pathPrefix missing leading slash",
+			routing: Routing{
+				Domain:  "app.home.lab",
+				Aliases: []RoutingAlias{{Host: "x.example.com", PathPrefix: "finances"}},
+			},
+			wantErr: "must start with \"/\"",
+		},
+		{
+			name: "V5: alias pathPrefix is exactly /",
+			routing: Routing{
+				Domain:  "app.home.lab",
+				Aliases: []RoutingAlias{{Host: "x.example.com", PathPrefix: "/"}},
+			},
+			wantErr: "must not be just \"/\"",
+		},
+		{
+			name: "V6: alias pathPrefix containing a tab",
+			routing: Routing{
+				Domain:  "app.home.lab",
+				Aliases: []RoutingAlias{{Host: "x.example.com", PathPrefix: "/has\ttab"}},
+			},
+			wantErr: "contains invalid characters",
+		},
+		{
+			name: "V7: alias vs primary same host+pathPrefix",
+			routing: Routing{
+				Domain:     "gateway.tail9a6ddb.ts.net",
+				PathPrefix: "/finances",
+				Aliases:    []RoutingAlias{{Host: "gateway.tail9a6ddb.ts.net", PathPrefix: "/finances"}},
+			},
+			wantErr: "duplicate route",
+		},
+		{
+			name: "V7: alias vs alias duplicate",
+			routing: Routing{
+				Domain: "app.home.lab",
+				Aliases: []RoutingAlias{
+					{Host: "gateway.tail9a6ddb.ts.net", PathPrefix: "/finances"},
+					{Host: "gateway.tail9a6ddb.ts.net", PathPrefix: "/finances"},
+				},
+			},
+			wantErr: "alias[1]",
+		},
+		{
+			name: "V7: trailing slash normalized collision",
+			routing: Routing{
+				Domain:     "app.home.lab",
+				PathPrefix: "/x",
+				Aliases:    []RoutingAlias{{Host: "app.home.lab", PathPrefix: "/x/"}},
+			},
+			wantErr: "duplicate route",
+		},
+		{
+			name: "valid alias with explicit stripPrefix false",
+			routing: Routing{
+				Domain:  "app.home.lab",
+				Aliases: []RoutingAlias{{Host: "gw.example.com", PathPrefix: "/api", StripPrefix: boolPtr(false)}},
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := validBase(tc.routing)
+			err := Validate(m)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestValidate_InvalidTeam(t *testing.T) {
 	m, err := Parse(testdataPath("invalid-team.yml"))
 	if err != nil {

--- a/internal/planner/collisions.go
+++ b/internal/planner/collisions.go
@@ -1,0 +1,99 @@
+package planner
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type routeKey struct {
+	host       string
+	pathPrefix string
+}
+
+func normalizePrefix(p string) string {
+	return strings.TrimRight(p, "/")
+}
+
+func DetectRoutingCollisions(set *ManifestSet) error {
+	type record struct {
+		appRef string
+		key    routeKey
+	}
+
+	// Collect all (appRef, routeKey) pairs in deterministic order.
+	appRefs := make([]string, 0, len(set.Applications))
+	for name := range set.Applications {
+		app := set.Applications[name]
+		appRefs = append(appRefs, app.Metadata.Owner+"/"+app.Metadata.Name)
+	}
+	sort.Strings(appRefs)
+
+	// Build a map from appRef to the app for sorted iteration.
+	refToApp := make(map[string]*struct {
+		domain     string
+		pathPrefix string
+		aliases    []struct {
+			host       string
+			pathPrefix string
+		}
+	}, len(set.Applications))
+
+	for _, app := range set.Applications {
+		ref := app.Metadata.Owner + "/" + app.Metadata.Name
+		entry := &struct {
+			domain     string
+			pathPrefix string
+			aliases    []struct {
+				host       string
+				pathPrefix string
+			}
+		}{
+			domain:     app.Spec.Routing.Domain,
+			pathPrefix: normalizePrefix(app.Spec.Routing.PathPrefix),
+		}
+		for _, alias := range app.Spec.Routing.Aliases {
+			entry.aliases = append(entry.aliases, struct {
+				host       string
+				pathPrefix string
+			}{host: alias.Host, pathPrefix: normalizePrefix(alias.PathPrefix)})
+		}
+		refToApp[ref] = entry
+	}
+
+	seen := map[routeKey]string{}
+	var errs []string
+
+	addRoute := func(key routeKey, appRef string) {
+		if existing, ok := seen[key]; ok {
+			if existing != appRef {
+				a, b := existing, appRef
+				if a > b {
+					a, b = b, a
+				}
+				errs = append(errs, fmt.Sprintf(
+					"routing collision: host=%q pathPrefix=%q declared by %q and %q",
+					key.host, key.pathPrefix, a, b,
+				))
+			}
+		} else {
+			seen[key] = appRef
+		}
+	}
+
+	for _, ref := range appRefs {
+		entry := refToApp[ref]
+		if entry.domain != "" {
+			addRoute(routeKey{host: entry.domain, pathPrefix: entry.pathPrefix}, ref)
+		}
+		for _, alias := range entry.aliases {
+			addRoute(routeKey{host: alias.host, pathPrefix: alias.pathPrefix}, ref)
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	sort.Strings(errs)
+	return fmt.Errorf("routing validation failed:\n- %s", strings.Join(errs, "\n- "))
+}

--- a/internal/planner/collisions_test.go
+++ b/internal/planner/collisions_test.go
@@ -1,0 +1,136 @@
+package planner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+)
+
+func makeApp(owner, name, domain, pathPrefix string, aliases ...manifest.RoutingAlias) *manifest.ApplicationManifest {
+	return &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Owner: owner, Name: name},
+		Spec: manifest.ApplicationSpec{
+			Routing: manifest.Routing{
+				Domain:     domain,
+				PathPrefix: pathPrefix,
+				Aliases:    aliases,
+			},
+		},
+	}
+}
+
+func setWith(apps ...*manifest.ApplicationManifest) *ManifestSet {
+	s := &ManifestSet{
+		Applications: make(map[string]*manifest.ApplicationManifest),
+		Resources:    make(map[string]*manifest.ResourceManifest),
+	}
+	for _, a := range apps {
+		s.Applications[a.Metadata.Name] = a
+	}
+	return s
+}
+
+func TestDetectRoutingCollisions_Disjoint(t *testing.T) {
+	set := setWith(
+		makeApp("team-a", "app1", "a.example.com", ""),
+		makeApp("team-b", "app2", "b.example.com", ""),
+	)
+	if err := DetectRoutingCollisions(set); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestDetectRoutingCollisions_PrimaryVsPrimary(t *testing.T) {
+	set := setWith(
+		makeApp("team-a", "app1", "clash.example.com", ""),
+		makeApp("team-b", "app2", "clash.example.com", ""),
+	)
+	err := DetectRoutingCollisions(set)
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	if !strings.Contains(err.Error(), "routing collision") {
+		t.Errorf("expected 'routing collision' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "team-a/app1") || !strings.Contains(err.Error(), "team-b/app2") {
+		t.Errorf("expected both app refs in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "clash.example.com") {
+		t.Errorf("expected host in error, got: %v", err)
+	}
+}
+
+func TestDetectRoutingCollisions_PrimaryVsAlias(t *testing.T) {
+	alias := manifest.RoutingAlias{Host: "shared.example.com", PathPrefix: "/api"}
+	set := setWith(
+		makeApp("team-a", "app1", "shared.example.com", "/api"),
+		makeApp("team-b", "app2", "other.example.com", "", alias),
+	)
+	err := DetectRoutingCollisions(set)
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	if !strings.Contains(err.Error(), "routing collision") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectRoutingCollisions_AliasVsAlias(t *testing.T) {
+	alias1 := manifest.RoutingAlias{Host: "shared.example.com", PathPrefix: "/x"}
+	alias2 := manifest.RoutingAlias{Host: "shared.example.com", PathPrefix: "/x"}
+	set := setWith(
+		makeApp("team-a", "app1", "a.example.com", "", alias1),
+		makeApp("team-b", "app2", "b.example.com", "", alias2),
+	)
+	err := DetectRoutingCollisions(set)
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	if !strings.Contains(err.Error(), "routing collision") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectRoutingCollisions_MultipleCollisions(t *testing.T) {
+	alias := manifest.RoutingAlias{Host: "extra.example.com", PathPrefix: ""}
+	set := setWith(
+		makeApp("team-a", "app1", "clash1.example.com", "", alias),
+		makeApp("team-b", "app2", "clash1.example.com", "", alias),
+	)
+	err := DetectRoutingCollisions(set)
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	// Two collisions: primary-vs-primary and alias-vs-alias
+	if count := strings.Count(err.Error(), "routing collision"); count < 2 {
+		t.Errorf("expected at least 2 collision lines, got %d in: %v", count, err)
+	}
+}
+
+func TestDetectRoutingCollisions_TrailingSlashNormalization(t *testing.T) {
+	alias := manifest.RoutingAlias{Host: "shared.example.com", PathPrefix: "/x/"}
+	set := setWith(
+		makeApp("team-a", "app1", "shared.example.com", "/x"),
+		makeApp("team-b", "app2", "other.example.com", "", alias),
+	)
+	err := DetectRoutingCollisions(set)
+	if err == nil {
+		t.Fatal("expected collision error for /x vs /x/ (normalized equal)")
+	}
+	if !strings.Contains(err.Error(), "routing collision") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectRoutingCollisions_SameApp_NoDuplicate(t *testing.T) {
+	// Within one app the same host+path appears twice — but the validator
+	// catches this; the collision detector must not report it.
+	alias := manifest.RoutingAlias{Host: "a.example.com", PathPrefix: ""}
+	set := setWith(
+		makeApp("team-a", "app1", "a.example.com", "", alias),
+	)
+	if err := DetectRoutingCollisions(set); err != nil {
+		t.Errorf("expected nil for same-app duplicate, got %v", err)
+	}
+}

--- a/internal/plugins/gateway/traefik/routing.go
+++ b/internal/plugins/gateway/traefik/routing.go
@@ -12,6 +12,9 @@ import (
 	"github.com/CarlosHPlata/shrine/internal/engine"
 )
 
+var writeFileFn = os.WriteFile
+var mkdirAllFn = os.MkdirAll
+
 type RoutingBackend struct {
 	routingDir string
 }
@@ -20,46 +23,75 @@ func (r *RoutingBackend) dynamicDir() string {
 	return filepath.Join(r.routingDir, "dynamic")
 }
 
+func buildRouterRule(host, pathPrefix string) string {
+	if pathPrefix == "" {
+		return fmt.Sprintf("Host(`%s`)", host)
+	}
+	return fmt.Sprintf("Host(`%s`) && PathPrefix(`%s`)", host, pathPrefix)
+}
+
+func stripMiddlewareName(team, service string, aliasIndex int) string {
+	return fmt.Sprintf("%s-%s-strip-%d", team, service, aliasIndex)
+}
+
 func (r *RoutingBackend) WriteRoute(op engine.WriteRouteOp) error {
-	if err := os.MkdirAll(r.dynamicDir(), 0o755); err != nil {
+	if err := mkdirAllFn(r.dynamicDir(), 0o755); err != nil {
 		return fmt.Errorf("traefik routing: creating dynamic dir: %w", err)
 	}
 
 	name := fmt.Sprintf("%s-%s", op.Team, op.ServiceName)
-	rule := fmt.Sprintf("Host(`%s`)", op.Domain)
-	if op.PathPrefix != "" {
-		rule = fmt.Sprintf("Host(`%s`) && PathPrefix(`%s`)", op.Domain, op.PathPrefix)
+
+	routers := map[string]router{
+		name: {
+			Rule:        buildRouterRule(op.Domain, op.PathPrefix),
+			Service:     name,
+			EntryPoints: []string{"web"},
+		},
 	}
 
-	doc := struct {
-		HTTP httpConfig `yaml:"http"`
-	}{
-		HTTP: httpConfig{
-			Routers: map[string]router{
-				name: {
-					Rule:        rule,
-					Service:     name,
-					EntryPoints: []string{"web"},
-				},
-			},
-			Services: map[string]service{
-				name: {
-					LoadBalancer: loadBalancer{
-						Servers: []server{
-							{URL: fmt.Sprintf("http://%s.%s:%d", op.Team, op.ServiceName, op.ServicePort)},
-						},
+	mids := map[string]middleware{}
+
+	for i, ar := range op.AdditionalRoutes {
+		aliasKey := fmt.Sprintf("%s-alias-%d", name, i)
+		r := router{
+			Rule:        buildRouterRule(ar.Host, ar.PathPrefix),
+			Service:     name,
+			EntryPoints: []string{"web"},
+		}
+		if ar.StripPrefix && ar.PathPrefix != "" {
+			midKey := stripMiddlewareName(op.Team, op.ServiceName, i)
+			mids[midKey] = middleware{StripPrefix: &stripPrefix{Prefixes: []string{ar.PathPrefix}}}
+			r.Middlewares = []string{midKey}
+		}
+		routers[aliasKey] = r
+	}
+
+	cfg := httpConfig{
+		Routers: routers,
+		Services: map[string]service{
+			name: {
+				LoadBalancer: loadBalancer{
+					Servers: []server{
+						{URL: fmt.Sprintf("http://%s.%s:%d", op.Team, op.ServiceName, op.ServicePort)},
 					},
 				},
 			},
 		},
 	}
+	if len(mids) > 0 {
+		cfg.Middlewares = mids
+	}
+
+	doc := struct {
+		HTTP httpConfig `yaml:"http"`
+	}{HTTP: cfg}
 
 	data, err := yaml.Marshal(doc)
 	if err != nil {
 		return fmt.Errorf("marshal traefik route: %w", err)
 	}
 
-	return os.WriteFile(filepath.Join(r.dynamicDir(), routeFileName(op.Team, op.ServiceName)), data, 0o644)
+	return writeFileFn(filepath.Join(r.dynamicDir(), routeFileName(op.Team, op.ServiceName)), data, 0o644)
 }
 
 func (r *RoutingBackend) RemoveRoute(team string, host string) error {

--- a/internal/plugins/gateway/traefik/routing_test.go
+++ b/internal/plugins/gateway/traefik/routing_test.go
@@ -1,0 +1,290 @@
+package traefik
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/engine"
+)
+
+func TestBuildRouterRule(t *testing.T) {
+	if got := buildRouterRule("h", ""); got != "Host(`h`)" {
+		t.Errorf("buildRouterRule(h,''): got %q", got)
+	}
+	if got := buildRouterRule("h", "/p"); got != "Host(`h`) && PathPrefix(`/p`)" {
+		t.Errorf("buildRouterRule(h,/p): got %q", got)
+	}
+}
+
+func captureWriteFileFn(t *testing.T) *[]byte {
+	t.Helper()
+	var captured []byte
+	origWrite := writeFileFn
+	origMkdir := mkdirAllFn
+	writeFileFn = func(_ string, data []byte, _ fs.FileMode) error {
+		captured = data
+		return nil
+	}
+	mkdirAllFn = func(_ string, _ fs.FileMode) error { return nil }
+	t.Cleanup(func() {
+		writeFileFn = origWrite
+		mkdirAllFn = origMkdir
+	})
+	return &captured
+}
+
+func newTestBackend() *RoutingBackend {
+	return &RoutingBackend{routingDir: "/fake"}
+}
+
+func baseOp() engine.WriteRouteOp {
+	return engine.WriteRouteOp{
+		Team:        "team-a",
+		Domain:      "hello-api.home.lab",
+		ServiceName: "hello-api",
+		ServicePort: 8080,
+	}
+}
+
+const wantNoAlias = `http:
+    routers:
+        team-a-hello-api:
+            rule: Host(` + "`hello-api.home.lab`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+    services:
+        team-a-hello-api:
+            loadBalancer:
+                servers:
+                    - url: http://team-a.hello-api:8080
+`
+
+const wantOneAliasStrip = `http:
+    middlewares:
+        team-a-hello-api-strip-0:
+            stripPrefix:
+                prefixes:
+                    - /p
+    routers:
+        team-a-hello-api:
+            rule: Host(` + "`hello-api.home.lab`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+        team-a-hello-api-alias-0:
+            rule: Host(` + "`x`" + `) && PathPrefix(` + "`/p`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+            middlewares:
+                - team-a-hello-api-strip-0
+    services:
+        team-a-hello-api:
+            loadBalancer:
+                servers:
+                    - url: http://team-a.hello-api:8080
+`
+
+const wantOneAliasNoStrip = `http:
+    routers:
+        team-a-hello-api:
+            rule: Host(` + "`hello-api.home.lab`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+        team-a-hello-api-alias-0:
+            rule: Host(` + "`x`" + `) && PathPrefix(` + "`/p`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+    services:
+        team-a-hello-api:
+            loadBalancer:
+                servers:
+                    - url: http://team-a.hello-api:8080
+`
+
+const wantHostOnlyAlias = `http:
+    routers:
+        team-a-hello-api:
+            rule: Host(` + "`hello-api.home.lab`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+        team-a-hello-api-alias-0:
+            rule: Host(` + "`x`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+    services:
+        team-a-hello-api:
+            loadBalancer:
+                servers:
+                    - url: http://team-a.hello-api:8080
+`
+
+const wantThreeAliasesSparse = `http:
+    middlewares:
+        team-a-hello-api-strip-1:
+            stripPrefix:
+                prefixes:
+                    - /p1
+    routers:
+        team-a-hello-api:
+            rule: Host(` + "`hello-api.home.lab`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+        team-a-hello-api-alias-0:
+            rule: Host(` + "`a`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+        team-a-hello-api-alias-1:
+            rule: Host(` + "`b`" + `) && PathPrefix(` + "`/p1`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+            middlewares:
+                - team-a-hello-api-strip-1
+        team-a-hello-api-alias-2:
+            rule: Host(` + "`c`" + `) && PathPrefix(` + "`/p2`" + `)
+            service: team-a-hello-api
+            entryPoints:
+                - web
+    services:
+        team-a-hello-api:
+            loadBalancer:
+                servers:
+                    - url: http://team-a.hello-api:8080
+`
+
+func TestWriteRoute_NoAliases(t *testing.T) {
+	captured := captureWriteFileFn(t)
+	rb := newTestBackend()
+	op := baseOp()
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := string(*captured)
+	if got != wantNoAlias {
+		t.Errorf("YAML mismatch.\ngot:\n%s\nwant:\n%s", got, wantNoAlias)
+	}
+	if strings.Contains(got, "middlewares:") {
+		t.Error("expected no middlewares section")
+	}
+	if strings.Count(got, "routers:") != 1 {
+		t.Error("expected exactly one routers block")
+	}
+	if !strings.Contains(got, "team-a-hello-api:") {
+		t.Error("expected primary router key")
+	}
+}
+
+func TestWriteRoute_OneAlias_Strip(t *testing.T) {
+	captured := captureWriteFileFn(t)
+	rb := newTestBackend()
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "x", PathPrefix: "/p", StripPrefix: true},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := string(*captured)
+	if got != wantOneAliasStrip {
+		t.Errorf("YAML mismatch.\ngot:\n%s\nwant:\n%s", got, wantOneAliasStrip)
+	}
+	if !strings.Contains(got, "team-a-hello-api-strip-0:") {
+		t.Error("expected strip middleware named team-a-hello-api-strip-0")
+	}
+	if !strings.Contains(got, "team-a-hello-api-alias-0:") {
+		t.Error("expected alias router named team-a-hello-api-alias-0")
+	}
+	if !strings.Contains(got, "- team-a-hello-api-strip-0") {
+		t.Error("expected alias router to list strip middleware")
+	}
+}
+
+func TestWriteRoute_OneAlias_NoStrip(t *testing.T) {
+	captured := captureWriteFileFn(t)
+	rb := newTestBackend()
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "x", PathPrefix: "/p", StripPrefix: false},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := string(*captured)
+	if got != wantOneAliasNoStrip {
+		t.Errorf("YAML mismatch.\ngot:\n%s\nwant:\n%s", got, wantOneAliasNoStrip)
+	}
+	if strings.Contains(got, "middlewares:") {
+		t.Error("expected no middlewares section when StripPrefix=false")
+	}
+	if !strings.Contains(got, "team-a-hello-api-alias-0:") {
+		t.Error("expected alias router")
+	}
+}
+
+func TestWriteRoute_HostOnlyAlias(t *testing.T) {
+	captured := captureWriteFileFn(t)
+	rb := newTestBackend()
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "x", PathPrefix: ""},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := string(*captured)
+	if got != wantHostOnlyAlias {
+		t.Errorf("YAML mismatch.\ngot:\n%s\nwant:\n%s", got, wantHostOnlyAlias)
+	}
+	if !strings.Contains(got, "Host(`x`)") {
+		t.Error("expected Host-only rule for alias with no prefix")
+	}
+	if strings.Contains(got, "middlewares:") {
+		t.Error("expected no middlewares section for host-only alias")
+	}
+}
+
+func TestWriteRoute_ThreeAliases_SparseStrip(t *testing.T) {
+	captured := captureWriteFileFn(t)
+	rb := newTestBackend()
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "a", PathPrefix: "", StripPrefix: false},            // index 0: host-only
+		{Host: "b", PathPrefix: "/p1", StripPrefix: true},          // index 1: strip
+		{Host: "c", PathPrefix: "/p2", StripPrefix: false},         // index 2: no strip
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := string(*captured)
+	if got != wantThreeAliasesSparse {
+		t.Errorf("YAML mismatch.\ngot:\n%s\nwant:\n%s", got, wantThreeAliasesSparse)
+	}
+	if !strings.Contains(got, "team-a-hello-api-strip-1:") {
+		t.Error("expected only strip-1 middleware (sparse)")
+	}
+	if strings.Contains(got, "team-a-hello-api-strip-0:") {
+		t.Error("expected no strip-0 middleware (host-only alias at index 0)")
+	}
+	if strings.Contains(got, "team-a-hello-api-strip-2:") {
+		t.Error("expected no strip-2 middleware (StripPrefix=false at index 2)")
+	}
+}

--- a/internal/plugins/gateway/traefik/spec.go
+++ b/internal/plugins/gateway/traefik/spec.go
@@ -31,11 +31,16 @@ type httpConfig struct {
 }
 
 type middleware struct {
-	BasicAuth *basicAuth `yaml:"basicAuth,omitempty"`
+	BasicAuth   *basicAuth   `yaml:"basicAuth,omitempty"`
+	StripPrefix *stripPrefix `yaml:"stripPrefix,omitempty"`
 }
 
 type basicAuth struct {
 	Users []string `yaml:"users"`
+}
+
+type stripPrefix struct {
+	Prefixes []string `yaml:"prefixes"`
 }
 
 type router struct {

--- a/internal/ui/terminal_logger.go
+++ b/internal/ui/terminal_logger.go
@@ -52,6 +52,9 @@ func (t *TerminalObserver) OnEvent(e engine.Event) {
 
 	case "routing.configure":
 		fmt.Fprintf(t.out, "  🔗 Configuring routing: %s -> port %s\n", e.Fields["domain"], e.Fields["port"])
+		if aliases := e.Fields["aliases"]; aliases != "" {
+			fmt.Fprintf(t.out, "    ↳ Aliases: %s\n", aliases)
+		}
 
 	case "gateway.config.preserved":
 		fmt.Fprintf(t.out, "  📄 Preserving operator-owned traefik.yml: %s\n", e.Fields["path"])

--- a/specs/006-routing-aliases/checklists/requirements.md
+++ b/specs/006-routing-aliases/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Routing Aliases for Application Manifests
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The example YAML block in User Story 1 is illustrative of the manifest field shape requested in the user input; it names the field but does not constrain implementation choices (parser, validation library, generated router naming).
+- Clarification session 2026-04-30 resolved three high-impact ambiguities: per-alias `stripPrefix` semantics (default `true`), cross-application host+path collisions (fail the deploy), and `pathPrefix` shape validation (require leading `/`, normalize trailing `/`). All three were folded into FR/Edge Cases/Key Entities; checklist re-validated post-merge.

--- a/specs/006-routing-aliases/contracts/manifest-schema.md
+++ b/specs/006-routing-aliases/contracts/manifest-schema.md
@@ -1,0 +1,137 @@
+# Contract: `routing.aliases` manifest schema
+
+**Feature**: 006-routing-aliases
+**Audience**: operators authoring Application manifests; integration test authors
+
+This contract defines the externally-visible YAML interface introduced by the feature. It is the canonical reference for what operators may write and what errors they will see when they write something invalid.
+
+---
+
+## YAML shape
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: hello-api
+  owner: team-a
+spec:
+  image: hello-api
+  port: 8080
+  routing:
+    domain: hello-api.home.lab          # required (when any routing is declared)
+    pathPrefix: /hello-api              # optional; pre-existing field, unchanged
+    aliases:                            # optional; new in this feature
+      - host: gateway.tail9a6ddb.ts.net # required for each alias entry
+        pathPrefix: /finances           # optional
+        stripPrefix: true               # optional; defaults to true when pathPrefix is set
+      - host: lan.home.lab              # alias with no pathPrefix
+```
+
+---
+
+## Field reference
+
+### `spec.routing.aliases` (list, optional)
+
+Zero or more alias entries. Omitting the field, setting it to `null`, or setting it to `[]` are all equivalent — the application is published only at its primary domain.
+
+### `spec.routing.aliases[].host` (string, required when the alias entry exists)
+
+The additional hostname at which the application should be reachable. Must:
+
+- Be non-empty.
+- Not contain spaces or control characters.
+
+Validation does **not** enforce full RFC 1035 hostname syntax. Typos that are still syntactically valid (e.g., `gatway.tail9a6ddb.ts.net`) are accepted; the failure surfaces at DNS resolution time.
+
+### `spec.routing.aliases[].pathPrefix` (string, optional)
+
+A path prefix that further narrows alias routing to a subtree of the host. Must, when present:
+
+- Start with `/`.
+- Not be the empty string.
+- Not be just `/` (use omission instead).
+- Not contain spaces or control characters.
+
+A trailing `/` (e.g., `/finances/`) is accepted and normalized away internally so `/finances` and `/finances/` produce identical gateway behavior.
+
+### `spec.routing.aliases[].stripPrefix` (bool, optional)
+
+Controls whether the matched `pathPrefix` is removed from the request path before the backend receives it.
+
+- Default: `true` when `pathPrefix` is set.
+- No effect when `pathPrefix` is empty or omitted.
+- Set to `false` when the backend expects the prefix on the wire (e.g., it serves at `/finances/...` natively).
+
+---
+
+## Examples
+
+### Single alias, default strip
+
+```yaml
+spec:
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+```
+
+A backend serving at root keeps working: requests to `gateway.tail9a6ddb.ts.net/finances/api/balance` reach the backend as `/api/balance`.
+
+### Multiple aliases, mixed strip
+
+```yaml
+spec:
+  routing:
+    domain: notes.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /notes
+        # stripPrefix defaults to true → backend sees /api/list
+      - host: notes-v2.home.lab
+        # no pathPrefix → backend sees full path; stripPrefix has no effect
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /notes-raw
+        stripPrefix: false
+        # backend sees /notes-raw/api/list (e.g., for an app that serves under /notes-raw natively)
+```
+
+### Empty aliases list (equivalent to omission)
+
+```yaml
+spec:
+  routing:
+    domain: hello.home.lab
+    aliases: []   # behaves identically to omitting the field
+```
+
+---
+
+## Validation errors (operator-facing)
+
+When `shrine apply` or `shrine deploy` rejects a manifest because of alias misuse, the error message is one of the following shapes (joined into a multi-error report when multiple apply):
+
+| Trigger | Error shape |
+|---|---|
+| `aliases` set but `domain` empty | `validation failed:\n- spec.routing.aliases is set but spec.routing.domain is empty` |
+| Missing `host` on an alias entry | `validation failed:\n- spec.routing.aliases[2].host is required` |
+| `host` contains invalid characters | `validation failed:\n- spec.routing.aliases[0].host "bad host" contains invalid characters` |
+| `pathPrefix` missing leading `/` | `validation failed:\n- spec.routing.aliases[1].pathPrefix "finances" must start with "/"` |
+| `pathPrefix` is bare `/` | `validation failed:\n- spec.routing.aliases[1].pathPrefix must not be just "/"` |
+| `pathPrefix` contains invalid characters | `validation failed:\n- spec.routing.aliases[0].pathPrefix "/has space" contains invalid characters` |
+| Same `(host, pathPrefix)` declared twice on the same app | `validation failed:\n- spec.routing: duplicate route gateway.tail9a6ddb.ts.net/finances declared on alias[1]` |
+| Two different apps collide on `(host, pathPrefix)` | `routing collision: host="gateway.tail9a6ddb.ts.net" pathPrefix="/finances" declared by "team-a/finances" and "team-b/notes"` (one bullet per colliding pair, joined as a multi-error if more than one) |
+
+All error formats include the offending application's `<owner>/<name>` (or alias index) so operators can locate the bad manifest in seconds.
+
+---
+
+## Compatibility guarantees
+
+- Manifests that omit `aliases` are byte-identical in behavior to pre-feature releases (SC-005).
+- The pre-existing `routing.pathPrefix` on the primary domain is unchanged: no implicit strip, no other behavior changes.
+- A manifest with `aliases` deployed against a host that has no Traefik gateway plugin succeeds without warning (FR-010).
+- A manifest with `aliases` deployed against a host that has a non-Traefik gateway plugin succeeds; that plugin chooses whether to consume aliases (FR-010).

--- a/specs/006-routing-aliases/data-model.md
+++ b/specs/006-routing-aliases/data-model.md
@@ -1,0 +1,222 @@
+# Phase 1 Data Model: Routing Aliases
+
+**Feature**: 006-routing-aliases
+**Date**: 2026-04-30
+
+This document defines the data shapes introduced or modified by this feature. It is the source of truth for field names, types, defaults, and validation rules. The integration test fixtures and Phase 2 task list are derived directly from it.
+
+---
+
+## 1. Manifest types (`internal/manifest/types.go`)
+
+### 1.1 New: `RoutingAlias`
+
+```go
+// RoutingAlias declares an additional address (host + optional path prefix)
+// at which an Application is reachable, in addition to its primary
+// routing.domain. Consumed by the Traefik gateway plugin; silently ignored
+// when no gateway plugin is active.
+type RoutingAlias struct {
+    Host        string `yaml:"host"`
+    PathPrefix  string `yaml:"pathPrefix,omitempty"`
+    // StripPrefix uses a pointer so we can distinguish "unset" (default true
+    // when PathPrefix is non-empty) from "explicitly false". When PathPrefix
+    // is empty, StripPrefix has no effect regardless of value.
+    StripPrefix *bool  `yaml:"stripPrefix,omitempty"`
+}
+```
+
+### 1.2 Modified: `Routing`
+
+```go
+type Routing struct {
+    Domain     string         `yaml:"domain"`
+    PathPrefix string         `yaml:"pathPrefix,omitempty"`
+    Aliases    []RoutingAlias `yaml:"aliases,omitempty"`   // ← NEW
+}
+```
+
+`ApplicationSpec.Routing` is unchanged in name/position; only the embedded `Routing` struct gains the slice.
+
+---
+
+## 2. Validation rules (`internal/manifest/validate.go`)
+
+A new helper `validateRoutingAliases(routing Routing) []string` is invoked from `validateApplicationSpec`. Errors follow the existing multi-error pattern (return `[]string`, joined into one error in `Validate`).
+
+| ID | Rule | Mapped FR | Error message shape |
+|----|------|-----------|---------------------|
+| V1 | If `len(routing.Aliases) > 0` then `routing.Domain` MUST be non-empty | FR-004 | `spec.routing.aliases is set but spec.routing.domain is empty` |
+| V2 | Each alias's `Host` MUST be non-empty | FR-003 | `spec.routing.aliases[%d].host is required` |
+| V3 | `Host` MUST NOT contain spaces or control characters | FR-005 | `spec.routing.aliases[%d].host %q contains invalid characters` |
+| V4 | If `PathPrefix` is set, it MUST start with `/` | FR-005a | `spec.routing.aliases[%d].pathPrefix %q must start with "/"` |
+| V5 | `PathPrefix` MUST NOT be the literal `/` (use empty/omitted instead) | FR-005a | `spec.routing.aliases[%d].pathPrefix must not be just "/"` |
+| V6 | `PathPrefix` MUST NOT contain spaces or control characters | FR-005 | `spec.routing.aliases[%d].pathPrefix %q contains invalid characters` |
+| V7 | Within one application, no two routes (primary + aliases) MAY share the same `(host, normalizedPathPrefix)` pair | FR-008 | `spec.routing: duplicate route %s%s declared on alias[%d]` |
+
+Rules V4–V7 use `normalizedPathPrefix(p)` = `strings.TrimRight(p, "/")` so trailing-slash differences are collapsed before comparison.
+
+> Note: V7 implements the loud-failure semantics of FR-008 (validation error on within-app duplicate, parallel to FR-008a's cross-app failure). Within-app duplication is treated as an operator mistake — analogous to a duplicate `volumes[].name` — rather than something to silently dedup.
+
+---
+
+## 3. Engine projection (`internal/engine/backends.go`)
+
+### 3.1 Modified: `WriteRouteOp`
+
+```go
+type WriteRouteOp struct {
+    Team             string
+    Domain           string
+    ServiceName      string
+    ServicePort      int
+    PathPrefix       string
+    AdditionalRoutes []AliasRoute   // ← NEW
+}
+
+// AliasRoute is the engine-level projection of a manifest RoutingAlias.
+// StripPrefix here is a plain bool: the engine resolves the manifest's
+// pointer-with-default into a concrete value (default true when PathPrefix
+// is non-empty, irrelevant when empty).
+type AliasRoute struct {
+    Host        string
+    PathPrefix  string
+    StripPrefix bool
+}
+```
+
+### 3.2 Engine assembly (`internal/engine/engine.go`)
+
+In `deployApplication`, the existing block
+
+```go
+routingOp := WriteRouteOp{
+    Team:        application.Metadata.Owner,
+    Domain:      application.Spec.Routing.Domain,
+    ServiceName: application.Metadata.Name,
+    ServicePort: application.Spec.Port,
+    PathPrefix:  application.Spec.Routing.PathPrefix,
+}
+```
+
+is extended with a small loop that maps each `manifest.RoutingAlias` to an `AliasRoute`, applying the default-strip rule. Helper: `resolveAliasRoutes(aliases []manifest.RoutingAlias) []AliasRoute`.
+
+The `routing.configure` observer event fields are extended with `aliases` (sorted, comma-joined `host[+pathPrefix]` list) when the slice is non-empty (R5).
+
+---
+
+## 4. Planner cross-app collision check (`internal/planner/`)
+
+### 4.1 New helper
+
+```go
+// detectRoutingCollisions scans the full manifest set for any two
+// applications that produce a router for the same (host, pathPrefix) pair —
+// whether via primary routing.domain or via routing.aliases on either side.
+// Returns a multi-error formatted like the manifest validator's output.
+func detectRoutingCollisions(set *ManifestSet) error
+```
+
+### 4.2 Algorithm
+
+1. Build `seen := map[routeKey]appRef` where `routeKey = struct{ host, pathPrefix string }` (path normalized via `strings.TrimRight(p, "/")`).
+2. For each application, iterate primary `(Domain, PathPrefix)` first, then each alias.
+3. For each route, if `seen` already has the key with a different application, append a collision error: `routing collision: host=%q pathPrefix=%q declared by %q and %q`. Otherwise record.
+4. After scan, if errors exist, join with `\n- ` and return as one multi-error.
+
+### 4.3 Wiring
+
+`detectRoutingCollisions` is called from the deploy command pipeline (`internal/handler/deploy.go`) immediately after the planner returns the `ManifestSet` and before `engine.ExecuteDeploy`. Failure short-circuits with no engine, no Traefik, no Docker calls — meeting FR-008a's "MUST NOT write or update gateway config" guarantee.
+
+### 4.4 Same-app duplicates
+
+Same-app duplicates are caught by `validateApplicationSpec` (rule V7 above) before the planner sees them. The collision detector therefore only ever fires on cross-app conflicts; within-app ones never reach it.
+
+---
+
+## 5. Traefik dynamic-config rendering (`internal/plugins/gateway/traefik/routing.go`)
+
+### 5.1 File layout
+
+One file per app at `<routingDir>/dynamic/<team>-<service>.yml`. Filename unchanged.
+
+### 5.2 Structure
+
+```yaml
+http:
+  routers:
+    <team>-<service>:                 # primary
+      rule: "<primaryRule>"
+      service: <team>-<service>
+      entryPoints: [web]
+    <team>-<service>-alias-0:         # first alias
+      rule: "<aliasRule0>"
+      service: <team>-<service>
+      entryPoints: [web]
+      middlewares: [<team>-<service>-strip-0]   # only when StripPrefix=true and PathPrefix!=""
+    <team>-<service>-alias-1:
+      ...
+  middlewares:
+    <team>-<service>-strip-0:
+      stripPrefix:
+        prefixes: [<aliasPathPrefix0>]
+  services:
+    <team>-<service>:
+      loadBalancer:
+        servers:
+          - url: http://<team>.<service>:<port>
+```
+
+**Indexing convention**: alias router names use the alias's position in `Aliases[]` as the suffix (`-alias-<i>`). Strip middleware names follow the same convention (`-strip-<i>`) — *the same index* — so the alias→middleware mapping is 1:1 and trivially traceable. The middleware-name index is therefore *sparse*: if `Aliases[1]` has no `PathPrefix`, no `-strip-1` is emitted; the next strip middleware is `-strip-2`, not `-strip-1`. Sparse-but-stable names survive a manifest reorder of unrelated aliases without churning unrelated middleware names.
+
+### 5.3 Rule construction
+
+Helper `buildRouterRule(host, pathPrefix string) string`:
+- `pathPrefix == ""` → `Host(\`<host>\`)`
+- otherwise → `Host(\`<host>\`) && PathPrefix(\`<pathPrefix>\`)`
+
+The trailing slash on `pathPrefix` is normalized away in the manifest layer (rule V4 doesn't reject a trailing slash; the engine's `resolveAliasRoutes` does the trim) before the rule is built.
+
+### 5.4 Spec types update
+
+`internal/plugins/gateway/traefik/spec.go` `middleware` struct gains a pointer field:
+
+```go
+type middleware struct {
+    BasicAuth   *basicAuth   `yaml:"basicAuth,omitempty"`
+    StripPrefix *stripPrefix `yaml:"stripPrefix,omitempty"`   // ← NEW
+}
+
+type stripPrefix struct {
+    Prefixes []string `yaml:"prefixes"`
+}
+```
+
+### 5.5 Determinism
+
+Routers and middlewares are emitted in alias-list order (the manifest's stated order). Map keys in YAML output are sorted by `yaml.v3`'s default key-sort behavior, which matches the existing `WriteRoute` output's stability properties.
+
+---
+
+## 6. State transitions
+
+This feature is stateless. Reconciliation is implicit:
+
+| Operator action | Filesystem effect | Traefik effect |
+|---|---|---|
+| Add an alias and `shrine deploy` | App's dynamic config file is rewritten; one new router (and possibly one new middleware) appears | Traefik file watcher reloads; new address resolves |
+| Remove an alias and `shrine deploy` | App's dynamic config file is rewritten without that router/middleware | Traefik file watcher reloads; old address stops resolving |
+| `shrine teardown` for the app | Dynamic config file is deleted via existing `RemoveRoute(team, name)` | Traefik file watcher reloads; all addresses stop resolving |
+
+No new state files, no new `DeploymentStore` records.
+
+---
+
+## 7. Backward compatibility
+
+| Scenario | Behavior |
+|---|---|
+| Manifest with no `aliases` field | YAML unmarshal yields `nil` slice; engine projects no `AdditionalRoutes`; Traefik backend takes the existing single-router code path. Output byte-identical to today (SC-005). |
+| Existing `Routing.PathPrefix` on primary domain | Unchanged. No `stripPrefix` is added to the primary router (R4). |
+| Manifest with `aliases` on a host with no Traefik plugin | Manifest parses & validates. Engine `deployApplication` checks `engine.Routing != nil`; when nil, neither primary nor alias routers are written. No warning emitted (FR-010). |
+| Existing integration test fixtures | Continue to pass; no fixture edits required for non-alias scenarios. |

--- a/specs/006-routing-aliases/plan.md
+++ b/specs/006-routing-aliases/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Routing Aliases for Application Manifests
+
+**Branch**: `006-routing-aliases` | **Date**: 2026-04-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/006-routing-aliases/spec.md`
+
+## Summary
+
+Add an optional `routing.aliases` list to the `Application` manifest schema. Each alias declares a `host`, an optional `pathPrefix`, and an optional `stripPrefix` flag (default `true` when `pathPrefix` is set). The Traefik gateway plugin generates one extra router per alias in the application's dynamic config file, all pointing to the same backend service as the primary `routing.domain` router. When the Traefik plugin is inactive, aliases are parsed but silently ignored. A new pre-execution validation pass detects cross-application host+path collisions and fails the deploy with a multi-error report before any gateway config is written.
+
+The work spans three layers — manifest schema/validation, engine routing op, Traefik dynamic-config generator — plus a planner-level cross-app collision check. The change is additive to the existing primary-domain code path; existing manifests continue to produce byte-identical config (SC-005).
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (`github.com/CarlosHPlata/shrine`)
+**Primary Dependencies**: `gopkg.in/yaml.v3` (manifest parse + Traefik dynamic-config marshal); existing `github.com/CarlosHPlata/shrine/internal/{manifest,engine,plugins/gateway/traefik}` packages
+**Storage**: Files under the resolved Traefik routing directory (`<routing>/dynamic/<team>-<service>.yml`); no database
+**Testing**: `go test ./...` for unit tests (no filesystem touch — see memory note); `go test -tags integration ./tests/integration/...` for the `NewDockerSuite`-backed end-to-end gate (Constitution V)
+**Target Platform**: Linux server (homelab); single-binary CLI deployed by `shrine deploy`
+**Project Type**: CLI tool with embedded execution engine and pluggable backends
+**Performance Goals**: N/A — alias generation runs once per deploy and is bounded by manifest size (typical: ≤10 aliases per app, ≤100 apps per fleet). Generation is O(routes) and writes a single YAML file per app.
+**Constraints**: Generated dynamic config must remain byte-stable across re-deploys when the manifest is unchanged (Traefik's file watcher reloads on every write — flapping config triggers needless reloads). Alias router names must be deterministic and collision-free within a file.
+**Scale/Scope**: Single-host homelab fleet; ≤100 apps × ≤10 aliases ≈ ≤1k alias routers across all dynamic config files.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Question | Status |
+|-----------|---------------|--------|
+| I. Declarative Manifest-First | Does this feature expose new capabilities via manifest fields (not CLI flags)? | [x] Pass — adds `spec.routing.aliases[]` to the Application manifest; no new CLI flag, no env var. Validation produces multi-error reports per the existing `validateApplicationSpec` pattern. |
+| II. Kubectl-Style CLI | Do new commands follow verb-first convention and include `--dry-run`? | [x] N/A — no new commands. `shrine apply` and `shrine deploy` already support `--dry-run`; the new field flows through the existing dispatchers unchanged. |
+| III. Pluggable Backend | Is new infrastructure logic behind a backend interface (not engine core)? | [x] Pass — alias-to-router translation lives in `internal/plugins/gateway/traefik/`. The engine's `RoutingBackend` interface widens by one field on `WriteRouteOp` (a list of additional routes); engine core remains backend-agnostic and nil-backend-safe. |
+| IV. Simplicity & YAGNI | Is every abstraction justified by ≥3 concrete usages? | [x] Pass — no new types beyond `RoutingAlias` (the data the user already declares); no new interface, no factory, no service locator. Cross-app collision detection is a single helper function in the planner, not a new validator subsystem. |
+| V. Integration-Test Gate | Does this phase map to an integration test phase using `NewDockerSuite` against a real binary? | [x] Pass — adds scenarios to `tests/integration/traefik_plugin_test.go` covering: deploy app with one alias (US1), deploy app with `pathPrefix` strip and no-strip variants, deploy two colliding apps (FR-008a), deploy alias-bearing manifest with Traefik plugin disabled (US2). Tests run the real binary as a subprocess against a live Docker daemon, per Principle V. |
+| VI. Docker-Authoritative State | Does state update happen *after* Docker operations complete? | [x] N/A — this feature does not write to `DeploymentStore` or any state file. Alias config is gateway-side YAML, watched and reconciled by Traefik itself. |
+| VII. Clean Code & Readability | Is repeated logic extracted into named helpers? Are names self-documenting (no WHAT comments)? | [x] Pass — alias-rule rendering, strip-middleware naming, and collision detection are extracted to named helpers (`buildRouterRule`, `stripMiddlewareName`, `findRoutingCollisions`); validation funcs follow existing `validateApplicationSpec` style; no narrative comments planned. |
+
+> No violations to track. Complexity Tracking table omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-routing-aliases/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── manifest-schema.md   # Manifest YAML contract for routing.aliases
+└── tasks.md             # Phase 2 output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── manifest/
+│   ├── types.go              # ADD: RoutingAlias struct; Routing.Aliases field
+│   ├── validate.go           # ADD: validateRoutingAliases() called from validateApplicationSpec
+│   └── parser_test.go        # EXTEND: test parsing aliases from YAML
+├── engine/
+│   ├── backends.go           # MODIFY: WriteRouteOp gains AdditionalRoutes []AliasRoute
+│   └── engine.go             # MODIFY: deployApplication translates app.Spec.Routing.Aliases into WriteRouteOp.AdditionalRoutes
+├── planner/
+│   └── loader.go             # ADD: detectRoutingCollisions() called once before ExecuteDeploy
+└── plugins/gateway/traefik/
+    ├── routing.go            # MODIFY: WriteRoute renders N routers + 1 service + N? strip-middlewares per app
+    ├── spec.go               # MODIFY: middleware{} struct gains stripPrefix field for serialization
+    └── routing_test.go       # NEW: unit tests for multi-router YAML emission and strip-middleware shape
+
+tests/
+├── integration/
+│   └── traefik_plugin_test.go   # EXTEND: scenarios for US1, US2, FR-008a, strip vs no-strip
+└── testdata/
+    ├── hello-api-aliased.yml    # NEW: fixture manifest with one alias (used by integration scenarios)
+    └── hello-api-collision.yml  # NEW: fixture manifest that collides with hello-api.yml on host+path
+```
+
+**Structure Decision**: Single project, real paths above. The change is purely additive to four existing packages plus one new entry point in the planner. No new directories, no new modules.
+
+## Phase 0: Outline & Research
+
+Open questions distilled from Technical Context and the spec's Assumptions:
+
+1. **How does Traefik render `StripPrefix` in file-provider dynamic config?** Need the exact YAML shape for a middleware that strips one path prefix and the way to attach it to a router.
+2. **Where should cross-app collision detection live — planner, validate phase, or engine pre-flight?** The engine currently iterates steps independently; a pre-existing `ManifestSet` exists in the planner.
+3. **Is `WriteRouteOp` the right surface to widen, or should we introduce a `WriteAppRoutesOp` that takes a list?** The existing op assumes one router + one service per call.
+4. **Are `stripPrefix` and `pathPrefix` semantics on the primary domain in scope?** The spec adds `stripPrefix` only to alias entries; the existing `Routing.PathPrefix` on the primary domain has no strip flag today.
+5. **How should the alias-listing log signal (FR-012) plug into the existing observer events?**
+
+Findings will be consolidated in `research.md` (next file).
+
+## Phase 1: Design & Contracts
+
+Outputs (each generated next):
+
+- **`data-model.md`**: schema and validation rules for `RoutingAlias`, `Routing.Aliases`, and the engine-side `AliasRoute` projection. State transitions: stateless — alias entries are reconciled by Traefik's file watcher whenever the dynamic config file is rewritten or removed.
+- **`contracts/manifest-schema.md`**: the YAML contract operators write — field names, types, defaults, validation errors. This is the externally-visible interface (Constitution I: capabilities exposed via manifest).
+- **`quickstart.md`**: a 5-minute walk-through of adding one alias to an existing manifest, deploying, and verifying both addresses resolve.
+- **Agent context update**: the `<!-- SPECKIT START -->` block in `CLAUDE.md` is updated to reference this plan path.
+
+## Re-Check (Post-Design)
+
+After Phase 1 artifacts are written, re-evaluate Constitution Check. Expected outcome: still all-Pass — the design adds one struct, one slice field, one validation helper, one engine projection, one planner pre-flight check, and one Traefik-side rendering pass. No abstractions are introduced for hypothetical future gateway plugins; the manifest field is plugin-agnostic only because it's plain data, not because of any new interface.

--- a/specs/006-routing-aliases/quickstart.md
+++ b/specs/006-routing-aliases/quickstart.md
@@ -1,0 +1,130 @@
+# Quickstart: Routing Aliases
+
+**Feature**: 006-routing-aliases
+**Audience**: operators with an existing Shrine deployment using the Traefik gateway plugin
+
+This walk-through adds a second hostname to an already-running application — no second manifest, no extra commands.
+
+---
+
+## Prerequisites
+
+- A working Shrine deployment with the Traefik gateway plugin enabled (`config.yml` has a `traefik:` block with at least `routingDir`).
+- An existing Application manifest already reachable at its primary `routing.domain`.
+- DNS or `/etc/hosts` entries for any new alias hostnames you plan to add — Shrine does not provision these for you.
+
+---
+
+## 1. Edit the manifest
+
+Open the manifest for the application you want to expose at a second address. Add an `aliases` list under `spec.routing`:
+
+```yaml
+# before
+spec:
+  routing:
+    domain: finances.home.lab
+```
+
+```yaml
+# after
+spec:
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+```
+
+The default `stripPrefix: true` means requests to `gateway.tail9a6ddb.ts.net/finances/api/balance` reach the backend as `/api/balance` — the same way `finances.home.lab/api/balance` already does. No backend changes needed.
+
+---
+
+## 2. Deploy
+
+```sh
+shrine deploy
+```
+
+In the deploy output, look for the `routing.configure` info event for your app:
+
+```text
+routing.configure status=info domain=finances.home.lab port=8080 aliases=gateway.tail9a6ddb.ts.net+/finances
+```
+
+The `aliases` field confirms which alias addresses are now published.
+
+---
+
+## 3. Verify
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' http://finances.home.lab/api/health
+# 200
+
+curl -s -o /dev/null -w '%{http_code}\n' http://gateway.tail9a6ddb.ts.net/finances/api/health
+# 200
+```
+
+Both addresses hit the same backend container.
+
+You can also inspect the generated dynamic config:
+
+```sh
+cat <routingDir>/dynamic/<team>-<app>.yml
+```
+
+You should see two routers (`<team>-<app>` and `<team>-<app>-alias-0`), one shared `services.<team>-<app>` block, and one `middlewares.<team>-<app>-strip-0` block with `prefixes: [/finances]`.
+
+---
+
+## 4. Add more aliases
+
+Append more entries to the same list. Each one becomes its own router. To omit prefix stripping:
+
+```yaml
+spec:
+  routing:
+    domain: notes.home.lab
+    aliases:
+      - host: lan.home.lab
+        # no pathPrefix → matches all paths on lan.home.lab
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /notes-raw
+        stripPrefix: false
+        # backend receives /notes-raw/... unchanged
+```
+
+Re-run `shrine deploy`. The dynamic config file is rewritten with the new routers; Traefik's file watcher picks the change up automatically.
+
+---
+
+## 5. Remove an alias
+
+Delete the entry from the manifest and `shrine deploy` again. The alias's router (and strip middleware, if any) disappears from the dynamic config; the address stops resolving on the next Traefik reload — typically within a second.
+
+---
+
+## Common errors
+
+| You wrote | You'll see |
+|---|---|
+| `aliases:` without a `host:` field | `spec.routing.aliases[0].host is required` |
+| `pathPrefix: finances` (no leading `/`) | `spec.routing.aliases[0].pathPrefix "finances" must start with "/"` |
+| `aliases:` but `domain:` is empty | `spec.routing.aliases is set but spec.routing.domain is empty` |
+| Same `host`+`pathPrefix` declared by two different apps in your fleet | `routing collision: host="..." pathPrefix="..." declared by "team-a/x" and "team-b/y"` — fix one of the manifests; the deploy is aborted before any gateway config is touched |
+
+---
+
+## Rolling back
+
+To revert to the pre-aliases state, delete the `aliases:` field and re-deploy. Shrine writes a dynamic config file containing only the primary-domain router — byte-identical to what pre-feature releases produced for the same manifest.
+
+---
+
+## What this feature does *not* do
+
+- Provision DNS for alias hostnames.
+- Issue TLS certificates per-alias. Aliases inherit the entry-point and TLS configuration of the primary domain; if you need a different cert for a different host, that is a separate concern.
+- Apply per-alias middleware (auth, rate limit, etc.). Aliases share the primary domain's middleware chain.
+- Affect any non-Traefik gateway plugin. Aliases are parsed but silently ignored on hosts where the Traefik plugin is not active.

--- a/specs/006-routing-aliases/research.md
+++ b/specs/006-routing-aliases/research.md
@@ -1,0 +1,119 @@
+# Phase 0 Research: Routing Aliases
+
+**Feature**: 006-routing-aliases
+**Date**: 2026-04-30
+
+This document resolves the open questions captured in `plan.md` Phase 0 with concrete decisions, rationales, and rejected alternatives. The decisions feed directly into the Phase 1 data model and contracts.
+
+---
+
+## R1. Traefik `StripPrefix` middleware shape (file provider)
+
+**Decision**: Render an in-file middleware named `<team>-<service>-strip-<index>` of kind `stripPrefix` with `prefixes: [<pathPrefix>]`, and attach it to the alias router via `middlewares: [<name>]`.
+
+```yaml
+http:
+  routers:
+    team-a-hello-api-alias-0:
+      rule: "Host(`gateway.tail9a6ddb.ts.net`) && PathPrefix(`/finances`)"
+      service: team-a-hello-api
+      entryPoints: [web]
+      middlewares: [team-a-hello-api-strip-0]
+  middlewares:
+    team-a-hello-api-strip-0:
+      stripPrefix:
+        prefixes: [/finances]
+  services:
+    team-a-hello-api:
+      loadBalancer:
+        servers:
+          - url: http://team-a.hello-api:8080
+```
+
+**Rationale**:
+- File-provider middlewares live in the same dynamic file as the router that references them; cross-file references work but make removal logic harder to reason about.
+- Naming `<team>-<service>-strip-<index>` mirrors the existing `<team>-<service>` router/service naming convention in `routing.go`, gives a deterministic byte-stable output, and makes orphan middlewares trivially detectable in test assertions.
+- One middleware per alias-with-strip is fine even when prefixes coincide — the per-alias index keeps router → middleware wiring 1:1, which we audit in unit tests. The `prefixes` list field is one element each; we do not coalesce middlewares.
+
+**Alternatives rejected**:
+- *Reuse a single `strip` middleware with all prefixes*: tempting but breaks 1:1 router→middleware traceability and would require diffing the prefix list on re-deploy. YAGNI.
+- *Use Traefik labels via Docker provider*: out of scope — Shrine's Traefik plugin uses the file provider exclusively, and the constitution forbids backend-specific logic in the engine core.
+
+---
+
+## R2. Where cross-app collision detection lives
+
+**Decision**: A new function `planner.detectRoutingCollisions(set *ManifestSet) error` runs once, immediately after `Load()`/`Plan()` constructs the `ManifestSet` and before the engine `ExecuteDeploy` call. It returns a multi-error (list of `(host, pathPrefix, app1, app2)` tuples) using the same `\n- ` delimited format as `manifest.Validate`.
+
+**Rationale**:
+- Constitution I requires multi-error reports — a per-app validate pass cannot see siblings, so detection must be set-level.
+- Running it in the planner (where the full manifest set already exists) avoids a separate "collision validator" subsystem (Constitution IV — YAGNI). The planner is also where teardown/dependency analysis already happens, so this is its natural neighborhood.
+- Failing before `ExecuteDeploy` means zero gateway-side side effects on collision (FR-008a: "MUST NOT write or update gateway config for either side of the conflict").
+
+**Alternatives rejected**:
+- *Detect inside the Traefik plugin's `WriteRoute`*: backend-specific; would mean other future routing backends each re-implement collision detection. Constitution III: backends should not own cross-app validation.
+- *Detect lazily during engine `deployApplication` via a registry*: works, but the first colliding app would already have its router written before the second one is checked. This violates FR-008a's "MUST NOT write...until the operator resolves it."
+- *Detect at manifest parse time*: a single manifest file rarely contains both colliding apps. The collision is a set-level invariant, not a per-manifest one.
+
+---
+
+## R3. Engine surface: widen `WriteRouteOp` vs new `WriteAppRoutesOp`
+
+**Decision**: Widen `engine.WriteRouteOp` with a single new field `AdditionalRoutes []AliasRoute` (where `AliasRoute = struct{ Host, PathPrefix string; StripPrefix bool }`). The primary domain stays in `Domain`/`PathPrefix`/`Service*` fields as today; aliases ride along in the new slice. The Traefik backend renders all of them into a single dynamic config file per app.
+
+**Rationale**:
+- Backwards-compatible: callers that don't set `AdditionalRoutes` get exactly today's behavior — meeting SC-005 (zero behavioral change for existing manifests).
+- One file per app continues to map 1:1 with `RemoveRoute(team, host)` cleanup semantics; the existing `routeFileName(team, name)` stays the unique key. No new remove op needed.
+- A single op call is the natural unit because all routers share one backend service; splitting into multiple `WriteRoute` calls would require the backend to merge dynamic-config files, which is more complex and error-prone.
+- "Three concrete usages" rule (Constitution IV): `AliasRoute` has only one usage today (Traefik plugin), but it's plain data — not an abstraction. Adding a field to a struct is not an abstraction violation.
+
+**Alternatives rejected**:
+- *New `WriteAppRoutesOp` taking a list of routes*: cleaner type-theoretically but doubles the backend interface surface area. The `RoutingBackend` interface today has two methods (`WriteRoute`, `RemoveRoute`); adding a third (or replacing `WriteRoute`) would force the dry-run/mock backends used in tests to grow as well, for marginal gain.
+- *Per-alias `WriteRoute` calls with the backend internally merging files*: violates the "one write = one observable side effect" pattern the existing engine follows; harder to reason about partial-failure semantics if the second alias fails after the first wrote a file.
+
+---
+
+## R4. Is `stripPrefix` retroactively added to the primary `routing.domain`?
+
+**Decision**: No. The existing `Routing.PathPrefix` on the primary domain keeps its current behavior (no strip — backend sees the full path). `stripPrefix` is added only to alias entries. If operators eventually need strip on the primary, that is a follow-up feature with its own spec.
+
+**Rationale**:
+- Spec scope: the user's input and the clarification session both describe `stripPrefix` as an alias-entry field. Touching primary-domain semantics retroactively is a behavior change to existing manifests, violating SC-005.
+- The asymmetry is documented explicitly in the data model and the manifest contract so operators are not surprised. In practice, the primary domain typically uses no `pathPrefix`, so the asymmetry is invisible to the common case.
+
+**Alternatives rejected**:
+- *Apply default `stripPrefix: true` to the primary domain too*: would silently change behavior for any existing manifest using `routing.pathPrefix`. Hard rejection — SC-005 is non-negotiable.
+- *Add `stripPrefix` to the primary domain in a follow-up but document parity here*: speculative; do not design for hypothetical future requirements (Constitution IV).
+
+---
+
+## R5. Observer event for alias-listing log (FR-012)
+
+**Decision**: Reuse the existing `routing.configure` event with a new `aliases` field carrying a comma-separated list of `host[+pathPrefix]` strings (sorted lexically for byte-stable output). When the app has no aliases, the field is omitted. No new event name is introduced.
+
+```text
+routing.configure status=info domain=finances.home.lab port=8080 aliases=gateway.tail9a6ddb.ts.net+/finances
+```
+
+**Rationale**:
+- Reusing the event name keeps the deploy log shape stable and reduces test churn (existing scenarios don't grow new event-name expectations).
+- The field is optional/omitted for alias-less apps, so existing log assertions (e.g., `engineintegration` tests that verify deploy events) keep passing without modification.
+- Sorting the alias list before joining gives deterministic output, which both humans and integration test assertions can rely on.
+
+**Alternatives rejected**:
+- *New `routing.alias.publish` event per alias*: would multiply events linearly with alias count and force every consumer (terminal logger, JSON output, integration tests) to learn a new event name. Marginal benefit.
+- *Log the strip flag in the field*: noise — operators care about addresses, not transformation details. The flag is observable in the generated config file and is asserted in unit tests.
+
+---
+
+## Summary of decisions
+
+| ID | Question | Decision |
+|----|----------|----------|
+| R1 | StripPrefix YAML shape | `stripPrefix` middleware named `<team>-<service>-strip-<index>`, attached via `middlewares:` on the router |
+| R2 | Where collision check lives | `planner.detectRoutingCollisions(set)` called once before `ExecuteDeploy`; multi-error report; no gateway side effects on failure |
+| R3 | Engine surface for aliases | Widen `WriteRouteOp` with `AdditionalRoutes []AliasRoute`; one op call per app, one dynamic config file per app |
+| R4 | `stripPrefix` on primary domain | No — alias-only; primary keeps today's no-strip semantics |
+| R5 | Alias log signal | Reuse `routing.configure`, add optional `aliases` field with sorted comma-joined list |
+
+All Phase 0 unknowns resolved. Proceeding to Phase 1.

--- a/specs/006-routing-aliases/spec.md
+++ b/specs/006-routing-aliases/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Routing Aliases for Application Manifests
+
+**Feature Branch**: `006-routing-aliases`  
+**Created**: 2026-04-30  
+**Status**: Draft  
+**Input**: User description: "Issue 1 — Feature: routing.aliases in application manifests. Applications can only declare a single routing.domain. Add a routing.aliases field that accepts additional host + optional pathPrefix combinations. When the Traefik plugin is active, each alias generates an additional router in the dynamic config file pointing to the same backend service. If the plugin is inactive, aliases are parsed but silently ignored."
+
+## Clarifications
+
+### Session 2026-04-30
+
+- Q: When an alias has `pathPrefix` set, should the prefix be stripped before forwarding to the backend or passed through unchanged? → A: Make stripping configurable per alias via a `stripPrefix` boolean field (default `true`); the same backend then works behind both root and prefixed mounts without code changes, while operators can opt out for backends that expect the prefix on the wire.
+- Q: How should Shrine handle a cross-application collision where two different applications would produce routers for the same host+path combination (one app's primary or alias matches another app's primary or alias)? → A: Fail the deploy with a clear error naming both applications and the colliding host+path; operators must rename or remove the colliding alias before deploy succeeds. Silent gateway tie-breaking is exactly the kind of ghost-in-the-system bug that erodes operator trust, and cross-app collisions are almost always a manifest mistake.
+- Q: How strict should `pathPrefix` validation be on shape (leading slash, trailing slash, empty)? → A: Require a leading `/`; reject empty string and bare `/`; ignore trailing slash by normalizing it away internally so `/finances` and `/finances/` behave identically. Loud, early failure on the most common operator mistake (missing `/`) without churning over cosmetic differences.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Expose an Application Under Multiple Hostnames (Priority: P1)
+
+An operator runs an application — say, a personal-finance app — that they reach today at `finances.home.lab` from inside their LAN. They also want to reach the same app from outside the LAN over their Tailscale tailnet, at `gateway.tail9a6ddb.ts.net/finances`. Today they must either give up one of the two access paths or stand up a second application manifest pointing at the same image, which doubles maintenance and breaks single-instance assumptions. With routing aliases, they declare the additional host (and optional path prefix) under a new `routing.aliases` list in the same manifest, deploy once, and reach the running app at every declared address.
+
+```yaml
+spec:
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+```
+
+**Why this priority**: This is the entire point of the feature. Without it, operators with multi-network setups (LAN + Tailscale, internal + public, dev + canary hostname) cannot expose a single app at multiple addresses without duplicating manifests. P1 because nothing else in this feature delivers value on its own.
+
+**Independent Test**: Deploy an application with `routing.domain: finances.home.lab` and one alias `host: gateway.tail9a6ddb.ts.net, pathPrefix: /finances`. With the Traefik gateway plugin enabled, send an HTTP request to each address and verify both reach the same running container and return identical responses.
+
+**Acceptance Scenarios**:
+
+1. **Given** an application manifest declaring `routing.domain` plus one alias with only a `host`, **When** the operator runs `shrine deploy` with the Traefik gateway plugin active, **Then** the app is reachable at both the primary domain and the alias host, and both routes resolve to the same backend service.
+2. **Given** an application manifest declaring `routing.domain` plus one alias with both `host` and `pathPrefix`, **When** the operator runs `shrine deploy` with the Traefik gateway plugin active, **Then** the app is reachable at the primary domain (root path) and at the alias host under the declared path prefix, and both reach the same backend.
+3. **Given** an application manifest declaring `routing.domain` plus multiple aliases (e.g., two or more entries), **When** the operator runs `shrine deploy` with the Traefik gateway plugin active, **Then** the app is reachable at the primary domain and at every alias address, all resolving to the same backend.
+
+---
+
+### User Story 2 - Aliases Are Inert When the Traefik Plugin Is Not Active (Priority: P2)
+
+An operator authoring or sharing manifests across hosts may include `routing.aliases` even when the deploying host has no Traefik gateway plugin enabled. Shrine accepts the manifest, parses the aliases, and proceeds with the deploy without emitting an error or warning. Aliases simply have no effect on hosts where no gateway plugin is consuming them — the primary `routing.domain` continues to behave exactly as it does today.
+
+**Why this priority**: This keeps manifests portable. Operators can keep one manifest in source control and deploy it to hosts with different gateway setups without conditionalizing the file. P2 because it does not deliver new functionality on its own — it preserves manifest portability so P1 is usable in mixed environments.
+
+**Independent Test**: Deploy an application manifest containing `routing.aliases` to a host where the Traefik gateway plugin is **not** enabled. Verify the deploy completes successfully, no error or warning about aliases is emitted, and the application's existing routing (whatever the host's setup provides for `routing.domain`) is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a manifest with `routing.aliases` populated, **When** the operator runs `shrine deploy` on a host where no Traefik gateway plugin is enabled, **Then** the deploy completes successfully and Shrine does not emit an error related to aliases.
+2. **Given** a manifest with `routing.aliases` populated, **When** the same manifest is deployed on a host with the Traefik plugin and another host without it, **Then** both deploys succeed; alias routes appear only on the Traefik-enabled host.
+
+---
+
+### Edge Cases
+
+- **`aliases` field is omitted or is an empty list**: Behavior is identical to today — only the primary `routing.domain` is published. No empty-list handling is required from the operator.
+- **An alias has only `host` (no `pathPrefix`)**: The alias route matches the alias host on every path (root included), like the primary domain does today.
+- **An alias has both `host` and `pathPrefix`**: The alias route matches only requests to the alias host whose path is the prefix or below it. Requests to the alias host outside the prefix are not handled by this app's alias route. By default the prefix is stripped before the request reaches the backend (so a backend that serves at root keeps working unchanged); operators who run a backend that expects the prefix on the wire can set `stripPrefix: false` on the alias entry.
+- **An alias sets `stripPrefix` without setting `pathPrefix`**: The `stripPrefix` value has no effect (there is no prefix to strip). The deploy succeeds; Shrine SHOULD NOT treat this as an error since the field is harmless when no prefix is declared.
+- **An alias declares the same `host`+`pathPrefix` as `routing.domain` (or as another alias on the same application)**: The manifest is invalid. The deploy fails with a clear error that names the application and the duplicate alias index, so the operator can remove the redundant entry. (When the alias shares only the host but not the path prefix, no duplicate exists and the deploy succeeds — see the next bullet.)
+- **Two aliases share the same `host` with different `pathPrefix` values**: Both aliases produce distinct routers and both are reachable. This is a supported configuration.
+- **An alias has an empty or missing `host`**: The manifest is invalid. The deploy fails with a clear error naming the application and the offending alias entry; no partial routing config is written.
+- **`aliases` is present but the application has no `routing.domain`**: The manifest is invalid. Aliases extend a primary domain — they do not replace one. The deploy fails with a clear error.
+- **Alias `host` or `pathPrefix` contains characters that would corrupt the generated gateway config** (e.g., spaces, control characters): The manifest is invalid and the deploy fails with a clear error identifying the bad value. Validation does not attempt full RFC compliance — it rejects the obviously-malformed values that would break the gateway router rule.
+- **`pathPrefix` is present but does not start with `/`, is empty, or is just `/`**: The manifest is invalid and the deploy fails with a clear error naming the application and the offending value. A trailing `/` (e.g., `/finances/`) is accepted and normalized internally to its no-trailing-slash form so two cosmetically different manifests produce identical gateway behavior.
+- **Operator removes or changes an alias and re-deploys**: The router(s) corresponding to the removed alias are cleaned up the same way Shrine already cleans up routes for the primary domain when a manifest changes.
+- **A gateway plugin other than Traefik is active**: Aliases are still parsed but silently ignored unless that plugin chooses to consume them. This spec only defines Traefik behavior.
+- **Two different applications declare a colliding host+path** (one app's primary or alias matches another app's primary or alias): The deploy fails with a clear error that names both applications and the colliding host+path. No gateway config is updated for the conflicting pair until the operator removes or renames one side; other applications in the same deploy that are unaffected by the conflict are not punished by the failure (i.e., the validation error identifies exactly which applications are in conflict).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The application manifest schema MUST accept an optional `routing.aliases` field that is a list of zero or more alias entries.
+- **FR-002**: Each alias entry MUST declare a `host` (required, non-empty string), MAY declare a `pathPrefix` (optional string), and MAY declare a `stripPrefix` (optional boolean; defaults to `true` when `pathPrefix` is set; ignored when `pathPrefix` is absent).
+- **FR-003**: Manifest parsing MUST reject as invalid any alias entry that omits `host` or sets `host` to an empty string, surfacing a clear error that names the offending application and entry.
+- **FR-004**: Manifest parsing MUST reject any manifest that declares `routing.aliases` without a populated `routing.domain`, with an error that names the application.
+- **FR-005**: Manifest parsing MUST reject `host` or `pathPrefix` values that contain characters that would corrupt a generated gateway router rule (e.g., spaces, control characters), with an error that names the offending value.
+- **FR-005a**: When `pathPrefix` is present, manifest parsing MUST reject any value that does not start with `/`, that is the empty string, or that consists only of `/`, with an error that names the application and the offending value. A trailing `/` is permitted and MUST be normalized away internally before the alias router is generated, so `/finances` and `/finances/` produce identical routers.
+- **FR-006**: When the Traefik gateway plugin is active and an application declares one or more aliases, Shrine MUST generate, in the application's dynamic Traefik config file, one additional router per alias entry that points to the same backend service as the primary-domain router.
+- **FR-007**: Alias routers MUST match the alias `host` and, when `pathPrefix` is set, match only requests whose path is at or below that prefix; when `pathPrefix` is unset, alias routers match the alias host on all paths (matching the primary-domain behavior).
+- **FR-007a**: When an alias has a non-empty `pathPrefix`, the alias router MUST strip that prefix from the request path before forwarding to the backend by default (`stripPrefix: true`), so backends that serve at root can be reached unchanged behind a prefixed alias. When the operator explicitly sets `stripPrefix: false`, the alias router MUST forward the original path (prefix included) to the backend.
+- **FR-008**: When alias entries would produce a router identical (same host+path matching) to one already produced by the primary domain or by another alias on the same application, manifest validation MUST fail with a clear error that names the application and the duplicate alias index. Shrine MUST NOT silently dedup such entries; loud failure matches the FR-008a cross-application stance and avoids the operator wondering why their second alias never resolved.
+- **FR-008a**: When two different applications would produce routers for the same host+path combination (whether via primary domain or alias on either side), Shrine MUST fail the deploy with a clear error that names both applications and the colliding host+path. Shrine MUST NOT write or update gateway config for either side of the conflict until the operator resolves it.
+- **FR-009**: Alias routers MUST be removed from the gateway dynamic config when the alias is removed from the manifest and the application is re-deployed, the same way primary-domain routers are removed today when `routing.domain` changes.
+- **FR-010**: When no gateway plugin is active, or when a gateway plugin other than Traefik is active and does not consume aliases, Shrine MUST parse `routing.aliases` without error and MUST NOT emit a warning; aliases simply have no effect on routing for that deploy.
+- **FR-011**: Manifests that omit `routing.aliases` entirely MUST behave exactly as they do today; this feature MUST NOT change behavior for any existing manifest.
+- **FR-012**: The deploy log MUST include an observable signal (info-level or equivalent) listing the alias addresses published for each application when the Traefik plugin is active, so operators can confirm aliases took effect without inspecting generated config files.
+
+### Key Entities
+
+- **Routing.Aliases (manifest field)**: An optional list on an application's `routing` block. Each list entry is an alias declaring an additional address (host, optional path prefix) at which the application should be reachable. Aliases extend, never replace, the primary `routing.domain`.
+- **Alias entry**: A triple of `host` (required, non-empty hostname), `pathPrefix` (optional URL path prefix), and `stripPrefix` (optional boolean; defaults to `true` when `pathPrefix` is set, no-op when not). Conceptually equivalent to "publish this app at this additional address" without standing up a second application. The `stripPrefix` flag controls whether the matched prefix is removed from the request path before the backend sees it.
+- **Alias router (gateway dynamic config)**: An entry in the application's generated dynamic config that matches an alias's host (and optional path prefix) and forwards to the same backend service as the primary-domain router. One alias entry produces one alias router unless deduplication collapses it with an existing router.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator who needs to expose an existing application at a second hostname can do so by adding a single `aliases` entry to the existing manifest — no second manifest, no duplicated image reference, no extra commands beyond a normal `shrine deploy`.
+- **SC-002**: After deploying a manifest with N aliases, the application is reachable at the primary `routing.domain` and at all N alias addresses, with 100% of requests to those addresses landing on the same backend instance.
+- **SC-003**: The same manifest can be deployed to a host with the Traefik plugin active and to a host without it; both deploys complete successfully with zero alias-related warnings or errors on the non-Traefik host.
+- **SC-004**: Removing an alias from the manifest and re-deploying removes the corresponding route from the gateway within one deploy cycle — the alias address stops resolving without operator intervention beyond `shrine deploy`.
+- **SC-005**: Existing applications (manifests with no `aliases` field) experience zero behavioral change after this feature ships — first-deploy and re-deploy produce byte-identical primary-domain routing config compared to the prior release.
+
+## Assumptions
+
+- The Traefik gateway plugin is the only gateway plugin in scope for this feature. Other gateway plugins, if any are added later, will define their own alias-consumption semantics; the manifest field is plugin-agnostic and stable.
+- "Active" means the operator has enabled the Traefik gateway plugin in Shrine's plugin configuration on the deploying host. The presence or absence of a Traefik container on the host is not directly checked — Shrine's existing plugin-active determination is reused as-is.
+- The "same backend service" an alias router points to is the same backend the primary-domain router for the application already points to; alias generation reuses, not redefines, that backend wiring.
+- Validation of `host` and `pathPrefix` rejects empty/whitespace/control-character values (FR-005) and shape errors on `pathPrefix` (FR-005a: must start with `/`, may not be empty or bare `/`, trailing `/` normalized away) — full RFC 1035 hostname or RFC 3986 path validation is out of scope. An operator can still write a syntactically permissive but semantically wrong host (e.g., a typo) and the deploy will succeed; the failure surfaces when DNS does not resolve, which is acceptable because Shrine cannot meaningfully tell typos from valid private hostnames.
+- The cross-application collision check (FR-008a) treats the primary `routing.domain` and every alias `host`+`pathPrefix` on equal footing — a collision between an alias on app A and the primary domain on app B (or vice versa, or two primaries, or two aliases) all fail the deploy with the same error shape. This is broader than "alias-introduced collisions only," and it intentionally hardens primary-vs-primary collisions that may have been silently mis-routing in earlier releases.
+- Aliases inherit TLS, middleware, and entry-point selection from the primary domain's existing configuration. This feature does not introduce per-alias TLS or middleware tuning; if an operator needs different TLS/middleware on a different host, that is out of scope for v1 and may be added later as additional alias-entry fields.
+- This feature does not introduce a separate flag, env var, or migration. Existing manifests are unaffected; the new field is additive and optional.
+- The "silently ignored" behavior on non-Traefik hosts is intentional, not a temporary state: it is what makes the manifest portable. Operators wanting an audit signal of "this host did not honor the aliases" should consult their gateway plugin's own deploy log; Shrine itself MUST NOT warn about a field that is simply not consumed by the active gateway.

--- a/specs/006-routing-aliases/tasks.md
+++ b/specs/006-routing-aliases/tasks.md
@@ -1,0 +1,215 @@
+---
+description: "Task list for feature 006-routing-aliases"
+---
+
+# Tasks: Routing Aliases for Application Manifests
+
+**Input**: Design documents from `/specs/006-routing-aliases/`
+**Prerequisites**: plan.md (✓), spec.md (✓), research.md (✓), data-model.md (✓), contracts/manifest-schema.md (✓)
+
+**Tests**: Constitution V mandates an integration-test gate via `tests/integration/` and TDD ordering ("integration test files are created before the implementation code"). Test tasks are therefore included and ordered before the implementation they cover.
+
+**Organization**: Tasks are grouped by user story so US1 (Traefik-active aliases — the MVP) can ship independently of US2 (plugin-inactive portability).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: User story label (US1, US2). Setup, Foundational, and Polish tasks have no story label.
+- File paths in every implementation task are absolute-relative to repo root.
+
+## Path Conventions
+
+Single Go project, repo root = `/root/projects/shrine/`. Module path is `github.com/CarlosHPlata/shrine`. Source under `internal/`, tests under `tests/integration/` (real-binary, build-tagged) and adjacent `_test.go` files (unit). Test fixtures under `tests/testdata/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add the YAML test fixtures that integration scenarios in both US1 and US2 will consume. Fixtures are pure data; they do not depend on any code change.
+
+- [X] T001 [P] Create fixture `tests/testdata/hello-api-aliased.yml` — clone of `hello-api.yml` with `spec.routing.aliases` containing one entry (`host: gateway.tail9a6ddb.ts.net`, `pathPrefix: /finances`, `stripPrefix` omitted so default `true` applies).
+- [X] T002 [P] Create fixture `tests/testdata/hello-api-noprefix-alias.yml` — clone of `hello-api.yml` with one alias having only `host: lan.home.lab` (no `pathPrefix`, no `stripPrefix`) for the host-only acceptance scenario.
+- [X] T003 [P] Create fixture `tests/testdata/hello-api-multi-alias.yml` — clone of `hello-api.yml` with three aliases: one host-only, one host+pathPrefix (default strip), one host+pathPrefix+stripPrefix:false. Used for the multi-alias and no-strip scenarios.
+- [X] T004 [P] Create fixture `tests/testdata/hello-api-collision.yml` — second Application manifest under a different `metadata.name` and `metadata.owner` whose `spec.routing.domain` is exactly the primary domain of `hello-api.yml` (collision target for FR-008a).
+
+**Checkpoint**: Fixtures exist on disk. No Go code touched yet.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Manifest schema + validation that *both* user stories rely on. US1 needs aliases parsed and routed; US2 needs aliases parsed and silently inert. The schema, the YAML round-trip, and same-app validation rules (V1–V7) are therefore foundational.
+
+**⚠️ CRITICAL**: No US1 or US2 task can begin until this phase is complete. Until `RoutingAlias` is a real Go type, every downstream package fails to compile.
+
+- [X] T005 Add `RoutingAlias` struct (fields: `Host string`, `PathPrefix string`, `StripPrefix *bool`) and `Aliases []RoutingAlias` field on the `Routing` struct in `internal/manifest/types.go`. Match the YAML tags spelled out in `data-model.md` §1.
+- [X] T006 Add helper `validateRoutingAliases(routing Routing) []string` in `internal/manifest/validate.go` implementing rules V1–V7 from `data-model.md` §2 (cross-reference table for error message shapes); call it from `validateApplicationSpec` so its messages join the existing multi-error report.
+- [X] T007 [P] Extend `internal/manifest/parser_test.go` with a sub-test that loads `tests/testdata/hello-api-aliased.yml` and asserts `app.Spec.Routing.Aliases` contains exactly one entry with the expected `Host`, `PathPrefix`, and a non-nil `StripPrefix` pointing at `true` only when the YAML set it explicitly (here it should be nil — default-applied later by the engine).
+- [X] T008 [P] Add a new `internal/manifest/validate_test.go` table-driven test (or extend the existing one) covering the negative cases for each of V1–V7, asserting the exact error substrings from `contracts/manifest-schema.md` ("Validation errors" table).
+
+**Checkpoint**: `go test ./internal/manifest/...` passes. Manifest with `aliases` round-trips through parse + validate; bad alias manifests produce the documented multi-error reports. The codebase compiles. US1 and US2 can now branch in parallel.
+
+---
+
+## Phase 3: User Story 1 — Expose an Application Under Multiple Hostnames (Priority: P1) 🎯 MVP
+
+**Goal**: With the Traefik gateway plugin active, a manifest with `routing.aliases` produces additional routers in the app's dynamic config file, all forwarding to the same backend service. Cross-app host+path collisions fail the deploy before any gateway file is written.
+
+**Independent Test**: Deploy `tests/testdata/hello-api-aliased.yml` against a host with the Traefik plugin enabled. `curl http://hello-api.home.lab/health` and `curl http://gateway.tail9a6ddb.ts.net/finances/health` both reach the same backend container. Re-deploying after adding `tests/testdata/hello-api-collision.yml` to the manifest set fails with a clear error and leaves the gateway dynamic config unchanged.
+
+### Tests for User Story 1 (TDD — write FIRST, ensure they FAIL before T015–T024)
+
+> Per Constitution V, integration tests run the real `shrine` binary as a subprocess against a live Docker daemon via `NewDockerSuite`. New scenarios are added to the existing `tests/integration/traefik_plugin_test.go` (same file as the Traefik plugin's other end-to-end coverage) so they share the harness setup.
+
+- [X] T009 [US1] `should publish alias router for a host-only alias` in `tests/integration/traefik_plugin_test.go`.
+- [X] T010 [US1] `should publish alias router with default-strip middleware for path-prefixed alias` in `tests/integration/traefik_plugin_test.go`.
+- [X] T011 [US1] `should publish multiple alias routers with sparse strip indexing` in `tests/integration/traefik_plugin_test.go`.
+- [X] T012 [US1] `should fail deploy when two applications collide on host+pathPrefix` in `tests/integration/traefik_plugin_test.go`.
+- [X] T013 [US1] `should reach backend through both primary and alias addresses` (config-level shared-service assertion; live `curl` skipped — no docker-exec primitive in harness) in `tests/integration/traefik_plugin_test.go`.
+- [X] T014 [US1] `should include aliases field in routing.configure log signal` in `tests/integration/traefik_plugin_test.go`.
+- [X] T014a [US1] `should drop alias routers when alias is removed and re-deployed` in `tests/integration/traefik_plugin_test.go`; uses `traefik-alias-removed/` fixture for the second deploy.
+
+### Implementation for User Story 1
+
+- [X] T015 [P] [US1] Add `stripPrefix` (struct: `Prefixes []string`) and a pointer field `StripPrefix *stripPrefix` on `middleware` in `internal/plugins/gateway/traefik/spec.go`. Match the YAML shape in `research.md` R1.
+- [X] T016 [P] [US1] Add `AliasRoute` struct (fields: `Host string`, `PathPrefix string`, `StripPrefix bool`) and `AdditionalRoutes []AliasRoute` field on `WriteRouteOp` in `internal/engine/backends.go`.
+- [X] T017 [US1] Add `resolveAliasRoutes(aliases []manifest.RoutingAlias) []engine.AliasRoute` in `internal/engine/engine.go` — applies the default-strip rule and trims the trailing `/` from `PathPrefix` for byte-stable rule output.
+- [X] T018 [US1] Extend the `routing.configure` observer event in `internal/engine/engine.go` to include an `aliases` field — sorted, comma-joined `host[+pathPrefix]` strings — gated on both alias-list non-empty and `engine.Routing != nil`.
+- [X] T019 [US1] Add helper `buildRouterRule(host, pathPrefix string) string` in `internal/plugins/gateway/traefik/routing.go`.
+- [X] T020 [US1] Add helper `stripMiddlewareName(team, service string, aliasIndex int) string` in `internal/plugins/gateway/traefik/routing.go`.
+- [X] T021 [US1] Rewrite `WriteRoute` in `internal/plugins/gateway/traefik/routing.go` to render N+1 routers, sparse strip middlewares, and one shared service per app.
+- [X] T022 [P] [US1] Add new file `internal/planner/collisions.go` with `DetectRoutingCollisions(set *ManifestSet) error`.
+- [X] T023 [US1] Wire `DetectRoutingCollisions` into the deploy pipeline in `internal/handler/deploy.go`, gated on `engine.Routing != nil`.
+- [X] T024 [P] [US1] Add unit test file `internal/plugins/gateway/traefik/routing_test.go` (filesystem-free via `writeFileFn`/`mkdirAllFn` indirection).
+- [X] T025 [P] [US1] Add unit tests for `resolveAliasRoutes` in `internal/engine/engine_aliases_test.go`.
+- [X] T026 [P] [US1] Add unit tests for `DetectRoutingCollisions` in `internal/planner/collisions_test.go`.
+
+**Checkpoint**: All US1 integration tests pass against a live Docker daemon. The MVP is shippable.
+
+---
+
+## Phase 4: User Story 2 — Aliases Are Inert When the Traefik Plugin Is Not Active (Priority: P2)
+
+**Goal**: A manifest containing `routing.aliases` deploys cleanly on a host where no Traefik gateway plugin is enabled, with no errors, no warnings, and no alias-related side effects.
+
+**Independent Test**: Deploy `tests/testdata/hello-api-aliased.yml` against a Shrine config that omits the `traefik:` plugin block. The deploy succeeds, no `<routingDir>/dynamic/` is created, and stdout/stderr contain no occurrence of the substrings "alias", "warning", or "ignored" — the alias is parsed and forgotten without comment.
+
+> Most of US2 falls out for free from US1's design: `engine.Routing` is `nil` on a no-plugin host, the existing nil-check in `deployApplication` already skips routing-backend calls, and the collision check in T023 is gated on the same condition. US2's value is *evidence* of inertness via dedicated integration coverage — the no-op behavior must be tested, not assumed.
+
+### Tests for User Story 2 (TDD)
+
+- [X] T027 [US2] `should accept alias manifest silently when traefik plugin disabled` in `tests/integration/deploy_test.go`.
+- [X] T028 [US2] `should run alias-bearing manifest on traefik-enabled and traefik-disabled hosts` in `tests/integration/traefik_plugin_test.go`.
+
+### Implementation for User Story 2
+
+- [X] T029 [US2] Verified: `engine.go:165` gates the entire routing block on `engine.Routing != nil`; `engine.go:172` adds the `aliases` field only inside that gate. Dual gate from F4 remediation is in place; no code change required.
+
+**Checkpoint**: T027 and T028 pass. The same manifest deploys cleanly on both Traefik-active and Traefik-inactive hosts. SC-003 is verifiable.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, regression coverage, and final acceptance.
+
+- [X] T030 [P] Updated `AGENTS.md` Application example to include the `aliases:` field with a per-line annotation pointing operators at the new behavior.
+- [~] T031 Unit-test gate green (`go build`, `go vet`, `go vet -tags integration`, `go test ./...` all pass). Integration suite (`make test-integration`) intentionally NOT run — per user guidance, run once as the final acceptance gate to avoid the ~10-minute cost.
+- [ ] T032 Manual walk-through of `quickstart.md` — DEFERRED to the operator with a real Traefik-enabled host. Cannot be performed in this implementation session.
+- [~] T033 SKIPPED. `specs/progress.md` tracks the legacy build-phase model; the last four spec-kit features (002–005) did not update it either. Adding an aliases-specific entry would be inconsistent with established practice. No-op.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup** (T001–T004): No code dependencies; can run immediately.
+- **Phase 2 Foundational** (T005–T008): Depends only on Setup; **blocks** US1 and US2.
+- **Phase 3 US1** (T009–T026): Depends on Foundational; independently testable end-to-end.
+- **Phase 4 US2** (T027–T029): Depends on Foundational. Can run in parallel with US1 once Phase 2 is done; integration assertions assume the engine nil-routing gate already exists (it does, in current `engine.go`).
+- **Phase 5 Polish** (T030–T033): Depends on US1 (and US2 if it ships in the same release).
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2. Owns the bulk of new code (engine widening, Traefik rendering, planner collision check).
+- **US2 (P2)**: Depends on Phase 2. Largely a verification phase — the engine's existing `nil`-routing-backend short-circuit is what makes aliases inert; T029 confirms it covers the new alias-log field too.
+
+### Within US1
+
+Strict order:
+1. Tests (T009–T014) — written first, must fail.
+2. Spec + struct widenings (T015, T016) — make the code compile.
+3. Engine resolver and event extension (T017, T018) — make the data flow.
+4. Traefik renderer rewrite (T019–T021) — make the tests for routing pass.
+5. Planner collision check + wiring (T022, T023) — make the collision test pass.
+6. Unit tests (T024–T026) — pin down the helpers.
+
+### Parallel Opportunities
+
+- T001–T004 (fixtures): all four [P], different files.
+- T007, T008 (manifest unit tests): both [P], different files.
+- T009–T014 (integration test stubs): all [US1], same file `tests/integration/traefik_plugin_test.go` — write sequentially within the file but can be drafted in parallel as separate functions before any of them is run.
+- T015 (Traefik spec.go) and T016 (engine backends.go): [P], different files.
+- T022 (planner/collisions.go): [P] with T015/T016 — different package.
+- T024 (Traefik routing_test.go), T025 (engine_aliases_test.go), T026 (planner/collisions_test.go): all [P] once their respective implementations are in.
+- T030 and T031: [P], independent.
+
+### Story-Boundary Parallelism
+
+Once Phase 2 is done, US1 and US2 can be staffed independently. US2 has very little code (T029 may even be a no-op) — a single contributor can take both stories without losing throughput.
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# All four fixtures are independent files — write in parallel:
+Task: "Create tests/testdata/hello-api-aliased.yml"
+Task: "Create tests/testdata/hello-api-noprefix-alias.yml"
+Task: "Create tests/testdata/hello-api-multi-alias.yml"
+Task: "Create tests/testdata/hello-api-collision.yml"
+```
+
+## Parallel Example: US1 Implementation Kickoff
+
+```bash
+# After T009–T014 are written and failing, three independent files can move in parallel:
+Task: "Add stripPrefix middleware type in internal/plugins/gateway/traefik/spec.go"   # T015
+Task: "Add AliasRoute and AdditionalRoutes in internal/engine/backends.go"           # T016
+Task: "Add detectRoutingCollisions in internal/planner/collisions.go"                # T022
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 1 Setup — fixtures.
+2. Phase 2 Foundational — manifest schema and validation.
+3. Phase 3 US1 — engine widening, Traefik rendering, planner collision check.
+4. **STOP and VALIDATE**: run the US1 integration tests; manually walk `quickstart.md` against a real Traefik-enabled host.
+5. Ship.
+
+### Incremental Delivery
+
+- Setup + Foundational → manifest accepts `aliases` and validates them. (Not directly user-visible but unblocks both stories.)
+- + US1 → operators can publish their apps at additional addresses via Traefik. **MVP shipped.**
+- + US2 → the same manifest is portable to no-Traefik hosts. (Mostly a verification milestone; little new code.)
+- + Polish → docs in sync, regression suite green, quickstart matches reality.
+
+### Single-Contributor Strategy
+
+Given US2 is a thin verification layer, a solo contributor can interleave T027/T028 alongside US1 work without context-switching cost. Recommended order: T001–T008 → T009–T014 → T015–T026 → T027–T029 → T030–T033.
+
+---
+
+## Format validation
+
+All tasks above:
+- Start with `- [ ]` checkbox.
+- Have a sequential ID (T001–T033).
+- Include `[P]` only when truly parallelizable (different files, no incomplete deps).
+- Carry `[US1]` / `[US2]` for user-story phases; Setup/Foundational/Polish carry no story label.
+- Name an exact file path in the description.

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -23,6 +23,7 @@ func TestDeploy(t *testing.T) {
 	s := NewDockerSuite(t, testTeam)
 
 	s.BeforeEach(func(tc *TestCase) {
+		CleanupTeam(tc, "shrine-alias-test")
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
 		// Use the dedicated team/ sub-fixture so BeforeEach does not scan the
@@ -32,6 +33,10 @@ func TestDeploy(t *testing.T) {
 			"--path", fixturesPath("team"),
 			"--state-dir", tc.StateDir,
 		).AssertSuccess()
+	})
+
+	s.AfterEach(func(tc *TestCase) {
+		CleanupTeam(tc, "shrine-alias-test")
 	})
 
 	s.Test("should deploy a basic app and create its container and network", func(tc *TestCase) {
@@ -193,8 +198,12 @@ func TestDeploy(t *testing.T) {
 
 		// No dynamic routing directory must be created.
 		// (No --config-dir means no plugin config at all, so no routingDir is configured.)
-		// We verify the alias was treated as fully inert via the output.
-		tc.AssertOutputNotContains("alias")
+		// We verify the alias was treated as fully inert by checking the alias-listing
+		// log signal — emitted by terminal_logger only when a routing backend is
+		// active — does not appear. We don't assert the bare word "alias" because the
+		// team name (shrine-alias-test) legitimately contains it.
+		tc.AssertOutputNotContains("Aliases:")
+		tc.AssertOutputNotContains("Configuring routing:")
 	})
 
 	s.Test("should succeed when specsDir contains non-YAML files", func(tc *TestCase) {

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -176,6 +176,27 @@ func TestDeploy(t *testing.T) {
 			AssertStderrContains("broken.yaml")
 	})
 
+	// T027 (US2): alias manifest deploys cleanly when the traefik plugin is disabled.
+	// The deploy must succeed, produce no alias-related output, and leave the routing
+	// directory untouched (no dynamic/ subdirectory created).
+	s.Test("should accept alias manifest silently when traefik plugin disabled", func(tc *TestCase) {
+		// Register the alias team; no traefik plugin block in the config.
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("prefix"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy",
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		// No dynamic routing directory must be created.
+		// (No --config-dir means no plugin config at all, so no routingDir is configured.)
+		// We verify the alias was treated as fully inert via the output.
+		tc.AssertOutputNotContains("alias")
+	})
+
 	s.Test("should succeed when specsDir contains non-YAML files", func(tc *TestCase) {
 		// T023: proves the extension filter never opens .json files (FR-001a).
 		// Copy the basic fixture into a writable temp dir so we can add siblings.

--- a/tests/integration/testutils/assert_general.go
+++ b/tests/integration/testutils/assert_general.go
@@ -82,6 +82,14 @@ func (tc *TestCase) AssertFileContains(path, want string) *TestCase {
 	return tc
 }
 
+func (tc *TestCase) AssertOutputNotContains(s string) *TestCase {
+	tc.t.Helper()
+	if strings.Contains(tc.result.Stdout, s) {
+		tc.t.Fatalf("expected stdout NOT to contain %q\nstdout: %s", s, tc.result.Stdout)
+	}
+	return tc
+}
+
 func expandTilde(path string) (string, error) {
 	if path != "~" && !strings.HasPrefix(path, "~/") {
 		return path, nil

--- a/tests/integration/traefik_plugin_test.go
+++ b/tests/integration/traefik_plugin_test.go
@@ -55,6 +55,7 @@ func copyFile(_ string, src, dst string) error {
 
 const traefikTestTeam = "shrine-traefik-test"
 const traefikContainerName = "platform.traefik"
+const aliasTestTeam = "shrine-alias-test"
 
 func writeConfig(t *testing.T, configDir, content string) {
 	t.Helper()
@@ -85,6 +86,7 @@ func TestTraefikPlugin(t *testing.T) {
 
 	s.BeforeEach(func(tc *TestCase) {
 		cleanupTraefikContainer(tc)
+		CleanupTeam(tc, aliasTestTeam)
 		tc.StateDir = tc.TempDir()
 		SeedSubnetState(tc)
 		tc.Run("apply", "teams",
@@ -94,6 +96,7 @@ func TestTraefikPlugin(t *testing.T) {
 	})
 	s.AfterEach(func(tc *TestCase) {
 		cleanupTraefikContainer(tc)
+		CleanupTeam(tc, aliasTestTeam)
 	})
 
 	s.Test("should deploy traefik container when plugin block is populated", func(tc *TestCase) {
@@ -703,8 +706,8 @@ func TestTraefikPlugin(t *testing.T) {
 			"--path", aliasFixturePath("prefix"),
 		).AssertSuccess()
 
-		tc.AssertOutputContains("routing.configure")
-		tc.AssertOutputContains("aliases=alias.shrine.lab+/finances")
+		tc.AssertOutputContains("Configuring routing:")
+		tc.AssertOutputContains("Aliases: alias.shrine.lab+/finances")
 	})
 
 	// T014a: re-deploying without aliases must drop alias routers and strip middlewares.

--- a/tests/integration/traefik_plugin_test.go
+++ b/tests/integration/traefik_plugin_test.go
@@ -78,6 +78,8 @@ func traefikFixturePath() string {
 	return fixturesPath("traefik")
 }
 
+func aliasFixturePath(variant string) string { return fixturesPath("traefik-alias-" + variant) }
+
 func TestTraefikPlugin(t *testing.T) {
 	s := NewDockerSuite(t, traefikTestTeam)
 
@@ -500,5 +502,300 @@ func TestTraefikPlugin(t *testing.T) {
 		if !bytes.Contains(content, []byte("entryPoints:")) {
 			t.Fatalf("regenerated traefik.yml missing canonical 'entryPoints:' key\ncontent: %s", content)
 		}
+	})
+
+	// T009: host-only alias produces a second router with no middlewares.
+	s.Test("should publish alias router for a host-only alias", func(tc *TestCase) {
+		// Register the alias team in addition to the traefik team registered by BeforeEach.
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("host-only"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8095
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("host-only"),
+		).AssertSuccess()
+
+		dynamicFile := filepath.Join(routingDir, "dynamic", "shrine-alias-test-whoami-host-only.yml")
+		tc.AssertFileExists(dynamicFile)
+		tc.AssertFileContains(dynamicFile, "whoami.shrine.lab")
+		tc.AssertFileContains(dynamicFile, "Host(`alias.shrine.lab`)")
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-host-only-alias-0")
+		// Host-only alias never produces a strip middleware.
+		content, err := os.ReadFile(dynamicFile)
+		if err != nil {
+			t.Fatalf("read dynamic file: %v", err)
+		}
+		if bytes.Contains(content, []byte("middlewares:")) {
+			t.Fatalf("host-only alias must not produce any middlewares:\ncontent: %s", content)
+		}
+	})
+
+	// T010: path-prefixed alias with default strip produces a strip middleware.
+	s.Test("should publish alias router with default-strip middleware for path-prefixed alias", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("prefix"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8096
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		dynamicFile := filepath.Join(routingDir, "dynamic", "shrine-alias-test-whoami-prefix.yml")
+		tc.AssertFileExists(dynamicFile)
+		tc.AssertFileContains(dynamicFile, "Host(`alias.shrine.lab`) && PathPrefix(`/finances`)")
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-prefix-strip-0:")
+		tc.AssertFileContains(dynamicFile, "prefixes:")
+		tc.AssertFileContains(dynamicFile, "/finances")
+		// The alias router must reference the strip middleware.
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-prefix-strip-0")
+	})
+
+	// T011: three aliases with mixed strip settings emit exactly one strip middleware at index 1.
+	s.Test("should publish multiple alias routers with sparse strip indexing", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("multi"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8097
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("multi"),
+		).AssertSuccess()
+
+		dynamicFile := filepath.Join(routingDir, "dynamic", "shrine-alias-test-whoami-multi.yml")
+		tc.AssertFileExists(dynamicFile)
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-multi-alias-0")
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-multi-alias-1")
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-multi-alias-2")
+
+		// Alias 1 has pathPrefix + default strip → strip-1 emitted.
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-multi-strip-1")
+
+		// Alias 0 has no pathPrefix; alias 2 has stripPrefix:false → no strip middleware for those.
+		content, err := os.ReadFile(dynamicFile)
+		if err != nil {
+			t.Fatalf("read dynamic file: %v", err)
+		}
+		if bytes.Contains(content, []byte("shrine-alias-test-whoami-multi-strip-0")) {
+			t.Fatalf("alias-0 is host-only — strip-0 must not be emitted:\ncontent: %s", content)
+		}
+		if bytes.Contains(content, []byte("shrine-alias-test-whoami-multi-strip-2")) {
+			t.Fatalf("alias-2 has stripPrefix:false — strip-2 must not be emitted:\ncontent: %s", content)
+		}
+	})
+
+	// T012: two apps colliding on the same primary domain must fail before any dynamic config is written.
+	s.Test("should fail deploy when two applications collide on host+pathPrefix", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("collision"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8098
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("collision"),
+		).AssertFailure().
+			AssertStderrContains("routing collision:").
+			AssertStderrContains("app-a").
+			AssertStderrContains("app-b")
+
+		// No dynamic config must have been written for either colliding app.
+		tc.AssertFileNotExists(filepath.Join(routingDir, "dynamic", "shrine-alias-test-app-a.yml"))
+		tc.AssertFileNotExists(filepath.Join(routingDir, "dynamic", "shrine-alias-test-app-b.yml"))
+	})
+
+	// T013: both primary and alias routers reference the same backend service.
+	// NOTE: The harness has no docker-exec primitive (assert_docker.go contains no
+	// ContainerExec helper), so end-to-end curl verification (SC-002) is out of scope
+	// for this test run. Instead we assert the config-level guarantee: both the primary
+	// router and all alias routers name the same service key — which is what routes
+	// traffic to the same backend. FR-006 live curl coverage belongs to quickstart.md.
+	s.Test("should reach backend through both primary and alias addresses", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("prefix"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8099
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		dynamicFile := filepath.Join(routingDir, "dynamic", "shrine-alias-test-whoami-prefix.yml")
+		tc.AssertFileExists(dynamicFile)
+		// Both the primary router and the alias router must point at the same service.
+		tc.AssertFileContains(dynamicFile, "service: shrine-alias-test-whoami-prefix")
+	})
+
+	// T014: the routing.configure log line must include an aliases= field.
+	s.Test("should include aliases field in routing.configure log signal", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("prefix"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8100
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		tc.AssertOutputContains("routing.configure")
+		tc.AssertOutputContains("aliases=alias.shrine.lab+/finances")
+	})
+
+	// T014a: re-deploying without aliases must drop alias routers and strip middlewares.
+	// Two fixture directories are used:
+	//   1. traefik-alias-prefix  — app with one alias (produces alias-0 + strip-0)
+	//   2. traefik-alias-removed — same app manifest but with the aliases section removed
+	// The same routingDir is reused across both deploys so the file is overwritten.
+	s.Test("should drop alias routers when alias is removed and re-deployed", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("prefix"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8101
+`)
+
+		// First deploy: with alias.
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		dynamicFile := filepath.Join(routingDir, "dynamic", "shrine-alias-test-whoami-prefix.yml")
+		tc.AssertFileExists(dynamicFile)
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-prefix-alias-0")
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-prefix-strip-0")
+
+		// Second deploy: alias removed — traefik-alias-removed has the same app name
+		// (whoami-prefix) but no aliases section.
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("removed"),
+		).AssertSuccess()
+
+		tc.AssertFileExists(dynamicFile)
+		afterContent, err := os.ReadFile(dynamicFile)
+		if err != nil {
+			t.Fatalf("read dynamic file after alias removal: %v", err)
+		}
+		if bytes.Contains(afterContent, []byte("alias-0")) {
+			t.Fatalf("alias router must be gone after alias is removed:\ncontent: %s", afterContent)
+		}
+		if bytes.Contains(afterContent, []byte("strip-0")) {
+			t.Fatalf("strip middleware must be gone after alias is removed:\ncontent: %s", afterContent)
+		}
+	})
+
+	// T028: same manifest (with aliases) must deploy cleanly on both a Traefik-disabled
+	// and a Traefik-enabled host. This validates the US2 "portable manifest" guarantee.
+	s.Test("should run alias-bearing manifest on traefik-enabled and traefik-disabled hosts", func(tc *TestCase) {
+		tc.Run("apply", "teams",
+			"--path", aliasFixturePath("prefix"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+
+		// First deploy: Traefik plugin DISABLED — alias must be inert.
+		writeConfig(t, configDir, "")
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		tc.AssertFileNotExists(filepath.Join(routingDir, "dynamic"))
+
+		// Second deploy: Traefik plugin ENABLED — alias routing must materialise.
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8102
+`)
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", aliasFixturePath("prefix"),
+		).AssertSuccess()
+
+		dynamicFile := filepath.Join(routingDir, "dynamic", "shrine-alias-test-whoami-prefix.yml")
+		tc.AssertFileExists(dynamicFile)
+		tc.AssertFileContains(dynamicFile, "shrine-alias-test-whoami-prefix-alias-0")
 	})
 }

--- a/tests/testdata/deploy/traefik-alias-collision/app-a.yaml
+++ b/tests/testdata/deploy/traefik-alias-collision/app-a.yaml
@@ -1,0 +1,13 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: app-a
+  owner: shrine-alias-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: true
+  routing:
+    domain: collide.shrine.lab

--- a/tests/testdata/deploy/traefik-alias-collision/app-b.yaml
+++ b/tests/testdata/deploy/traefik-alias-collision/app-b.yaml
@@ -1,0 +1,13 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: app-b
+  owner: shrine-alias-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: true
+  routing:
+    domain: collide.shrine.lab

--- a/tests/testdata/deploy/traefik-alias-collision/team.yaml
+++ b/tests/testdata/deploy/traefik-alias-collision/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-alias-test
+spec:
+  displayName: "Shrine Alias Test"
+  contact: "test@shrine-alias.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/traefik-alias-host-only/app.yaml
+++ b/tests/testdata/deploy/traefik-alias-host-only/app.yaml
@@ -1,0 +1,15 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami-host-only
+  owner: shrine-alias-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: true
+  routing:
+    domain: whoami.shrine.lab
+    aliases:
+      - host: alias.shrine.lab

--- a/tests/testdata/deploy/traefik-alias-host-only/team.yaml
+++ b/tests/testdata/deploy/traefik-alias-host-only/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-alias-test
+spec:
+  displayName: "Shrine Alias Test"
+  contact: "test@shrine-alias.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/traefik-alias-multi/app.yaml
+++ b/tests/testdata/deploy/traefik-alias-multi/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami-multi
+  owner: shrine-alias-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: true
+  routing:
+    domain: whoami-multi.shrine.lab
+    aliases:
+      - host: lan.shrine.lab
+      - host: gw.shrine.lab
+        pathPrefix: /notes
+      - host: gw.shrine.lab
+        pathPrefix: /notes-raw
+        stripPrefix: false

--- a/tests/testdata/deploy/traefik-alias-multi/team.yaml
+++ b/tests/testdata/deploy/traefik-alias-multi/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-alias-test
+spec:
+  displayName: "Shrine Alias Test"
+  contact: "test@shrine-alias.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/traefik-alias-prefix/app.yaml
+++ b/tests/testdata/deploy/traefik-alias-prefix/app.yaml
@@ -1,0 +1,16 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami-prefix
+  owner: shrine-alias-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: true
+  routing:
+    domain: whoami-primary.shrine.lab
+    aliases:
+      - host: alias.shrine.lab
+        pathPrefix: /finances

--- a/tests/testdata/deploy/traefik-alias-prefix/team.yaml
+++ b/tests/testdata/deploy/traefik-alias-prefix/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-alias-test
+spec:
+  displayName: "Shrine Alias Test"
+  contact: "test@shrine-alias.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy/traefik-alias-removed/app.yaml
+++ b/tests/testdata/deploy/traefik-alias-removed/app.yaml
@@ -1,0 +1,13 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: whoami-prefix
+  owner: shrine-alias-test
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  networking:
+    exposeToPlatform: true
+  routing:
+    domain: whoami-primary.shrine.lab

--- a/tests/testdata/deploy/traefik-alias-removed/team.yaml
+++ b/tests/testdata/deploy/traefik-alias-removed/team.yaml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-alias-test
+spec:
+  displayName: "Shrine Alias Test"
+  contact: "test@shrine-alias.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/hello-api-aliased.yml
+++ b/tests/testdata/hello-api-aliased.yml
@@ -1,0 +1,26 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: hello-api
+  owner: team-a
+spec:
+  image: hello-api
+  port: 8080
+  replicas: 1
+  routing:
+    domain: hello-api.home.lab
+    pathPrefix: /hello-api
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+  dependencies:
+    - kind: Resource
+      name: hello-db
+      owner: team-a
+  env:
+    - name: DATABASE_URL
+      valueFrom: resource.hello-db.url
+    - name: NODE_ENV
+      value: production
+  networking:
+    exposeToplatform: false

--- a/tests/testdata/hello-api-collision.yml
+++ b/tests/testdata/hello-api-collision.yml
@@ -1,0 +1,14 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: collider
+  owner: team-b
+spec:
+  image: nginx
+  port: 80
+  replicas: 1
+  routing:
+    domain: hello-api.home.lab
+    pathPrefix: /hello-api
+  networking:
+    exposeToplatform: false

--- a/tests/testdata/hello-api-multi-alias.yml
+++ b/tests/testdata/hello-api-multi-alias.yml
@@ -1,0 +1,30 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: hello-api
+  owner: team-a
+spec:
+  image: hello-api
+  port: 8080
+  replicas: 1
+  routing:
+    domain: hello-api.home.lab
+    pathPrefix: /hello-api
+    aliases:
+      - host: lan.home.lab
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /notes
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /notes-raw
+        stripPrefix: false
+  dependencies:
+    - kind: Resource
+      name: hello-db
+      owner: team-a
+  env:
+    - name: DATABASE_URL
+      valueFrom: resource.hello-db.url
+    - name: NODE_ENV
+      value: production
+  networking:
+    exposeToplatform: false

--- a/tests/testdata/hello-api-noprefix-alias.yml
+++ b/tests/testdata/hello-api-noprefix-alias.yml
@@ -1,0 +1,25 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: hello-api
+  owner: team-a
+spec:
+  image: hello-api
+  port: 8080
+  replicas: 1
+  routing:
+    domain: hello-api.home.lab
+    pathPrefix: /hello-api
+    aliases:
+      - host: lan.home.lab
+  dependencies:
+    - kind: Resource
+      name: hello-db
+      owner: team-a
+  env:
+    - name: DATABASE_URL
+      valueFrom: resource.hello-db.url
+    - name: NODE_ENV
+      value: production
+  networking:
+    exposeToplatform: false


### PR DESCRIPTION
## What

Applications can now declare additional hostnames (with optional path prefix and a per-alias strip toggle) under `spec.routing.aliases`, so a single app can be reached at multiple addresses without standing up a duplicate manifest.

## Why

Operators with multi-network setups (LAN + Tailscale, internal + public, dev + canary hostname) previously had no way to publish one application at two addresses — they had to clone the manifest, which doubles maintenance and breaks single-instance assumptions. This change adds the missing manifest field, wires it through the Traefik gateway plugin (one extra router per alias, sharing the same backend), and fails the deploy with a clear error if two applications would collide on the same host+path. On hosts where the Traefik plugin is not active, aliases are parsed but silently inert so the same manifest stays portable.

Spec, plan, research, data model, contracts, and quickstart for this feature are under `specs/006-routing-aliases/`.

## How to test

- Unit tests: `go test ./...` — covers manifest validation (rules V1–V7), alias-route resolution, Traefik dynamic-config rendering (sparse strip-middleware indexing), and cross-application collision detection.
- Integration suite (one ~10-minute run): `go test -tags integration ./tests/integration/...` or `make test-integration`. The new scenarios live inside `TestTraefikPlugin` in `tests/integration/traefik_plugin_test.go` (8 cases: host-only alias, path-prefix alias with default strip, multi-alias sparse strip, cross-app collision failure, shared backend service, log signal, alias removal cleanup, plugin-active/inactive portability) and one case in `TestDeploy` in `tests/integration/deploy_test.go` (alias manifest deploys silently when no Traefik plugin is configured).
- Manual smoke: walk through `specs/006-routing-aliases/quickstart.md` against a real Traefik-enabled host — verify the `routing.configure status=info … aliases=…` log line appears and both addresses resolve.

## Checklist

- [x] Tests added or updated
- [x] `go test ./...` passes locally
- [x] Documentation updated (if behaviour changed)
- [x] This is a breaking change (manifest schema, CLI flags, or config format changed)