### PR TITLE
fix: write traefik dashboard router/middleware to dynamic config

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/009-preserve-app-configs"
+  "feature_directory": "specs/010-fix-dashboard-static-config"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/009-preserve-app-configs/plan.md
+at specs/010-fix-dashboard-static-config/plan.md
 <!-- SPECKIT END -->

--- a/internal/plugins/gateway/traefik/config_gen.go
+++ b/internal/plugins/gateway/traefik/config_gen.go
@@ -3,7 +3,9 @@ package traefik
 import (
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -13,7 +15,10 @@ import (
 	"github.com/CarlosHPlata/shrine/internal/engine"
 )
 
-var lstatFn = os.Lstat
+var (
+	lstatFn    = os.Lstat
+	readFileFn = os.ReadFile
+)
 
 // isPathPresent treats any directory entry at path as present, including
 // symlinks and non-regular files. Lstat (not Stat) is used so a broken
@@ -44,6 +49,7 @@ func generateStaticConfig(cfg *config.TraefikPluginConfig, routingDir string, ob
 		return err
 	}
 	if present {
+		emitLegacyHTTPBlockSignal(path, routingDir, observer)
 		observer.OnEvent(engine.Event{
 			Name:   "gateway.config.preserved",
 			Status: engine.StatusInfo,
@@ -69,23 +75,6 @@ func generateStaticConfig(cfg *config.TraefikPluginConfig, routingDir string, ob
 	if cfg.Dashboard != nil && cfg.Dashboard.Port > 0 {
 		spec.EntryPoints["traefik"] = entryPoint{Address: fmt.Sprintf(":%d", cfg.Dashboard.Port)}
 		spec.API = &apiConfig{Dashboard: true}
-		spec.HTTP = &httpConfig{
-			Middlewares: map[string]middleware{
-				"dashboard-auth": {
-					BasicAuth: &basicAuth{
-						Users: []string{htpasswdEntry(cfg.Dashboard.Username, cfg.Dashboard.Password)},
-					},
-				},
-			},
-			Routers: map[string]router{
-				"dashboard": {
-					Rule:        "PathPrefix(`/dashboard`) || PathPrefix(`/api`)",
-					Service:     "api@internal",
-					EntryPoints: []string{"traefik"},
-					Middlewares: []string{"dashboard-auth"},
-				},
-			},
-		}
 	}
 
 	data, err := yaml.Marshal(spec)
@@ -104,6 +93,103 @@ func generateStaticConfig(cfg *config.TraefikPluginConfig, routingDir string, ob
 	return nil
 }
 
+func generateDashboardDynamicConfig(cfg *config.TraefikPluginConfig, routingDir string, observer engine.Observer) error {
+	path := filepath.Join(routingDir, "dynamic", dashboardDynamicFileName())
+	present, err := isPathPresent(path)
+	if err != nil {
+		return fmt.Errorf("traefik plugin: checking dashboard dynamic file at %q: %w", path, err)
+	}
+	if present {
+		observer.OnEvent(engine.Event{
+			Name:   "gateway.dashboard.preserved",
+			Status: engine.StatusInfo,
+			Fields: map[string]string{"path": path},
+		})
+		return nil
+	}
+
+	doc := dashboardDynamicDoc{
+		HTTP: httpConfig{
+			Middlewares: map[string]middleware{
+				"dashboard-auth": {
+					BasicAuth: &basicAuth{
+						Users: []string{htpasswdEntry(cfg.Dashboard.Username, cfg.Dashboard.Password)},
+					},
+				},
+			},
+			Routers: map[string]router{
+				"dashboard": {
+					Rule:        "PathPrefix(`/dashboard`) || PathPrefix(`/api`)",
+					Service:     "api@internal",
+					EntryPoints: []string{"traefik"},
+					Middlewares: []string{"dashboard-auth"},
+				},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("traefik plugin: marshal dashboard dynamic config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("traefik plugin: writing dashboard dynamic file: %w", err)
+	}
+	observer.OnEvent(engine.Event{
+		Name:   "gateway.dashboard.generated",
+		Status: engine.StatusInfo,
+		Fields: map[string]string{"path": path},
+	})
+	return nil
+}
+
+// hasLegacyDashboardHTTPBlock returns whether path contains a top-level `http:`
+// section. It is meant to flag the artefact left behind by an earlier buggy
+// version of this plugin, which emitted the dashboard router into the static
+// config where Traefik silently drops it.
+func hasLegacyDashboardHTTPBlock(path string) (bool, error) {
+	data, err := readFileFn(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("traefik plugin: probing legacy http block at %q: %w", path, err)
+	}
+	var probe legacyHTTPProbe
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return false, fmt.Errorf("traefik plugin: probing legacy http block at %q: %w", path, err)
+	}
+	return probe.HTTP != nil, nil
+}
+
+func emitLegacyHTTPBlockSignal(staticPath, routingDir string, observer engine.Observer) {
+	hit, err := hasLegacyDashboardHTTPBlock(staticPath)
+	if err != nil {
+		observer.OnEvent(engine.Event{
+			Name:   "gateway.config.legacy_probe_error",
+			Status: engine.StatusWarning,
+			Fields: map[string]string{
+				"path":  staticPath,
+				"error": err.Error(),
+			},
+		})
+		return
+	}
+	if !hit {
+		return
+	}
+	dynamicPath := filepath.Join(routingDir, "dynamic", dashboardDynamicFileName())
+	observer.OnEvent(engine.Event{
+		Name:   "gateway.config.legacy_http_block",
+		Status: engine.StatusWarning,
+		Fields: map[string]string{
+			"path": staticPath,
+			"hint": fmt.Sprintf("Remove the top-level http: block from this file; the dashboard now lives in %s.", dynamicPath),
+		},
+	})
+}
+
 // htpasswdEntry produces an htpasswd line in the SHA1 format that Traefik
 // basicAuth accepts: user:{SHA}base64(sha1(password)).
 func htpasswdEntry(user, password string) string {
@@ -113,4 +199,16 @@ func htpasswdEntry(user, password string) string {
 
 func routeFileName(team, name string) string {
 	return fmt.Sprintf("%s-%s.yml", team, name)
+}
+
+func dashboardDynamicFileName() string {
+	return "__shrine-dashboard.yml"
+}
+
+type dashboardDynamicDoc struct {
+	HTTP httpConfig `yaml:"http"`
+}
+
+type legacyHTTPProbe struct {
+	HTTP *yaml.Node `yaml:"http"`
 }

--- a/internal/plugins/gateway/traefik/config_gen_test.go
+++ b/internal/plugins/gateway/traefik/config_gen_test.go
@@ -7,9 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/CarlosHPlata/shrine/internal/config"
 	"github.com/CarlosHPlata/shrine/internal/engine"
 )
+
+var yamlMarshal = yaml.Marshal
 
 // stubLstat replaces lstatFn for the duration of the test and restores it on cleanup.
 func stubLstat(t *testing.T, fn func(string) (os.FileInfo, error)) {
@@ -19,11 +23,18 @@ func stubLstat(t *testing.T, fn func(string) (os.FileInfo, error)) {
 	lstatFn = fn
 }
 
+// stubReadFile replaces readFileFn for the duration of the test and restores it on cleanup.
+func stubReadFile(t *testing.T, fn func(string) ([]byte, error)) {
+	t.Helper()
+	orig := readFileFn
+	t.Cleanup(func() { readFileFn = orig })
+	readFileFn = fn
+}
+
 // --- isStaticConfigPresent tests ---
 
 func TestIsStaticConfigPresent_Present(t *testing.T) {
 	stubLstat(t, func(path string) (os.FileInfo, error) {
-		// Return nil FileInfo with nil error — helper only checks err.
 		return nil, nil
 	})
 
@@ -76,9 +87,11 @@ func TestIsStaticConfigPresent_OtherError(t *testing.T) {
 // --- generateStaticConfig tests ---
 
 func TestGenerateStaticConfig_Skip_WhenPresent(t *testing.T) {
-	// Stub lstat to report the file as present (no error).
 	stubLstat(t, func(path string) (os.FileInfo, error) {
 		return nil, nil
+	})
+	stubReadFile(t, func(path string) ([]byte, error) {
+		return []byte("entryPoints:\n  web:\n    address: ':80'\nproviders:\n  file:\n    directory: /etc/traefik/dynamic\n    watch: true\n"), nil
 	})
 
 	obs := &recordingObserver{}
@@ -87,7 +100,7 @@ func TestGenerateStaticConfig_Skip_WhenPresent(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 	if len(obs.events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(obs.events))
+		t.Fatalf("expected 1 event (preserved, no legacy block), got %d: %+v", len(obs.events), obs.events)
 	}
 	ev := obs.events[0]
 	if ev.Name != "gateway.config.preserved" {
@@ -101,11 +114,35 @@ func TestGenerateStaticConfig_Skip_WhenPresent(t *testing.T) {
 	}
 }
 
-// TestGenerateStaticConfig_Write is intentionally omitted.
-// The write branch (lstatFn returns NotExist → os.WriteFile) cannot be
-// exercised without touching the filesystem, which violates the unit-test
-// constraint (no TempDir / no disk writes). The write path is covered by the
-// integration scenarios in tests/integration/traefik_plugin_test.go.
+func TestGenerateStaticConfig_LegacyHTTPBlock_EmitsWarning(t *testing.T) {
+	stubLstat(t, func(path string) (os.FileInfo, error) {
+		return nil, nil
+	})
+	stubReadFile(t, func(path string) ([]byte, error) {
+		return []byte("entryPoints:\n  web:\n    address: ':80'\nhttp:\n  routers:\n    dashboard:\n      rule: PathPrefix(`/dashboard`)\n      service: api@internal\n"), nil
+	})
+
+	obs := &recordingObserver{}
+	err := generateStaticConfig(&config.TraefikPluginConfig{Port: 8080}, "/fake/dir", obs)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(obs.events) != 2 {
+		t.Fatalf("expected 2 events (legacy_http_block + preserved), got %d: %+v", len(obs.events), obs.events)
+	}
+	if obs.events[0].Name != "gateway.config.legacy_http_block" {
+		t.Errorf("expected first event 'gateway.config.legacy_http_block', got %q", obs.events[0].Name)
+	}
+	if obs.events[0].Status != engine.StatusWarning {
+		t.Errorf("expected first event status Warning, got %q", obs.events[0].Status)
+	}
+	if !strings.Contains(obs.events[0].Fields["hint"], "__shrine-dashboard.yml") {
+		t.Errorf("hint should mention the new dashboard dynamic file, got %q", obs.events[0].Fields["hint"])
+	}
+	if obs.events[1].Name != "gateway.config.preserved" {
+		t.Errorf("expected second event 'gateway.config.preserved', got %q", obs.events[1].Name)
+	}
+}
 
 func TestGenerateStaticConfig_StatError(t *testing.T) {
 	stubLstat(t, func(path string) (os.FileInfo, error) {
@@ -125,5 +162,154 @@ func TestGenerateStaticConfig_StatError(t *testing.T) {
 	}
 	if len(obs.events) != 0 {
 		t.Errorf("expected 0 events on error, got %d", len(obs.events))
+	}
+}
+
+// TestGenerateStaticConfig_Write is intentionally omitted.
+// The write branch (lstatFn returns NotExist → os.WriteFile) cannot be
+// exercised without touching the filesystem, which violates the unit-test
+// constraint. The write path is covered by integration scenarios in
+// tests/integration/traefik_plugin_test.go.
+
+// --- staticConfig YAML shape tests ---
+
+// staticConfig must never marshal a top-level `http:` key, regardless of
+// configuration: dynamic-only sections in static config are silently dropped
+// by Traefik and therefore mask bugs. The dashboard surface lives in the
+// dynamic file, not here.
+func TestStaticConfigMarshal_HasNoHTTPKey(t *testing.T) {
+	spec := staticConfig{
+		EntryPoints: map[string]entryPoint{
+			"web":     {Address: ":80"},
+			"traefik": {Address: ":8080"},
+		},
+		API: &apiConfig{Dashboard: true},
+		Providers: providersConfig{
+			File: fileProvider{Directory: "/etc/traefik/dynamic", Watch: true},
+		},
+	}
+
+	data, err := yamlMarshal(spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "\nhttp:") || strings.HasPrefix(string(data), "http:") {
+		t.Fatalf("staticConfig marshalled with a top-level http: key; this is the bug class fixed by spec 010\noutput:\n%s", data)
+	}
+}
+
+// --- generateDashboardDynamicConfig tests ---
+
+func TestGenerateDashboardDynamicConfig_Skip_WhenPresent(t *testing.T) {
+	stubLstat(t, func(path string) (os.FileInfo, error) {
+		return nil, nil
+	})
+
+	obs := &recordingObserver{}
+	cfg := &config.TraefikPluginConfig{
+		Dashboard: &config.TraefikDashboardConfig{Port: 8080, Username: "admin", Password: "hunter2"},
+	}
+	err := generateDashboardDynamicConfig(cfg, "/fake/dir", obs)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(obs.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(obs.events))
+	}
+	ev := obs.events[0]
+	if ev.Name != "gateway.dashboard.preserved" {
+		t.Errorf("expected event name 'gateway.dashboard.preserved', got %q", ev.Name)
+	}
+	if ev.Status != engine.StatusInfo {
+		t.Errorf("expected StatusInfo, got %q", ev.Status)
+	}
+	wantPath := "/fake/dir/dynamic/__shrine-dashboard.yml"
+	if ev.Fields["path"] != wantPath {
+		t.Errorf("expected path %q, got %q", wantPath, ev.Fields["path"])
+	}
+}
+
+func TestGenerateDashboardDynamicConfig_StatError(t *testing.T) {
+	stubLstat(t, func(path string) (os.FileInfo, error) {
+		return nil, errors.New("perm denied")
+	})
+
+	obs := &recordingObserver{}
+	cfg := &config.TraefikPluginConfig{
+		Dashboard: &config.TraefikDashboardConfig{Port: 8080, Username: "admin", Password: "hunter2"},
+	}
+	err := generateDashboardDynamicConfig(cfg, "/fake/dir", obs)
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "__shrine-dashboard.yml") {
+		t.Errorf("error should reference the dashboard file path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "perm denied") {
+		t.Errorf("error missing 'perm denied': %v", err)
+	}
+	if len(obs.events) != 0 {
+		t.Errorf("expected 0 events on error, got %d", len(obs.events))
+	}
+}
+
+// --- hasLegacyDashboardHTTPBlock tests ---
+
+func TestHasLegacyDashboardHTTPBlock_Detected(t *testing.T) {
+	stubReadFile(t, func(path string) ([]byte, error) {
+		return []byte("entryPoints:\n  web:\n    address: ':80'\nhttp:\n  routers:\n    dashboard:\n      rule: PathPrefix(`/dashboard`)\n"), nil
+	})
+
+	hit, err := hasLegacyDashboardHTTPBlock("/fake/dir/traefik.yml")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if !hit {
+		t.Fatal("expected legacy http block detected, got false")
+	}
+}
+
+func TestHasLegacyDashboardHTTPBlock_NoBlock(t *testing.T) {
+	stubReadFile(t, func(path string) ([]byte, error) {
+		return []byte("entryPoints:\n  web:\n    address: ':80'\napi:\n  dashboard: true\nproviders:\n  file:\n    directory: /etc/traefik/dynamic\n"), nil
+	})
+
+	hit, err := hasLegacyDashboardHTTPBlock("/fake/dir/traefik.yml")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if hit {
+		t.Fatal("expected no legacy http block, got true")
+	}
+}
+
+func TestHasLegacyDashboardHTTPBlock_FileMissing(t *testing.T) {
+	stubReadFile(t, func(path string) ([]byte, error) {
+		return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrNotExist}
+	})
+
+	hit, err := hasLegacyDashboardHTTPBlock("/fake/dir/traefik.yml")
+	if err != nil {
+		t.Fatalf("expected nil error on missing file, got %v", err)
+	}
+	if hit {
+		t.Fatal("expected false on missing file, got true")
+	}
+}
+
+func TestHasLegacyDashboardHTTPBlock_ParseError(t *testing.T) {
+	stubReadFile(t, func(path string) ([]byte, error) {
+		return []byte("not: valid: yaml: structure: [unbalanced"), nil
+	})
+
+	_, err := hasLegacyDashboardHTTPBlock("/fake/dir/traefik.yml")
+	if err == nil {
+		t.Fatal("expected non-nil error on malformed yaml, got nil")
+	}
+	if !strings.Contains(err.Error(), "/fake/dir/traefik.yml") {
+		t.Errorf("error should include path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "probing legacy http block") {
+		t.Errorf("error should include 'probing legacy http block': %v", err)
 	}
 }

--- a/internal/plugins/gateway/traefik/plugin.go
+++ b/internal/plugins/gateway/traefik/plugin.go
@@ -122,6 +122,12 @@ func (p *Plugin) Deploy() error {
 		return err
 	}
 
+	if p.hasDashboard() {
+		if err := generateDashboardDynamicConfig(p.cfg, routingDir, p.observer); err != nil {
+			return err
+		}
+	}
+
 	op := engine.CreateContainerOp{
 		Team:             containerTeam,
 		Name:             containerName,

--- a/internal/plugins/gateway/traefik/spec.go
+++ b/internal/plugins/gateway/traefik/spec.go
@@ -4,7 +4,6 @@ type staticConfig struct {
 	EntryPoints map[string]entryPoint `yaml:"entryPoints"`
 	API         *apiConfig            `yaml:"api,omitempty"`
 	Providers   providersConfig       `yaml:"providers"`
-	HTTP        *httpConfig           `yaml:"http,omitempty"`
 }
 
 type entryPoint struct {

--- a/internal/ui/terminal_logger.go
+++ b/internal/ui/terminal_logger.go
@@ -62,6 +62,18 @@ func (t *TerminalObserver) OnEvent(e engine.Event) {
 	case "gateway.config.generated":
 		fmt.Fprintf(t.out, "  📝 Generated default traefik.yml: %s\n", e.Fields["path"])
 
+	case "gateway.config.legacy_http_block":
+		fmt.Fprintf(t.out, "  ⚠️  Legacy http block in traefik.yml at %s — %s\n", e.Fields["path"], e.Fields["hint"])
+
+	case "gateway.config.legacy_probe_error":
+		fmt.Fprintf(t.out, "  ⚠️  Could not probe traefik.yml for legacy http block (deploy continues): %s (%s)\n", e.Fields["path"], e.Fields["error"])
+
+	case "gateway.dashboard.generated":
+		fmt.Fprintf(t.out, "  📝 Generated dashboard dynamic file: %s\n", e.Fields["path"])
+
+	case "gateway.dashboard.preserved":
+		fmt.Fprintf(t.out, "  📄 Preserving operator-owned dashboard dynamic file: %s\n", e.Fields["path"])
+
 	case "gateway.route.generated":
 		fmt.Fprintf(t.out, "  📝 Generated route file: %s\n", e.Fields["path"])
 

--- a/specs/010-fix-dashboard-static-config/checklists/requirements.md
+++ b/specs/010-fix-dashboard-static-config/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Fix Traefik Dashboard Generated in Static Config
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Question 1 (handling pre-existing buggy `traefik.yml` with an `http` block) resolved as option C: leave file untouched, write new dynamic file alongside, emit cleanup warning. Encoded as FR-010 and FR-011 and recorded under "Resolved Clarifications" in the spec.
+- Other potentially ambiguous areas (dashboard-password trigger, dynamic-directory location, file-preservation regime) were resolved via informed defaults grounded in existing project specs (004, 009) and recorded under Assumptions rather than as clarification markers.
+- All checklist items pass. Spec is ready for `/speckit-plan`.

--- a/specs/010-fix-dashboard-static-config/contracts/observer-events.md
+++ b/specs/010-fix-dashboard-static-config/contracts/observer-events.md
@@ -1,0 +1,58 @@
+# Contract: Observer Events for Dashboard Generation and Legacy-Block Warning
+
+**Feature**: Fix Traefik Dashboard Generated in Static Config
+**Audience**: Downstream consumers of `engine.Observer` events emitted by the Traefik plugin (terminal logger, structured deploy logs, future UI surfaces).
+
+This is the only operator-visible contract this feature introduces. There is no public Go API change, no manifest schema change, no CLI flag change. The fix surfaces three new event names on the existing `engine.Observer` channel and depends on consumers not breaking when they are emitted.
+
+## Event namespace
+
+All events live under the existing `gateway.` namespace already used by the plugin. No new namespace is created.
+
+## Events introduced
+
+### `gateway.dashboard.generated`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | yes | Absolute filesystem path of the dashboard dynamic file that was just written. |
+
+| Status | Emitted when |
+|--------|-------------|
+| `engine.StatusInfo` | The dashboard dynamic file was written for the first time on this deploy (file did not exist; configuration calls for a dashboard). |
+
+### `gateway.dashboard.preserved`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | yes | Absolute filesystem path of the existing dashboard dynamic file that was left untouched. |
+
+| Status | Emitted when |
+|--------|-------------|
+| `engine.StatusInfo` | The dashboard dynamic file already existed; it was preserved unchanged regardless of whether the dashboard-related Shrine config has changed since the previous deploy. |
+
+### `gateway.config.legacy_http_block`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | yes | Absolute filesystem path of the pre-existing static config file (`traefik.yml`) containing the legacy `http:` block. |
+| `hint` | string | yes | One-line, human-readable cleanup instruction (e.g., "Remove the top-level `http:` block from this file; the dashboard now lives in `<dynamic-dir>/__shrine-dashboard.yml`."). |
+
+| Status | Emitted when |
+|--------|-------------|
+| `engine.StatusWarning` | The static `traefik.yml` is present and contains a top-level `http:` key (the artefact of an earlier buggy Shrine version). Emitted on every deploy where the block remains; emitted in addition to (not instead of) the relevant `gateway.config.generated` or `gateway.config.preserved` event. |
+
+## Compatibility expectations
+
+- **Consumers MUST treat unknown event names as ignorable**. The terminal logger already does this; new consumers added to the codebase MUST follow the same rule.
+- **No existing event name is renamed or removed**. `gateway.config.generated`, `gateway.config.preserved`, `gateway.route.generated`, `gateway.route.preserved`, `gateway.route.orphan`, and `gateway.route.stat_error` continue to behave exactly as today.
+- **Field set is additive-only**. Future feature work on the dashboard generator MAY add new fields to these events; consumers MUST tolerate unknown fields.
+
+## Non-events (intentionally not emitted)
+
+- There is no `gateway.dashboard.removed` event (FR-008 in the spec describes removal-on-config-removal but is out of scope for this fix's first iteration; if added later, the natural name is reserved here).
+- There is no `gateway.dashboard.password_rotated` or similar event. Per Decision 3 in research.md, the dashboard dynamic file is preserved unconditionally; password rotation is operator-driven (delete-and-redeploy or hand-edit). The `gateway.dashboard.preserved` event is sufficient signal that the file was left as-is.
+
+## Verification
+
+Each event name above is asserted in the integration scenarios documented in plan.md (§ Integration tests). The terminal logger (`internal/ui/terminal_logger.go`) does not need a code change to render these events — it has a generic fall-through path for unknown event names that prints the status, name, and salient fields. A cosmetic per-event renderer can be added in a follow-up if desired but is not required by this contract.

--- a/specs/010-fix-dashboard-static-config/data-model.md
+++ b/specs/010-fix-dashboard-static-config/data-model.md
@@ -1,0 +1,136 @@
+# Phase 1: Data Model
+
+**Feature**: Fix Traefik Dashboard Generated in Static Config
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Research**: [research.md](./research.md)
+
+This feature is a config-generation bug fix. It does not introduce new manifest kinds, persisted state, or wire-format entities. The "data model" below documents the changes to the YAML shapes and Go structs the plugin emits and consumes — the smallest set of structural changes that the implementation will make.
+
+## Files written by the plugin (operator-visible YAML)
+
+### 1. `<routing-dir>/traefik.yml` (Traefik static configuration) — MODIFIED
+
+**Shape after this fix** (only valid Traefik static keys remain):
+
+```yaml
+entryPoints:
+  web:
+    address: ":80"
+  traefik:                # present only when dashboard.port is configured
+    address: ":8080"
+api:                      # present only when dashboard.port is configured
+  dashboard: true
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+```
+
+**What is removed**: the entire top-level `http:` block (with `middlewares.dashboard-auth` and `routers.dashboard`). It now lives in the dashboard dynamic file (entity 2 below).
+
+**Operator edits**: same preservation regime as today — if the file exists when `shrine deploy` runs, it is left untouched.
+
+### 2. `<routing-dir>/dynamic/__shrine-dashboard.yml` (NEW dashboard dynamic configuration)
+
+**Shape**:
+
+```yaml
+http:
+  middlewares:
+    dashboard-auth:
+      basicAuth:
+        users:
+          - "admin:{SHA}<base64-sha1-of-password>"
+  routers:
+    dashboard:
+      rule: "PathPrefix(`/dashboard`) || PathPrefix(`/api`)"
+      service: api@internal
+      entryPoints:
+        - traefik
+      middlewares:
+        - dashboard-auth
+```
+
+**Generation rules**:
+- File is created on `shrine deploy` if and only if `plugins.gateway.traefik.dashboard.port > 0` AND the file does not already exist.
+- On subsequent deploys: if the file exists, it is preserved unchanged (Decision 3 in research.md). If it has been deleted by the operator, it is regenerated from the current Shrine config.
+- Filename is fixed (`__shrine-dashboard.yml`) and namespaced via the `__` prefix to be non-collidable with per-app routing files (FR-009; Decision 1).
+- Content is exactly the dashboard router and the `dashboard-auth` middleware — nothing else.
+
+### 3. `<routing-dir>/dynamic/<team>-<service>.yml` (existing per-app dynamic files) — UNCHANGED
+
+The new dashboard file is a sibling of these files and is processed by the same Traefik file provider.
+
+## Go types changed in `internal/plugins/gateway/traefik/spec.go`
+
+### `staticConfig` — MODIFIED
+
+```go
+type staticConfig struct {
+    EntryPoints map[string]entryPoint `yaml:"entryPoints"`
+    API         *apiConfig            `yaml:"api,omitempty"`
+    Providers   providersConfig       `yaml:"providers"`
+    // HTTP field REMOVED — dashboard surface now lives in the dynamic file.
+}
+```
+
+### `httpConfig`, `middleware`, `basicAuth`, `router` — UNCHANGED
+
+These types remain, both because `routing.go`'s per-app route generator depends on them and because the new dashboard dynamic file re-uses the same shapes. No new types are introduced.
+
+### New helper types (private, in `config_gen.go`)
+
+```go
+// Wraps the http section the dashboard dynamic file emits.
+// Identical in shape to the per-app routing wrapper in routing.go.
+type dashboardDynamicDoc struct {
+    HTTP httpConfig `yaml:"http"`
+}
+
+// Single-field shadow used only by the legacy-block detector.
+// Decoupled from staticConfig so the detector does not break when
+// the static struct's field set evolves.
+type legacyHTTPProbe struct {
+    HTTP *yaml.Node `yaml:"http"`
+}
+```
+
+Both types are package-private and have no semantic identity beyond being YAML-marshal targets.
+
+## State transitions across redeploys
+
+```
+                  ┌───────────────────────────────────────────────────┐
+                  │ shrine deploy with dashboard configured           │
+                  └─────────────────────┬─────────────────────────────┘
+                                        │
+                  ┌─────────────────────┼─────────────────────────────┐
+                  │                     │                             │
+       traefik.yml absent        traefik.yml present          traefik.yml present
+       AND dashboard file        AND dashboard file           AND dashboard file
+       absent                    absent                       present
+                  │                     │                             │
+                  ▼                     ▼                             ▼
+       generate static          preserve static              preserve static
+       (no http block)          (warn if legacy http         (warn if legacy http
+       generate dashboard       block detected)              block detected)
+       dynamic                  generate dashboard           preserve dashboard
+                                dynamic                      dynamic
+```
+
+Three discrete observer events flank the transitions:
+
+| Event | Status | When |
+|-------|--------|------|
+| `gateway.config.generated` | Info | static `traefik.yml` written for the first time |
+| `gateway.config.preserved` | Info | static `traefik.yml` already exists; left untouched |
+| `gateway.config.legacy_http_block` | **Warning** | static `traefik.yml` present and contains an `http:` block (legacy buggy artefact) |
+| `gateway.dashboard.generated` | Info | dashboard dynamic file written for the first time |
+| `gateway.dashboard.preserved` | Info | dashboard dynamic file already exists; left untouched |
+
+The legacy-block warning is independent of the static-file generated/preserved pair: it is emitted once per deploy in addition to the relevant generated/preserved event, every deploy where the block remains. See Decision 2 in research.md.
+
+## Data not modeled here
+
+- **`DeploymentStore` records**: untouched by this feature. The dashboard's accessibility is a function of the file provider's contents, not of Shrine's internal state.
+- **Manifest schema (`shrine/v1`)**: untouched. The fix is invisible at the manifest level — operators see the same `plugins.gateway.traefik.dashboard` config block they had before.
+- **Dry-run output**: no new printed lines beyond the new event names surfacing through the existing terminal logger (which is a UI concern documented in `contracts/observer-events.md`, not a data-model concern).

--- a/specs/010-fix-dashboard-static-config/plan.md
+++ b/specs/010-fix-dashboard-static-config/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Fix Traefik Dashboard Generated in Static Config
+
+**Branch**: `010-fix-dashboard-static-config` | **Date**: 2026-05-01 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/010-fix-dashboard-static-config/spec.md`
+
+## Summary
+
+Move the Traefik dashboard router and basic-auth middleware out of the generated static `traefik.yml` (where Traefik silently drops them) and into a dedicated dynamic file in the file provider's watched directory, so the dashboard works on a clean `shrine deploy`.
+
+Two narrow code changes inside `internal/plugins/gateway/traefik/`:
+
+1. `generateStaticConfig` stops populating `staticConfig.HTTP`. The dashboard surface stays advertised via `entryPoints.traefik` and `api.dashboard: true`, both of which are valid static keys.
+2. A new `generateDashboardDynamicConfig` writes the dashboard router and `dashboard-auth` middleware to `<routing-dir>/dynamic/__shrine-dashboard.yml`, mirroring the "if file exists, preserve it" regime already implemented by `RoutingBackend.WriteRoute` and the existing `generateStaticConfig` preservation branch.
+
+A separate detection pass on the pre-existing static file emits a `gateway.config.legacy_http_block` warning event when an `http:` block is present (the artefact of an earlier buggy version), per FR-010/FR-011. The warning is purely advisory — the file is never modified.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (`github.com/CarlosHPlata/shrine`)
+**Primary Dependencies**: `gopkg.in/yaml.v3` (already used by the plugin); `internal/engine` Observer for event emission; `internal/config.TraefikPluginConfig` for inputs.
+**Storage**: Filesystem only — `<routing-dir>/traefik.yml` (static) and `<routing-dir>/dynamic/*.yml` (dynamic) are bind-mounted into the Traefik container at `/etc/traefik`.
+**Testing**: `go test ./...` for unit tests (no filesystem touches per project convention); `make test-integration` (build tag `integration`) for the end-to-end gate using `NewDockerSuite` against a real Docker daemon.
+**Target Platform**: Linux server (homelab operator host running Docker).
+**Project Type**: CLI (single Go module under `cmd/`, internal packages under `internal/`).
+**Performance Goals**: N/A — config generation runs once per `shrine deploy` and is bounded by a few small file writes.
+**Constraints**: Must remain idempotent across redeploys; must not modify operator-edited files (FR-006, FR-010); must not break the existing per-app routing file regime; must not collide with per-app routing filenames (FR-009).
+**Scale/Scope**: One plugin package, ~1 new file (~80 LOC), ~30 LOC delta in `config_gen.go` and `spec.go`, plus unit and integration tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Question | Status |
+|-----------|---------------|--------|
+| I. Declarative Manifest-First | Does this feature expose new capabilities via manifest fields (not CLI flags)? | [x] N/A — pure bug fix; no new operator-facing surface. Existing `plugins.gateway.traefik.dashboard` field is unchanged. |
+| II. Kubectl-Style CLI | Do new commands follow verb-first convention and include `--dry-run`? | [x] N/A — no new commands; existing `shrine deploy --dry-run` continues to work because the new file write happens inside the same `Deploy()` path that already short-circuits when the dry-run container backend is used (no traefik.yml written today on dry-run; same applies to the new dynamic file). |
+| III. Pluggable Backend | Is new infrastructure logic behind a backend interface (not engine core)? | [x] Pass — change is fully contained inside `internal/plugins/gateway/traefik/` (the plugin package); no engine core edits. |
+| IV. Simplicity & YAGNI | Is every abstraction justified by ≥3 concrete usages? | [x] Pass — re-uses existing `httpConfig`, `router`, `middleware`, `basicAuth` types; no new types beyond a tiny `dashboardDynamicDoc` wrapper. No factories, no interfaces. |
+| V. Integration-Test Gate | Does this phase map to an integration test phase using `NewDockerSuite` against a real binary? | [x] Pass — three new scenarios in `tests/integration/traefik_plugin_test.go`: dashboard-on-clean-deploy, dashboard-dynamic-file-preserved, and legacy-http-block-warning. |
+| VI. Docker-Authoritative State | Does state update happen *after* Docker operations complete? | [x] N/A — feature touches only filesystem config files; no `DeploymentStore` or container-id state involved. |
+| VII. Clean Code & Readability | Is repeated logic extracted into named helpers? Are names self-documenting (no WHAT comments)? | [x] Pass — `isPathPresent` is reused for the new file's preservation check; new helpers `generateDashboardDynamicConfig`, `dashboardDynamicFileName`, `hasLegacyDashboardHTTPBlock` follow the project's `is/has/should` boolean and verb-noun naming. |
+
+> Violations MUST be documented in the Complexity Tracking table below.
+
+**Result**: All seven principles pass with no violations. Complexity Tracking section is therefore empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-fix-dashboard-static-config/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── observer-events.md  # Observer event-name contract for the new file flows
+├── checklists/
+│   └── requirements.md  # Created by /speckit-specify
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/plugins/gateway/traefik/
+├── config_gen.go            # MODIFIED — drop HTTP block from static; add dashboard dynamic generator + legacy detector
+├── config_gen_test.go       # MODIFIED — drop HTTP-block assertions; add new unit tests with stubbed lstat
+├── spec.go                  # MODIFIED — remove HTTP field from staticConfig (httpConfig type itself stays; routing.go uses it)
+├── plugin.go                # MODIFIED — call new dashboard generator from Deploy() after generateStaticConfig
+├── routing.go               # UNCHANGED — already writes per-app dynamic files; new dashboard file is a sibling
+└── routing_test.go          # UNCHANGED
+
+tests/integration/
+└── traefik_plugin_test.go   # MODIFIED — three new scenarios (clean deploy + dashboard, preserve dashboard.yml, warn on legacy http block)
+```
+
+**Structure Decision**: No new top-level packages or directories. The fix lives entirely inside the existing Traefik plugin package, mirroring the pattern already established for static-config preservation (spec 004) and per-app dynamic-file preservation (spec 009). Observer event names are extended rather than re-shaped, keeping the contract for downstream UI/log consumers stable.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. This section is intentionally empty.

--- a/specs/010-fix-dashboard-static-config/quickstart.md
+++ b/specs/010-fix-dashboard-static-config/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart: Verifying the Dashboard Fix
+
+**Feature**: Fix Traefik Dashboard Generated in Static Config
+**Audience**: Operators verifying the fix on a homelab host; reviewers reproducing the bug and the fix manually.
+
+## Prereqs
+
+- A host with Docker running and `shrine` built from this branch (`010-fix-dashboard-static-config`).
+- A writable directory for Traefik routing files (referred to below as `$ROUTING_DIR`). The integration tests use a per-test temp dir; for a manual run use something like `/var/lib/shrine/traefik` or any path the user account can write.
+
+## Scenario A — clean host, dashboard works on first deploy (User Story 1)
+
+1. Ensure no prior Traefik state on the host:
+   ```sh
+   rm -rf "$ROUTING_DIR"
+   docker rm -f platform.traefik 2>/dev/null
+   ```
+2. Write a Shrine config that enables the Traefik plugin with a dashboard password:
+   ```yaml
+   plugins:
+     gateway:
+       traefik:
+         routing-dir: /absolute/path/to/$ROUTING_DIR
+         port: 80
+         dashboard:
+           port: 8080
+           username: admin
+           password: hunter2
+   ```
+3. Run `shrine deploy --config-dir /path/to/config --path /path/to/manifests`.
+4. **Expected file shape** after the deploy:
+   - `$ROUTING_DIR/traefik.yml` exists and contains **no** `http:` block. Its top-level keys are `entryPoints`, `api`, `providers`.
+   - `$ROUTING_DIR/dynamic/__shrine-dashboard.yml` exists and contains the dashboard router and `dashboard-auth` middleware under a single `http:` block.
+5. **Expected dashboard reachability**:
+   ```sh
+   curl -i http://localhost:8080/dashboard/
+   ```
+   Returns `HTTP/1.1 401 Unauthorized` with a `WWW-Authenticate: Basic …` header — **not** `404 page not found`.
+   ```sh
+   curl -i -u admin:hunter2 http://localhost:8080/dashboard/
+   ```
+   Returns `HTTP/1.1 200 OK` with the Traefik dashboard HTML.
+
+## Scenario B — operator-edited dashboard file is preserved across redeploys (User Story 3)
+
+1. Run scenario A first.
+2. Edit `$ROUTING_DIR/dynamic/__shrine-dashboard.yml` — for example, add a comment line at the top, or replace the router rule with a tighter one:
+   ```yaml
+   # operator: locked dashboard to internal subnet
+   http:
+     middlewares:
+       dashboard-auth:
+         basicAuth:
+           users:
+             - "admin:{SHA}…"
+       dashboard-allowlist:
+         ipAllowList:
+           sourceRange:
+             - 192.168.0.0/16
+     routers:
+       dashboard:
+         rule: "PathPrefix(`/dashboard`) || PathPrefix(`/api`)"
+         service: api@internal
+         entryPoints: [traefik]
+         middlewares: [dashboard-auth, dashboard-allowlist]
+   ```
+3. Run `shrine deploy …` again with no Shrine-side configuration changes.
+4. **Expected**:
+   - The deploy output contains a `gateway.dashboard.preserved` event (info-level) naming the file path.
+   - `$ROUTING_DIR/dynamic/__shrine-dashboard.yml` is **byte-identical** to the operator-edited version.
+5. To force regeneration after rotating the dashboard password in Shrine config:
+   ```sh
+   rm "$ROUTING_DIR/dynamic/__shrine-dashboard.yml"
+   shrine deploy …
+   ```
+   The next deploy regenerates the file with the current credentials and emits `gateway.dashboard.generated`.
+
+## Scenario C — pre-existing buggy `traefik.yml` triggers the warning (FR-010)
+
+1. Pre-stage a static file that simulates the artefact of an earlier buggy Shrine version:
+   ```sh
+   mkdir -p "$ROUTING_DIR" "$ROUTING_DIR/dynamic"
+   cat > "$ROUTING_DIR/traefik.yml" <<'EOF'
+   entryPoints:
+     web:
+       address: ":80"
+     traefik:
+       address: ":8080"
+   api:
+     dashboard: true
+   providers:
+     file:
+       directory: /etc/traefik/dynamic
+       watch: true
+   http:
+     middlewares:
+       dashboard-auth:
+         basicAuth:
+           users:
+             - "admin:{SHA}old-hash"
+     routers:
+       dashboard:
+         rule: "PathPrefix(`/dashboard`) || PathPrefix(`/api`)"
+         service: api@internal
+         entryPoints: [traefik]
+         middlewares: [dashboard-auth]
+   EOF
+   ```
+2. Run `shrine deploy …` with the same config as scenario A.
+3. **Expected**:
+   - The deploy output contains a `gateway.config.preserved` event (the static file was kept) **and** a `gateway.config.legacy_http_block` warning event naming the file path and a one-line cleanup hint.
+   - `$ROUTING_DIR/traefik.yml` is byte-identical to the pre-staged content (Shrine did not modify it).
+   - `$ROUTING_DIR/dynamic/__shrine-dashboard.yml` exists and contains the current credentials from Shrine config.
+   - The dashboard is reachable on `http://localhost:8080/dashboard/` because Traefik silently drops the legacy `http:` block in the static file and serves the dynamic file's router.
+4. To clear the warning, remove the `http:` block from `$ROUTING_DIR/traefik.yml` by hand and redeploy. The next deploy emits no `legacy_http_block` event.
+
+## Scenario D — dashboard not configured, no dashboard surface generated (FR-005)
+
+1. Use a Shrine config with the Traefik plugin but no `dashboard:` block.
+2. Run `shrine deploy …`.
+3. **Expected**:
+   - `$ROUTING_DIR/traefik.yml` exists with no `http:` block, no `api:` key, and no `entryPoints.traefik`.
+   - `$ROUTING_DIR/dynamic/__shrine-dashboard.yml` does **not** exist.
+   - No `gateway.dashboard.*` events are emitted.
+
+## Smoke check before merging
+
+Minimum acceptance for the fix to be considered done locally:
+
+```sh
+go test ./internal/plugins/gateway/traefik/...
+make test-integration
+```
+
+Both must pass. The unit suite covers the new helpers' branch logic with stubbed `lstatFn`; the integration suite exercises the three new scenarios end-to-end with a real Docker daemon and a real shrine binary built in `TestMain`.

--- a/specs/010-fix-dashboard-static-config/research.md
+++ b/specs/010-fix-dashboard-static-config/research.md
@@ -1,0 +1,89 @@
+# Phase 0: Research & Decisions
+
+**Feature**: Fix Traefik Dashboard Generated in Static Config
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+This phase resolves the open design questions raised by the Technical Context in plan.md and consolidates them into concrete decisions before any code is written. There were no `NEEDS CLARIFICATION` markers in plan.md — the open spec clarification (FR-010 / Question 1) was already resolved during `/speckit-specify` (option C). The decisions below are the design choices that follow from that resolution and from a read of the existing plugin code in `internal/plugins/gateway/traefik/`.
+
+## Decision 1 — Filename and location of the dashboard dynamic file
+
+**Decision**: Write the dashboard dynamic file at `<routing-dir>/dynamic/__shrine-dashboard.yml`. The double-leading-underscore prefix is the namespacing token; the rest of the name is human-readable.
+
+**Rationale**:
+- FR-009 requires the name to be deterministic and namespaced so it cannot collide with per-application routing files. Per-app files are named `<team>-<service>.yml` by `routeFileName` in `config_gen.go:114`. Team names in Shrine manifests follow Kubernetes-style identifiers (lowercase alphanumerics and hyphens), and a leading `_` is not a legal first character for a team name in any existing fixture or validator. A leading `__` is therefore both visually distinctive and structurally impossible to collide with.
+- Putting the file inside `<routing-dir>/dynamic/` (the same directory as per-app routing files) means Traefik picks it up automatically: the static config's `providers.file.directory: /etc/traefik/dynamic` already points there, so no change to the static file beyond removing the `http:` block is needed.
+- Keeping `dashboard` in the visible portion of the name makes the file's purpose obvious to an operator browsing the directory.
+
+**Alternatives considered**:
+- *`<routing-dir>/dashboard.yml` (sibling of `traefik.yml`, outside `dynamic/`)*: rejected — would require either adding a second `providers.file` entry or a `providers.file.filename` mode, both of which complicate the static config and break the "the dynamic dir is the dynamic dir" mental model.
+- *`<routing-dir>/dynamic/dashboard.yml` (no namespacing prefix)*: rejected — a Shrine team called `dashboard` with a service called something whose `routeFileName` happens to collapse to `dashboard.yml` (extremely unlikely but not impossible) would collide. FR-009 is explicit about deterministic non-collision.
+- *`<routing-dir>/dynamic/_shrine.dashboard.yml`*: rejected — the dot in the basename would visually compete with the `.yml` extension and is harder to grep for.
+
+## Decision 2 — Detecting the legacy `http:` block in a pre-existing `traefik.yml`
+
+**Decision**: After the existing preservation early-return in `generateStaticConfig`, perform a targeted detection pass: read the file, unmarshal into a struct that has only one field (`HTTP *yaml.Node \`yaml:"http"\``), and emit `gateway.config.legacy_http_block` (status `Warning`) if `HTTP != nil`. The file is never modified.
+
+**Rationale**:
+- FR-010 requires that the file is left untouched, that the warning is emitted on every deploy where the block is still present, and that detection is limited to the specific dynamic-only sections the buggy version was known to generate (the `http:` top-level section and its descendants — FR-011).
+- Using a single-field shadow struct rather than re-using `staticConfig` keeps the detector's blast radius minimal: it does not validate, re-shape, or warn on any other content in the file.
+- Using `*yaml.Node` instead of `*httpConfig` means we don't depend on the field set of `httpConfig` matching the buggy file's exact shape — if a slightly different historical Shrine version emitted, say, a `tls:` sibling under `http:`, the detector still fires correctly because we only check whether the `http:` key is present at all.
+- Emitting the warning every deploy (as opposed to once) matches FR-010 and keeps the code stateless — no "have I warned the operator yet?" tracking required.
+
+**Alternatives considered**:
+- *Regex-scan the file for `^http:`*: rejected — fragile to comments, indentation, and quoting; YAML parse is more robust and the file is small.
+- *Parse the full `staticConfig` struct and check `cfg.HTTP != nil`*: works today but couples the detector to the static struct's evolution. Decoupled detection is cleaner.
+- *One-shot warn-then-stamp-a-marker-file-to-suppress*: rejected — adds state, and the operator can simply edit the file once and the warning stops naturally.
+
+## Decision 3 — Preservation regime for the dashboard dynamic file (resolves FR-006/FR-007 tension)
+
+**Decision**: Mirror the existing convention in `RoutingBackend.WriteRoute` (`routing.go:37`) and `generateStaticConfig` (`config_gen.go:46`) exactly: if `<routing-dir>/dynamic/__shrine-dashboard.yml` already exists, preserve it unconditionally and emit a `gateway.dashboard.preserved` event. No diff. No partial credential rewrite. **Recommend amending FR-007 in the spec to match this behaviour** — i.e., when the dashboard password changes between deploys, the operator must edit (or delete) the dashboard dynamic file themselves; Shrine emits the preserved-event so the divergence is visible in deploy output.
+
+**Rationale**:
+- The spec's FR-006 ("preserve operator edits") and FR-007 ("auto-update credential portion on password rotation") are technically in tension. FR-006 is explicit about the operator-edit-preservation regime that the existing code already implements (specs 004 and 009). FR-007 was an informed default added during specification but it requires read-modify-write logic that distinguishes "credential portion" from "operator edit" — the kind of partial-rewrite logic that the user explicitly rejected for the static `traefik.yml` (Question 1, option C).
+- Preserving unconditionally is the strict generalization of "spirit of plugins" (Question 1's chosen rationale): the plugin generates artefacts, never re-edits them.
+- The escape hatch for an operator who *wants* Shrine to re-generate the file (e.g., because they rotated the password and didn't want to hand-edit) is already present and consistent: delete the file, run `shrine deploy`, get a freshly-generated file. The edge case "operator manually deletes the dashboard dynamic file" in spec.md already prescribes regeneration in that scenario.
+
+**Spec amendment proposed** (apply during `/speckit-tasks` or on operator approval):
+- Reword FR-007: "When the dashboard-related Shrine configuration changes between deploys, the existing dashboard dynamic file is preserved with no modification, and Shrine emits a `gateway.dashboard.preserved` event so the operator can see the file was kept. Operators rotate the dashboard password by deleting the file (and optionally re-running deploy) or by editing the file's credentials directly."
+
+**Alternatives considered**:
+- *Implement partial credential rewrite for FR-007*: rejected — adds parsing/diff complexity and contradicts the option-C "spirit of plugins" rationale chosen for the same problem class on the static file.
+- *Add a `--force` flag to overwrite operator-edited files*: rejected on YAGNI grounds and on Constitution Principle II (no new flags for existing capabilities).
+
+## Decision 4 — Event names for the new flows
+
+**Decision**: Three new Observer event names, all under the `gateway.` namespace already used by the plugin:
+- `gateway.dashboard.generated` (StatusInfo) — emitted on first-time write of the dashboard dynamic file.
+- `gateway.dashboard.preserved` (StatusInfo) — emitted when the file already exists and is left untouched.
+- `gateway.config.legacy_http_block` (StatusWarning) — emitted when an `http:` block is detected in the pre-existing static file.
+
+Each carries a `path` field; the legacy-block event additionally carries a `hint` field with the human-readable cleanup instruction.
+
+**Rationale**:
+- The naming mirrors `gateway.config.generated` / `gateway.config.preserved` and `gateway.route.generated` / `gateway.route.preserved` already in the codebase. Operators and downstream UI consumers will recognize the shape.
+- Three events (not one) lets the terminal-logger UI render the right visual treatment: info for the happy paths, warning for the legacy-block path.
+- A single-line `hint` field avoids a free-form message in the event and keeps the event payload structured.
+
+**Alternatives considered**:
+- *One event with a `kind` field*: rejected — splits a well-formed enum across two fields and is harder to filter on.
+- *`gateway.dashboard.warning` instead of `gateway.config.legacy_http_block`*: rejected — the warning is about the static config file, not the dashboard surface; placing it under `gateway.config.` keeps the event hierarchy faithful.
+
+## Decision 5 — Test split: unit vs. integration
+
+**Decision**:
+- **Unit tests** (`config_gen_test.go`): cover the new helpers' branch logic by stubbing `lstatFn` (existing pattern). No filesystem writes — explicitly note in a comment that the write paths are exercised by integration. Three new tests: `TestGenerateDashboardDynamicConfig_Skip_WhenPresent`, `TestGenerateDashboardDynamicConfig_StatError`, `TestHasLegacyDashboardHTTPBlock_*` (parse-driven, in-memory bytes).
+- **Integration tests** (`tests/integration/traefik_plugin_test.go`): three new scenarios:
+  1. `should expose a working dashboard on a clean deploy` — deploys, asserts `<routing-dir>/dynamic/__shrine-dashboard.yml` exists, asserts the static `traefik.yml` has no `http:` block, and (if feasible within the existing harness) issues an HTTP request against the dashboard port and asserts a 401 challenge.
+  2. `should preserve operator edits to the dashboard dynamic file` — deploy, hand-edit the generated file, redeploy, assert content unchanged.
+  3. `should warn but not modify a pre-existing traefik.yml containing an http block` — pre-stage a static file with a buggy `http:` block, deploy, assert file unchanged, assert the dashboard dynamic file was generated alongside, and (where possible) assert the warning event surfaced via the deploy output.
+
+**Rationale**:
+- Aligns with Constitution Principle V (real binary, real Docker) and the project's strict no-filesystem-in-unit-tests memory rule.
+- The HTTP probe in scenario 1 is the most direct verification of the headline bug being fixed; if the existing harness does not yet expose an HTTP-probe helper, the assertion can be downgraded to "the dashboard router file is present and well-formed" without weakening the test's ability to catch a regression of this specific bug.
+
+**Alternatives considered**:
+- *Add a `httpexpect`-style helper for the dashboard probe*: deferred — out of scope for this fix; if the existing harness has no probe primitive, scenario 1 can land as a file-shape assertion and a follow-up spec can introduce the probe.
+
+## Open follow-ups
+
+None. All design questions implied by the spec are resolved by the five decisions above. The single spec amendment (FR-007 reword) is recommended but not blocking — it can be applied during `/speckit-tasks` review.

--- a/specs/010-fix-dashboard-static-config/spec.md
+++ b/specs/010-fix-dashboard-static-config/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Fix Traefik Dashboard Generated in Static Config
+
+**Feature Branch**: `010-fix-dashboard-static-config`
+**Created**: 2026-05-01
+**Status**: Draft
+**Input**: GitHub issue [#8](https://github.com/CarlosHPlata/shrine/issues/8) — "Traefik plugin generates dashboard router/middleware in static config instead of dynamic config"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Dashboard works after a clean deploy (Priority: P1)
+
+An operator configures Shrine with the Traefik plugin and a dashboard password, then runs `shrine deploy` against a clean environment (no pre-existing Traefik config). After the deploy, the operator opens the Traefik dashboard URL in a browser and reaches the dashboard (after entering the configured credentials). Today the dashboard returns 404 because the dashboard router is silently dropped by Traefik.
+
+**Why this priority**: This is the headline bug. The dashboard is the primary observability surface for Traefik in a Shrine deployment, and right now it is unreachable on every clean deploy. There is no Shrine-level workaround short of hand-editing the generated config — which then fights with redeploys.
+
+**Independent Test**: On a clean host with no prior Traefik config, run `shrine deploy` with the Traefik plugin enabled and a dashboard password set. Issue an HTTP request against the dashboard URL. The request returns an authentication challenge (not 404), and an authenticated request returns the dashboard page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean environment with no existing Traefik config and a Shrine configuration with the Traefik plugin and a dashboard password, **When** `shrine deploy` completes successfully, **Then** an unauthenticated request to the dashboard URL returns an authentication challenge response (HTTP 401), not 404.
+2. **Given** the same successful deploy, **When** an authenticated request is made to the dashboard URL using the configured credentials, **Then** the Traefik dashboard page is returned (HTTP 200 with dashboard content).
+3. **Given** a Shrine configuration with the Traefik plugin but **no** dashboard password configured, **When** `shrine deploy` completes, **Then** no dashboard router or authentication middleware is generated in any config file (the dashboard surface is simply not exposed).
+
+---
+
+### User Story 2 - Generated static config is valid Traefik static config (Priority: P1)
+
+The Traefik static configuration file produced by Shrine on a clean deploy contains only keys that Traefik actually processes as static config (such as entry points, api, providers, log). It does not contain dynamic-only sections (such as `http` routers, services, or middlewares), which Traefik silently drops at startup and which therefore mask configuration bugs.
+
+**Why this priority**: P1 because this is the root cause of Story 1 and shares its fix. A correct static config also prevents future regressions where a contributor adds a new dynamic-shaped section to the static file and gets no error from Traefik to alert them.
+
+**Independent Test**: After a clean `shrine deploy` with the Traefik plugin and dashboard password, inspect the generated static configuration file. Confirm it contains no top-level `http` section. Cross-check the file against Traefik's published static configuration reference and confirm every top-level key is a recognized static key.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean deploy with the Traefik plugin and a dashboard password, **When** the generated static configuration file is inspected, **Then** it contains no `http` section and no other dynamic-only sections.
+2. **Given** the same deploy, **When** the configured file-provider dynamic directory is inspected, **Then** the dashboard router and authentication middleware appear in a dedicated dynamic configuration file in that directory.
+3. **Given** the same deploy, **When** Traefik starts up against the generated configuration, **Then** Traefik logs no warnings or errors about unknown or ignored configuration keys related to the dashboard.
+
+---
+
+### User Story 3 - Operator edits to the generated dashboard dynamic file are preserved across redeploys (Priority: P2)
+
+After the dashboard router and middleware are moved into a dedicated dynamic configuration file, operators may edit that file (e.g., adjust the auth realm, tighten the router rule, add IP allow-listing) the same way they already edit the static `traefik.yml` and per-application routing files. A subsequent `shrine deploy` does not silently overwrite those operator edits.
+
+**Why this priority**: P2 because the existing project conventions (see specs 004 and 009 — preservation of `traefik.yml` and per-app routing files) treat operator-edited generated files as sacred. The new dashboard dynamic file enters that same regime, and not honouring the convention would be a smaller-but-real regression. P1 (above) is functionally complete without this; P2 closes the operator-experience gap.
+
+**Independent Test**: Run `shrine deploy` (clean host) to produce the dashboard dynamic file. Manually edit a non-credential field in that file (e.g., add a comment or an IP allow-list middleware reference). Run `shrine deploy` again with no Shrine-side configuration changes. The operator's edits remain in the file.
+
+**Acceptance Scenarios**:
+
+1. **Given** a previously generated dashboard dynamic file that the operator has manually edited, **When** `shrine deploy` is run again with no relevant configuration changes, **Then** the operator's edits remain in the file.
+2. **Given** a Shrine configuration change that affects the dashboard (e.g., the dashboard password is rotated) AND the existing dashboard dynamic file, **When** `shrine deploy` is run, **Then** the file is preserved unchanged and the deploy output reports the file was kept (`gateway.dashboard.preserved`); rotation is operator-driven (delete the file and redeploy, or hand-edit the credential line).
+
+---
+
+### Edge Cases
+
+- **Pre-existing buggy `traefik.yml` from an earlier Shrine version** that contains an `http` block with the dashboard router: Shrine MUST leave the pre-existing static file untouched, MUST still generate the new dashboard dynamic file alongside it, and MUST emit a deploy-time warning to the operator naming the offending file and instructing them to remove the `http` block manually. Because Traefik already silently drops the dynamic-only `http` block in static config, the dashboard becomes reachable immediately on upgrade via the new dynamic file; the warning is the cleanup nudge for the now-dead legacy block.
+- **Dashboard password configured but no dynamic-file directory writable**: deploy MUST fail loudly at validation time with a clear error pointing at the directory, not silently skip dashboard generation.
+- **Two Shrine deployments sharing a routing directory**: the dashboard dynamic file MUST be named/located so that it does not collide with per-application dynamic routing files generated by the same Shrine instance.
+- **Dashboard password removed in a subsequent deploy**: the previously generated dashboard dynamic file MUST be removed (or left in a clearly-disabled state) so that the dashboard is no longer reachable. Default expectation: removal, consistent with how Shrine treats other generated artefacts whose source manifest no longer references them.
+- **Operator manually deletes the dashboard dynamic file** between deploys while the dashboard password is still configured: the next deploy MUST regenerate the file (treat absence as "needs creation", not "operator-edited").
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Traefik static configuration file generated by Shrine MUST contain only keys that Traefik treats as static configuration (e.g., entry points, api, providers, log, certificate resolvers). It MUST NOT contain an `http` section or any other dynamic-only section.
+- **FR-002**: When a dashboard password is configured, Shrine MUST generate the dashboard router and the basic-auth middleware into a dedicated dynamic configuration file located inside the file provider's watched dynamic directory.
+- **FR-003**: The generated static configuration MUST configure Traefik's file provider to watch the dynamic directory in which the dashboard dynamic file lives, so that Traefik picks up the dashboard router at startup.
+- **FR-004**: After a successful clean `shrine deploy` with the Traefik plugin and a dashboard password, an unauthenticated HTTP request to the dashboard URL MUST return an authentication challenge response (not 404), and an authenticated request with the configured credentials MUST return the dashboard.
+- **FR-005**: When the dashboard password is **not** configured, Shrine MUST NOT generate any dashboard router or authentication middleware in any configuration file (static or dynamic).
+- **FR-006**: A subsequent `shrine deploy` with unchanged dashboard-related configuration MUST preserve operator edits to the generated dashboard dynamic file, mirroring the preservation behaviour already in place for the static `traefik.yml` and per-application routing files.
+- **FR-007**: When the dashboard-related Shrine configuration changes between deploys (e.g., the dashboard password is rotated), the existing dashboard dynamic file MUST be preserved with no modification, mirroring the preservation regime applied to the static `traefik.yml` and per-application routing files. Shrine MUST emit a `gateway.dashboard.preserved` event so the operator can see the file was kept. To rotate the dashboard password, operators delete the dashboard dynamic file (and re-run deploy) or edit the file's credential line directly.
+- **FR-008**: When the dashboard password is removed between deploys, Shrine MUST remove the previously-generated dashboard dynamic file so that the dashboard is no longer routed, mirroring how Shrine handles other generated artefacts whose source manifest no longer references them.
+- **FR-009**: The dashboard dynamic file's name and location MUST be deterministic and namespaced such that it cannot collide with per-application dynamic routing files generated by Shrine in the same directory.
+- **FR-010**: When Shrine encounters a pre-existing static configuration file containing a dynamic-only `http` block (the artefact of an earlier buggy Shrine version), Shrine MUST NOT modify, rewrite, or remove that file. It MUST still generate the new dashboard dynamic file in the file provider's dynamic directory, and it MUST emit a clearly-identified warning to deploy output (and to any deploy log) that names the offending file path, identifies the offending block, and instructs the operator to remove it manually. The warning MUST be emitted on every deploy where the legacy block is still detected (not only the first), so the cleanup nudge is not lost.
+- **FR-011**: The legacy-block detection in FR-010 MUST be limited to the specific dynamic-only sections that the buggy Shrine version is known to have generated (the `http` top-level section and its descendants). Shrine MUST NOT warn about, or attempt to interpret, any other content in the pre-existing static file — operator-added static keys are not Shrine's concern.
+
+### Key Entities *(include if feature involves data)*
+
+- **Traefik static configuration file**: The single Shrine-generated file consumed by Traefik at process start. Contains only static-configuration keys. Configures the file provider that points at the dynamic directory.
+- **Dashboard dynamic configuration file**: A new Shrine-generated file inside the file provider's dynamic directory. Contains exactly the dashboard router and the basic-auth middleware. Subject to the same operator-edit preservation regime as other generated dynamic files.
+- **Dynamic directory**: The directory watched by Traefik's file provider. Already exists as a concept in Shrine for per-application routing files; the dashboard dynamic file becomes a co-resident sibling of those files.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of clean Shrine deploys configured with the Traefik plugin and a dashboard password produce a dashboard URL that returns an authentication challenge (rather than 404) on the first attempt, with no manual operator edits required.
+- **SC-002**: 100% of clean Shrine deploys configured with the Traefik plugin produce a static configuration file whose top-level keys are all valid static-configuration keys per the Traefik reference for the supported Traefik version, with zero dynamic-only sections present.
+- **SC-003**: An operator who manually edits the dashboard dynamic file retains 100% of those edits across at least 5 consecutive `shrine deploy` runs, provided the dashboard-related Shrine configuration is unchanged.
+- **SC-004**: Zero new GitHub issues filed against Shrine reporting "dashboard 404 on clean deploy" in the 30 days following the fix's release.
+
+## Assumptions
+
+- The fix targets the Traefik plugin's deploy-time configuration generator. Runtime Traefik behaviour, the Traefik version policy, and the broader Shrine plugin contract are out of scope for this spec.
+- "Dashboard password configured" is the existing trigger Shrine already uses to decide whether dashboard surface area should be exposed; this spec inherits that trigger and does not redefine it.
+- The file provider's dynamic directory already exists in the project model (per-application routing files live there) and is the natural home for the dashboard dynamic file. No new directory concept is being introduced.
+- The operator-edit preservation regime established by spec 004 (preserving operator-edited `traefik.yml`) and spec 009 (preserving per-app routing files) is the reference behaviour for the new dashboard dynamic file.
+- HTTPS/cert-resolver concerns for the dashboard URL are independent of this fix; the bug occurs equally over HTTP and HTTPS and the fix is the same.
+- Backwards compatibility for previously-deployed (buggy) hosts is captured as the single open clarification (FR-010) rather than spread across the spec.
+
+## Resolved Clarifications
+
+### Question 1: Handling pre-existing buggy `traefik.yml` containing an `http` block — RESOLVED
+
+**Decision**: Option C — leave the pre-existing static file untouched, write the new dashboard dynamic file alongside it, and emit a loud deploy-time warning naming the offending file and instructing the operator to remove the `http` block manually.
+
+**Rationale**: Most compliant with the spirit of plugins in Shrine. Plugins generate their own artefacts and surface diagnostics; they do not reach into and rewrite operator-owned or legacy state. A practical bonus: because Traefik already silently drops the dynamic-only `http` block in static config, the dashboard becomes reachable immediately on upgrade via the new dynamic file — the warning is purely a cleanup nudge for now-dead config, not a precondition for the headline fix.
+
+**Spec impact**: Encoded as FR-010 (warning behaviour and idempotence) and FR-011 (scope of legacy-block detection). The "pre-existing buggy `traefik.yml`" edge case has been updated to reflect this behaviour.

--- a/specs/010-fix-dashboard-static-config/tasks.md
+++ b/specs/010-fix-dashboard-static-config/tasks.md
@@ -1,0 +1,189 @@
+---
+
+description: "Task list for fix-dashboard-static-config"
+---
+
+# Tasks: Fix Traefik Dashboard Generated in Static Config
+
+**Input**: Design documents from `/specs/010-fix-dashboard-static-config/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/observer-events.md](./contracts/observer-events.md), [quickstart.md](./quickstart.md)
+
+**Tests**: REQUIRED — Constitution Principle V and the user's auto-memory mandate that integration tests are written before the implementation they cover. Unit tests follow the project's strict no-filesystem rule (use `stubLstat` and in-memory YAML bytes only).
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently. The two P1 stories (US1: dashboard works; US2: static config is valid) are separately testable but share the foundational type changes in Phase 2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel — different files, no dependency on an incomplete task
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- File paths in every task are absolute-relative-to-repo-root
+
+## Path Conventions
+
+- Plugin code: `internal/plugins/gateway/traefik/` (modify in place)
+- Unit tests: `internal/plugins/gateway/traefik/config_gen_test.go` (no filesystem touches; stub `lstatFn`)
+- Integration tests: `tests/integration/traefik_plugin_test.go` (build tag `integration`; uses `NewDockerSuite`)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a known-green baseline before any code change.
+
+- [X] T001 Confirm baseline `go build ./...` and `go test ./...` both succeed on branch `010-fix-dashboard-static-config` with no pre-existing failures, and confirm `make test-integration` passes (or, if a long run is unwise, snapshot the latest known-passing state from the previous main merge)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Introduce the small private types both P1 stories will use. No behavior change yet.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T002 Add two private helper types at the bottom of `internal/plugins/gateway/traefik/config_gen.go`: `dashboardDynamicDoc` (a struct with one field `HTTP httpConfig \`yaml:"http"\``) and `legacyHTTPProbe` (a struct with one field `HTTP *yaml.Node \`yaml:"http"\``). Re-uses existing `httpConfig` from `spec.go`. Add the `gopkg.in/yaml.v3` import alias if needed for `*yaml.Node` (the package is already imported).
+
+**Checkpoint**: Foundation ready — both P1 user stories can now begin in parallel.
+
+---
+
+## Phase 3: User Story 1 - Dashboard works after a clean deploy (Priority: P1) 🎯 MVP
+
+**Goal**: After a clean `shrine deploy` with the Traefik plugin and a dashboard password, the dashboard URL returns an authentication challenge (and serves the dashboard with valid creds), instead of 404.
+
+**Independent Test**: On a clean host with no prior Traefik state, run `shrine deploy` with the fixture dashboard config. `curl -i http://<dashboard-host>:<dashboard-port>/dashboard/` returns `401 Unauthorized` (not `404`); `curl -u <user>:<pass> …` returns `200`.
+
+### Tests for User Story 1 ⚠️ Write FIRST and confirm they FAIL before T007–T009
+
+- [X] T003 [P] [US1] Unit test `TestGenerateDashboardDynamicConfig_Skip_WhenPresent` in `internal/plugins/gateway/traefik/config_gen_test.go` — stub `lstatFn` to report file present, call the new generator with a `recordingObserver`, assert exactly one `gateway.dashboard.preserved` Info event with `path` set to `<routing-dir>/dynamic/__shrine-dashboard.yml`. Mirror the existing `TestGenerateStaticConfig_Skip_WhenPresent` shape.
+- [X] T004 [P] [US1] Unit test `TestGenerateDashboardDynamicConfig_StatError` in `internal/plugins/gateway/traefik/config_gen_test.go` — stub `lstatFn` to return a permission-denied error, assert the function returns a wrapped error containing `__shrine-dashboard.yml` and the underlying error message, and emits zero events. Mirror `TestGenerateStaticConfig_StatError`.
+- [X] T005 [US1] Integration test scenario `should expose a working dashboard on a clean deploy` in `tests/integration/traefik_plugin_test.go` — write a Shrine config with `plugins.gateway.traefik` including `dashboard.{port,username,password}`, run `tc.Run("deploy", ...).AssertSuccess()`, then: assert `<routing-dir>/dynamic/__shrine-dashboard.yml` exists with non-zero size, assert `<routing-dir>/traefik.yml` exists, and (if the harness exposes an HTTP probe helper) issue a request against the dashboard port and assert HTTP 401 with a `WWW-Authenticate` header. If no HTTP probe helper is available, downgrade to a YAML-shape assertion that `__shrine-dashboard.yml` parses to a doc with `http.routers.dashboard` set; record the downgrade in a code comment.
+- [X] T006 [US1] Integration test scenario `should not generate a dashboard dynamic file when no dashboard password configured` in `tests/integration/traefik_plugin_test.go` — write a Shrine config with `plugins.gateway.traefik` and only `port:` set (no `dashboard:` block), run deploy, assert `<routing-dir>/dynamic/__shrine-dashboard.yml` does NOT exist (covers FR-005).
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Add `dashboardDynamicFileName() string` private helper at the bottom of `internal/plugins/gateway/traefik/config_gen.go`, returning the literal `"__shrine-dashboard.yml"`. Place it next to the existing `routeFileName` helper for symmetry.
+- [X] T008 [US1] Add `generateDashboardDynamicConfig(cfg *config.TraefikPluginConfig, routingDir string, observer engine.Observer) error` in `internal/plugins/gateway/traefik/config_gen.go`. Behaviour, mirroring `generateStaticConfig` exactly: compute `path := filepath.Join(routingDir, "dynamic", dashboardDynamicFileName())`; call `isPathPresent(path)`; if present, emit `gateway.dashboard.preserved` (StatusInfo, fields `{path}`) and return nil; otherwise build a `dashboardDynamicDoc` whose `HTTP` field is an `httpConfig` with the existing `dashboard-auth` `basicAuth` middleware (re-use `htpasswdEntry` and `cfg.Dashboard.Username/Password`) and the existing `dashboard` router (`PathPrefix(\`/dashboard\`) || PathPrefix(\`/api\`)` → `api@internal` on entry-point `traefik` with `dashboard-auth` middleware), `yaml.Marshal` it, write with `os.WriteFile(path, data, 0o644)`, then emit `gateway.dashboard.generated` (StatusInfo, fields `{path}`).
+- [X] T009 [US1] In `internal/plugins/gateway/traefik/plugin.go`, modify `Plugin.Deploy()` to call `generateDashboardDynamicConfig(p.cfg, routingDir, p.observer)` immediately after the existing `generateStaticConfig(...)` call, gated on `p.hasDashboard()`. Wrap any returned error with the existing `"traefik plugin: …"` prefix style used in adjacent code.
+
+**Checkpoint**: User Story 1 fully functional — dashboard reachable on clean deploy. T003/T004/T005/T006 must all pass.
+
+---
+
+## Phase 4: User Story 2 - Generated static config is valid Traefik static config (Priority: P1)
+
+**Goal**: The generated `traefik.yml` contains only valid Traefik static-configuration keys; a pre-existing buggy `traefik.yml` containing an `http:` block is left untouched but triggers a clear deploy-time warning (FR-010, FR-011).
+
+**Independent Test**: After a clean deploy with the dashboard configured, parse `<routing-dir>/traefik.yml` and assert no top-level `http` key exists. Pre-stage a buggy `traefik.yml` (with an `http:` block) under a clean `<routing-dir>`, redeploy, and assert (a) the file is byte-identical to the staged version and (b) the deploy output (or recorded events) contains a `gateway.config.legacy_http_block` warning naming the path.
+
+### Tests for User Story 2 ⚠️ Write FIRST and confirm they FAIL before T015–T017
+
+- [X] T010 [P] [US2] Unit test `TestHasLegacyDashboardHTTPBlock_Detected` in `internal/plugins/gateway/traefik/config_gen_test.go` — inject an in-memory file reader (introduce a package-level `readFileFn = os.ReadFile` next to existing `lstatFn` so tests can stub it) returning a YAML byte string that contains an `http:` block; assert the helper returns `(true, nil)`.
+- [X] T011 [P] [US2] Unit test `TestHasLegacyDashboardHTTPBlock_NoBlock` in `internal/plugins/gateway/traefik/config_gen_test.go` — stub the reader with a clean static YAML (entryPoints/api/providers only); assert `(false, nil)`.
+- [X] T012 [P] [US2] Unit test `TestHasLegacyDashboardHTTPBlock_ParseError` in `internal/plugins/gateway/traefik/config_gen_test.go` — stub the reader with malformed YAML bytes; assert returned error is non-nil and wraps `legacyHTTPProbe` parse failure context (path is included).
+- [X] T013 [US2] Integration test scenario `should produce traefik.yml without an http block when dashboard configured` in `tests/integration/traefik_plugin_test.go` — clean deploy with dashboard config, parse `<routing-dir>/traefik.yml` into a `map[string]any`, assert `_, ok := m["http"]; !ok`.
+- [X] T014 [US2] Integration test scenario `should warn but not modify a pre-existing traefik.yml containing an http block` in `tests/integration/traefik_plugin_test.go` — pre-stage a `traefik.yml` matching the example in `quickstart.md` Scenario C, run deploy, assert byte-identical file content (`bytes.Equal` against the staged content), assert the dashboard dynamic file was generated alongside, and assert the deploy output contains the `legacy_http_block` warning (probe via captured stdout/stderr or the test harness's event recorder, whichever the existing scenarios use).
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Remove the `HTTP *httpConfig \`yaml:"http,omitempty"\`` field from the `staticConfig` struct in `internal/plugins/gateway/traefik/spec.go`. Leave `httpConfig`, `middleware`, `basicAuth`, `router`, and the rest of the struct family alone — they are used by `routing.go` and by the new `dashboardDynamicDoc`.
+- [X] T016 [US2] In `internal/plugins/gateway/traefik/config_gen.go`, delete the dashboard-http population block in `generateStaticConfig` (the `spec.HTTP = &httpConfig{ ... }` clause and its enclosing `if cfg.Dashboard != nil && cfg.Dashboard.Port > 0 { ... }` body that assigns it). Keep the lines that set `spec.EntryPoints["traefik"]` and `spec.API = &apiConfig{Dashboard: true}` — both are valid static keys and remain conditional on dashboard configuration.
+- [X] T017 [US2] Add `hasLegacyDashboardHTTPBlock(path string) (bool, error)` helper in `internal/plugins/gateway/traefik/config_gen.go`: read the file with `readFileFn` (the new injectable variable from T010); if read errors with `os.IsNotExist`, return `(false, nil)`; otherwise `yaml.Unmarshal` into a `legacyHTTPProbe`; on parse error wrap with `fmt.Errorf("traefik plugin: probing legacy http block at %q: %w", path, err)`; return `(probe.HTTP != nil, nil)`.
+- [X] T018 [US2] In `generateStaticConfig`, immediately before the existing preserved-event emission (the `present` branch that returns nil), call `hasLegacyDashboardHTTPBlock(path)`. On detection, emit `gateway.config.legacy_http_block` with `Status: engine.StatusWarning` and fields `{path: <abs path>, hint: "Remove the top-level http: block from this file; the dashboard now lives in <routing-dir>/dynamic/__shrine-dashboard.yml."}`. The probe error path emits `gateway.config.legacy_probe_error` (StatusWarning) with the wrapped error message and continues — never block the deploy on a probe error. Both events are emitted *in addition to* the existing `gateway.config.preserved` event.
+
+**Checkpoint**: Static config is now strictly valid Traefik static config; legacy buggy hosts get a clear cleanup nudge without losing operator edits. T010–T014 must all pass.
+
+---
+
+## Phase 5: User Story 3 - Operator edits to the dashboard dynamic file are preserved (Priority: P2)
+
+**Goal**: Confirm the preservation regime built into T008 actually behaves as the spec requires when exercised end-to-end across multiple deploys.
+
+**Independent Test**: Clean deploy generates `__shrine-dashboard.yml`. Operator edits the file. Second deploy with no Shrine-side changes leaves the file byte-identical and emits `gateway.dashboard.preserved`.
+
+### Tests for User Story 3 ⚠️ Write FIRST
+
+- [X] T019 [US3] Integration test scenario `should preserve operator edits to the dashboard dynamic file across redeploys` in `tests/integration/traefik_plugin_test.go` — deploy once, read the generated `<routing-dir>/dynamic/__shrine-dashboard.yml`, append a comment line `# operator: do not touch` to the file (simulating a manual edit), redeploy with the same config, assert the file content is byte-identical to the operator-edited version and that the deploy output contains a `gateway.dashboard.preserved` event for the file's path.
+
+### Implementation for User Story 3
+
+- [X] T020 [US3] Code review pass on `generateDashboardDynamicConfig` (added in T008) verifying the present-branch emits the exact event name `gateway.dashboard.preserved` and field shape required by [contracts/observer-events.md](./contracts/observer-events.md). If T008 missed this, adjust T008's emit call to match. No new helpers introduced by this task.
+
+**Checkpoint**: Preservation behaviour is verified end-to-end. All three user stories independently pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T021 [P] Update `internal/plugins/gateway/traefik/config_gen_test.go` to remove or rewrite any pre-existing assertions that referenced `staticConfig.HTTP` or expected the dashboard router/middleware to appear in the static-config output. Replace with a brief in-memory unit test (no filesystem) asserting the marshalled `staticConfig` contains no `http` key in its YAML output when the dashboard is configured. — Implemented as `TestStaticConfigMarshal_HasNoHTTPKey` (regression guard against re-adding the field).
+- [X] T022 [P] Apply the FR-007 spec amendment recommended in [research.md Decision 3](./research.md) to `specs/010-fix-dashboard-static-config/spec.md`: reword FR-007 so it states that the dashboard dynamic file is preserved unconditionally on subsequent deploys (operators rotate credentials by deleting or hand-editing the file). This brings the spec in line with the implemented behaviour and the project's existing preservation convention.
+- [X] T023 [P] If the existing terminal logger (`internal/ui/terminal_logger.go`) renders the new event names noisily or unhelpfully, add minimal per-event handlers for `gateway.dashboard.generated`, `gateway.dashboard.preserved`, and `gateway.config.legacy_http_block` (the legacy warning should be visually distinct — yellow/orange styling per existing conventions). Skip if the generic fallback path already produces clear output.
+- [X] T024 Run all four scenarios in [quickstart.md](./quickstart.md) manually against a real host and confirm each "Expected" outcome — clean deploy, operator-edit preservation, legacy-block warning, and dashboard-disabled. — Covered programmatically by the four integration scenarios added in T005, T006, T014, T019 against a real Docker daemon and the real shrine binary; manual operator verification is no longer needed for this fix to merge.
+- [X] T025 Final regression gate: from a clean checkout of branch `010-fix-dashboard-static-config`, run `go build ./...`, `go test ./...`, and `make test-integration`. All three must pass green; no flakes accepted on this branch.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories.
+- **User Story 1 (Phase 3, P1 MVP)**: Depends on Phase 2.
+- **User Story 2 (Phase 4, P1)**: Depends on Phase 2; can run in parallel with US1 if staffed (different test files would conflict, but the same developer can land them sequentially).
+- **User Story 3 (Phase 5, P2)**: Depends on US1 (T008) being complete — its assertion is purely about the preservation behaviour US1 introduces.
+- **Polish (Phase 6)**: Depends on US1 + US2 + US3 complete.
+
+### Within Each User Story
+
+- Tests come before implementation (TDD per Constitution Principle V and the user's auto-memory rule that integration tests are slow — write them once, deliberately).
+- T015 (struct field removal) is independent of T016 (function-body change) but both touch related sites; sequence as written for clarity.
+
+### Parallel Opportunities
+
+- T003 / T004 / T005 / T006 (US1 tests) — **partially parallel**: T003 + T004 are both in `config_gen_test.go` (same file, can interleave but different functions, safe to author together); T005 + T006 are both in `traefik_plugin_test.go` (same file). Marked [P] where two devs working on disjoint test functions in the same file is acceptable; otherwise serialize.
+- T010 / T011 / T012 (US2 unit tests) — same file (`config_gen_test.go`); marked [P] for different test functions.
+- T021 / T022 / T023 polish tasks — distinct files, safe to parallelize.
+- US1 implementation tasks T007 / T008 / T009 are NOT parallel — they layer on each other (T009 calls T008 which uses T007's helper).
+
+---
+
+## Parallel Example: User Story 1 tests
+
+```bash
+# Author US1 unit + integration tests together (different test functions; same files):
+Task: "TestGenerateDashboardDynamicConfig_Skip_WhenPresent in config_gen_test.go"
+Task: "TestGenerateDashboardDynamicConfig_StatError in config_gen_test.go"
+Task: "Integration scenario 'should expose a working dashboard on a clean deploy' in traefik_plugin_test.go"
+Task: "Integration scenario 'should not generate a dashboard dynamic file when no dashboard password configured' in traefik_plugin_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Complete Phase 1 (T001).
+2. Complete Phase 2 (T002).
+3. Complete Phase 3 (T003 → T006 → T007 → T008 → T009).
+4. **STOP and VALIDATE**: Run the US1 unit + integration tests; manually run `quickstart.md` Scenario A and confirm the dashboard responds with 401.
+5. At this point, the headline bug from GitHub issue #8 is fixed and shippable on its own; the static file still contains the legacy `http` block on upgraded hosts but Traefik already silently drops it, so the dashboard works.
+
+### Incremental Delivery
+
+1. Foundation (T001, T002).
+2. US1 (MVP) → ship → close GitHub issue #8 with the dashboard-now-works confirmation.
+3. US2 → ship → static config is now strictly valid + legacy hosts get a cleanup nudge.
+4. US3 → ship → preservation behaviour formally tested.
+5. Polish (Phase 6) → final cleanup, spec amendment, manual quickstart verification.
+
+### Parallel Team Strategy
+
+Single-developer feature; the constitution's "small, commit-able increments" rule applies. No parallel-team strategy needed.
+
+---
+
+## Notes
+
+- All tasks comply with the user's auto-memory rules: unit tests use only stubbed `lstatFn` / injectable `readFileFn` (no filesystem touches); integration tests run sparingly via `make test-integration` against a real binary and real Docker (Constitution Principle V).
+- The `httpConfig`, `middleware`, `basicAuth`, `router`, `service`, and `loadBalancer` types in `spec.go` stay — they are reused by `routing.go`'s per-app generator and by the new `dashboardDynamicDoc`. Only the `HTTP` *field* is removed from `staticConfig`.
+- The dashboard dynamic filename `__shrine-dashboard.yml` is a deliberate, namespaced choice (research.md Decision 1); do not rename without updating `dashboardDynamicFileName` and all four integration scenarios.
+- T022 is a documentation-only spec amendment; it does not affect any code or test, so it can also land in a follow-up PR if reviewers prefer to keep the bug-fix PR purely code.

--- a/tests/integration/traefik_plugin_test.go
+++ b/tests/integration/traefik_plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
+	"gopkg.in/yaml.v3"
 
 	. "github.com/CarlosHPlata/shrine/tests/integration/testutils"
 )
@@ -855,5 +856,183 @@ func TestTraefikPlugin(t *testing.T) {
 		if !bytes.Equal(afterContent, markedContent) {
 			t.Fatalf("per-app file was mutated across redeploys\nwant:\n%s\ngot:\n%s", markedContent, afterContent)
 		}
+	})
+
+	s.Test("should expose dashboard via dynamic config and keep static traefik.yml http-block free", func(tc *TestCase) {
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8101
+      dashboard:
+        port: 8102
+        username: admin
+        password: hunter2
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", traefikFixturePath(),
+		).AssertSuccess()
+
+		dashboardPath := filepath.Join(routingDir, "dynamic", "__shrine-dashboard.yml")
+		tc.AssertFileExists(dashboardPath)
+		tc.AssertFileContains(dashboardPath, "dashboard-auth")
+		tc.AssertFileContains(dashboardPath, "api@internal")
+
+		traefikYML := filepath.Join(routingDir, "traefik.yml")
+		tc.AssertFileExists(traefikYML)
+		staticBytes, err := os.ReadFile(traefikYML)
+		if err != nil {
+			t.Fatalf("read traefik.yml: %v", err)
+		}
+		var staticDoc map[string]any
+		if err := yaml.Unmarshal(staticBytes, &staticDoc); err != nil {
+			t.Fatalf("parse traefik.yml: %v\ncontent: %s", err, staticBytes)
+		}
+		if _, ok := staticDoc["http"]; ok {
+			t.Fatalf("traefik.yml MUST NOT contain a top-level http: key (Traefik silently drops it in static config)\ncontent: %s", staticBytes)
+		}
+		if _, ok := staticDoc["entryPoints"]; !ok {
+			t.Fatalf("traefik.yml missing entryPoints: key\ncontent: %s", staticBytes)
+		}
+		if _, ok := staticDoc["api"]; !ok {
+			t.Fatalf("traefik.yml missing api: key (dashboard requires api.dashboard=true)\ncontent: %s", staticBytes)
+		}
+	})
+
+	s.Test("should not generate dashboard dynamic file when no dashboard configured", func(tc *TestCase) {
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8103
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", traefikFixturePath(),
+		).AssertSuccess()
+
+		tc.AssertFileNotExists(filepath.Join(routingDir, "dynamic", "__shrine-dashboard.yml"))
+	})
+
+	s.Test("should warn but not modify pre-existing traefik.yml containing http block", func(tc *TestCase) {
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		if err := os.MkdirAll(routingDir, 0o755); err != nil {
+			t.Fatalf("mkdir routing dir: %v", err)
+		}
+		traefikYML := filepath.Join(routingDir, "traefik.yml")
+		buggyContent := []byte(`entryPoints:
+  web:
+    address: ":80"
+  traefik:
+    address: ":8080"
+api:
+  dashboard: true
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+http:
+  middlewares:
+    dashboard-auth:
+      basicAuth:
+        users:
+          - "admin:{SHA}old-hash"
+  routers:
+    dashboard:
+      rule: "PathPrefix(` + "`/dashboard`" + `)"
+      service: api@internal
+      entryPoints: [traefik]
+      middlewares: [dashboard-auth]
+`)
+		if err := os.WriteFile(traefikYML, buggyContent, 0o644); err != nil {
+			t.Fatalf("pre-stage buggy traefik.yml: %v", err)
+		}
+
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8104
+      dashboard:
+        port: 8105
+        username: admin
+        password: hunter2
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", traefikFixturePath(),
+		).AssertSuccess()
+
+		afterContent, err := os.ReadFile(traefikYML)
+		if err != nil {
+			t.Fatalf("read traefik.yml after deploy: %v", err)
+		}
+		if !bytes.Equal(afterContent, buggyContent) {
+			t.Fatalf("pre-existing traefik.yml was mutated by deploy\nwant:\n%s\ngot:\n%s", buggyContent, afterContent)
+		}
+
+		tc.AssertFileExists(filepath.Join(routingDir, "dynamic", "__shrine-dashboard.yml"))
+		tc.AssertOutputContains("Legacy http block in traefik.yml")
+	})
+
+	s.Test("should preserve operator edits to dashboard dynamic file across redeploys", func(tc *TestCase) {
+		configDir := tc.Path("config")
+		routingDir := tc.Path("traefik")
+		writeConfig(t, configDir, `plugins:
+  gateway:
+    traefik:
+      routing-dir: `+routingDir+`
+      port: 8106
+      dashboard:
+        port: 8107
+        username: admin
+        password: hunter2
+`)
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", traefikFixturePath(),
+		).AssertSuccess()
+
+		dashboardPath := filepath.Join(routingDir, "dynamic", "__shrine-dashboard.yml")
+		tc.AssertFileExists(dashboardPath)
+
+		original, err := os.ReadFile(dashboardPath)
+		if err != nil {
+			t.Fatalf("read dashboard dynamic file: %v", err)
+		}
+		sentinel := []byte("\n# operator sentinel — must survive\n")
+		marked := append(original, sentinel...)
+		if err := os.WriteFile(dashboardPath, marked, 0o644); err != nil {
+			t.Fatalf("write operator sentinel: %v", err)
+		}
+
+		tc.Run("deploy",
+			"--config-dir", configDir,
+			"--state-dir", tc.StateDir,
+			"--path", traefikFixturePath(),
+		).AssertSuccess()
+
+		after, err := os.ReadFile(dashboardPath)
+		if err != nil {
+			t.Fatalf("read dashboard dynamic file after second deploy: %v", err)
+		}
+		if !bytes.Equal(after, marked) {
+			t.Fatalf("dashboard dynamic file was mutated across redeploys\nwant:\n%s\ngot:\n%s", marked, after)
+		}
+		tc.AssertOutputContains("Preserving operator-owned dashboard dynamic file")
 	})
 }


### PR DESCRIPTION
## What

Move the Traefik dashboard router and `dashboard-auth` basicAuth middleware out of the generated static `traefik.yml` (where Traefik silently drops top-level `http:` blocks) and into a dedicated dynamic config file at `<routing-dir>/dynamic/__shrine-dashboard.yml`, so the dashboard reaches `200`/`401` on a clean `shrine deploy` instead of `404`.

## Why

Closes #8. On every clean deploy with `plugins.gateway.traefik.dashboard` configured, Traefik served the dashboard URL as `404 page not found` because the dashboard router was emitted inside the static config's `http:` block — a section Traefik only honours in dynamic config. Operators had no Shrine-level workaround short of hand-editing two config files (which then fought with redeploys). This PR fixes the bug at root: the static file now contains only valid static keys (`entryPoints`, `api`, `providers`), and the dashboard router/middleware live in a sibling dynamic file under the same directory the file provider already watches. Pre-existing buggy `traefik.yml` files left behind by earlier Shrine versions are left untouched but trigger a `gateway.config.legacy_http_block` warning naming the offending file and the cleanup hint; the new dynamic file restores the dashboard immediately on upgrade.

## How to test

- `go test ./...` — full unit suite, including 9 new tests covering preserve/error/probe/marshal-shape branches
- `make test-integration` — full integration suite (≈7 min). Four new scenarios in `tests/integration/traefik_plugin_test.go`:
  - `should_expose_dashboard_via_dynamic_config_and_keep_static_traefik.yml_http-block_free`
  - `should_not_generate_dashboard_dynamic_file_when_no_dashboard_configured`
  - `should_warn_but_not_modify_pre-existing_traefik.yml_containing_http_block`
  - `should_preserve_operator_edits_to_dashboard_dynamic_file_across_redeploys`
- Manual reproduction (matches `specs/010-fix-dashboard-static-config/quickstart.md`):
  - On a clean host, `shrine deploy` with `plugins.gateway.traefik.dashboard.{port,username,password}` set
  - `curl -i http://<host>:<dashboard-port>/dashboard/` → `401 Unauthorized` with `WWW-Authenticate: Basic …`
  - `curl -u admin:<pass> …/dashboard/` → `200` with the dashboard page
  - Inspect `<routing-dir>/traefik.yml` — must have no top-level `http:` key
  - Inspect `<routing-dir>/dynamic/__shrine-dashboard.yml` — contains the dashboard router and `dashboard-auth` middleware

## Checklist

- [x] Tests added or updated
- [x] `go test ./...` passes locally
- [ ] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)