### PR TITLE
feat: support tls: true on routing.aliases entries (closes #13)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/011-traefik-tlsport-config"
+  "feature_directory": "specs/012-tls-alias-routers"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ spec:
       - host: gateway.tail9a6ddb.ts.net
         pathPrefix: /finances                  # required to start with `/`; trailing `/` normalized
         stripPrefix: true                      # default true when pathPrefix is set; set false to forward unchanged
+        tls: false                             # optional; when true, generated router uses web + websecure entrypoints
   dependencies:
     - kind: Resource
       name: hello-db
@@ -88,6 +89,8 @@ Each `env` entry uses exactly one of `value` / `valueFrom` / `template`. `templa
 Applications expose exactly two built-in outputs to other manifests: `host` (`<owner>.<name>`, the container DNS name) and `port` (`spec.port`). There is no `url` built-in — scheme composition is the consumer's job via `template`.
 
 If the backend handles the path prefix itself (Next.js with `basePath`, Grafana with `root_url`, JupyterLab with `base_url`), set `stripPrefix: false` on the alias — otherwise Shrine strips the prefix before the request reaches the backend, causing redirect loops and asset 404s. The deploy log's `routing.configure` event annotates affected aliases with `(no strip)` so you can confirm the opt-out took effect. See `specs/008-alias-strip-prefix/quickstart.md` for the full diagnosis-and-fix walkthrough.
+
+For TLS-terminated aliases, set `tls: true` to open the routing/entrypoint side only; certificate provisioning, ACME, and HTTPS redirects remain operator-owned via standard Traefik mechanisms (mirrors spec 011's `tlsPort` contract).
 
 ### Resource
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/011-traefik-tlsport-config/plan.md
+at specs/012-tls-alias-routers/plan.md
 <!-- SPECKIT END -->

--- a/internal/engine/backends.go
+++ b/internal/engine/backends.go
@@ -55,6 +55,7 @@ type AliasRoute struct {
 	Host        string
 	PathPrefix  string
 	StripPrefix bool
+	TLS         bool
 }
 
 type WriteRouteOp struct {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -323,6 +323,7 @@ func resolveAliasRoutes(aliases []manifest.RoutingAlias) []AliasRoute {
 			Host:        alias.Host,
 			PathPrefix:  prefix,
 			StripPrefix: strip,
+			TLS:         alias.TLS,
 		})
 	}
 	return routes
@@ -337,6 +338,9 @@ func formatAliasesForLog(routes []AliasRoute) string {
 		}
 		if r.PathPrefix != "" && !r.StripPrefix {
 			entry += " (no strip)"
+		}
+		if r.TLS {
+			entry += " (tls)"
 		}
 		entries = append(entries, entry)
 	}

--- a/internal/engine/engine_aliases_test.go
+++ b/internal/engine/engine_aliases_test.go
@@ -122,3 +122,61 @@ func TestFormatAliasesForLog(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveAliasRoutes_CarriesTLS(t *testing.T) {
+	input := []manifest.RoutingAlias{
+		{Host: "a.example.com", TLS: true},
+		{Host: "b.example.com", TLS: false},
+	}
+	routes := resolveAliasRoutes(input)
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	if routes[0].TLS != true {
+		t.Errorf("routes[0].TLS: got %v, want true", routes[0].TLS)
+	}
+	if routes[1].TLS != false {
+		t.Errorf("routes[1].TLS: got %v, want false", routes[1].TLS)
+	}
+}
+
+func TestFormatAliasesForLog_AppendsTLSMarker(t *testing.T) {
+	tests := []struct {
+		name   string
+		routes []AliasRoute
+		want   string
+	}{
+		{
+			name:   "host-only with tls",
+			routes: []AliasRoute{{Host: "a.example.com", TLS: true}},
+			want:   "a.example.com (tls)",
+		},
+		{
+			name:   "prefix with strip and tls",
+			routes: []AliasRoute{{Host: "a.example.com", PathPrefix: "/x", StripPrefix: true, TLS: true}},
+			want:   "a.example.com+/x (tls)",
+		},
+		{
+			name:   "prefix with no-strip and tls",
+			routes: []AliasRoute{{Host: "a.example.com", PathPrefix: "/x", StripPrefix: false, TLS: true}},
+			want:   "a.example.com+/x (no strip) (tls)",
+		},
+		{
+			name: "mixed tls and non-tls sorted",
+			routes: []AliasRoute{
+				{Host: "z.example.com", TLS: true},
+				{Host: "a.example.com", TLS: false},
+			},
+			want: "a.example.com,z.example.com (tls)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatAliasesForLog(tc.routes)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -89,7 +89,19 @@ func rejectTLSOutsideAliasEntries(data []byte) error {
 		return nil
 	}
 	if _, hasTLS := routing["tls"]; hasTLS {
-		return fmt.Errorf("parsing Application manifest: field tls is not valid at spec.routing; tls is only valid inside an alias entry under spec.routing.aliases[]")
+		return fmt.Errorf("parsing Application manifest %q: field tls is not valid at spec.routing; tls is only valid inside an alias entry under spec.routing.aliases[]", applicationName(doc))
 	}
 	return nil
+}
+
+func applicationName(doc map[string]any) string {
+	meta, ok := doc["metadata"].(map[string]any)
+	if !ok {
+		return "<unknown>"
+	}
+	name, ok := meta["name"].(string)
+	if !ok || name == "" {
+		return "<unknown>"
+	}
+	return name
 }

--- a/internal/manifest/parser.go
+++ b/internal/manifest/parser.go
@@ -45,6 +45,9 @@ func parseManifest(meta *Manifest, data []byte) (*Manifest, error) {
 		if err := yaml.Unmarshal(data, &app); err != nil {
 			return nil, fmt.Errorf("parsing Application manifest: %w", err)
 		}
+		if err := rejectTLSOutsideAliasEntries(data); err != nil {
+			return nil, err
+		}
 		meta.Application = &app
 	case ResourceKind:
 		var res ResourceManifest
@@ -66,4 +69,27 @@ func parseManifest(meta *Manifest, data []byte) (*Manifest, error) {
 		return nil, fmt.Errorf("unknown manifest kind: %q", meta.Kind)
 	}
 	return meta, nil
+}
+
+// rejectTLSOutsideAliasEntries enforces FR-005: the `tls` field is only valid
+// inside a spec.routing.aliases[] entry, never at spec.routing top level.
+// The strongly-typed unmarshal silently drops unknown fields, so we re-walk
+// the raw YAML to catch this one specific misuse.
+func rejectTLSOutsideAliasEntries(data []byte) error {
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil
+	}
+	spec, ok := doc["spec"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	routing, ok := spec["routing"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if _, hasTLS := routing["tls"]; hasTLS {
+		return fmt.Errorf("parsing Application manifest: field tls is not valid at spec.routing; tls is only valid inside an alias entry under spec.routing.aliases[]")
+	}
+	return nil
 }

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -260,5 +261,106 @@ func TestParse_ResourceManifest(t *testing.T) {
 	wantTemplate := "postgres://postgres:{{.password}}@{{.host}}:{{.port}}/{{.database}}"
 	if res.Spec.Outputs[4].Template != wantTemplate {
 		t.Errorf("Outputs[4].Template = %q, want %q", res.Spec.Outputs[4].Template, wantTemplate)
+	}
+}
+
+// parseBytes parses a manifest from an in-memory YAML byte slice without
+// touching the filesystem, allowing unit tests to stay fully in-memory.
+func parseBytes(data []byte) (*Manifest, error) {
+	meta, err := probeKind(data)
+	if err != nil {
+		return nil, err
+	}
+	return parseManifest(meta, data)
+}
+
+// appYAMLWithAliases builds a minimal Application manifest YAML containing the
+// given aliases block (already indented under routing:).
+func appYAMLWithAliases(aliasesYAML string) []byte {
+	return []byte("apiVersion: shrine/v1\nkind: Application\nmetadata:\n  name: test-app\n  owner: team-a\nspec:\n  image: myapp\n  port: 8080\n  routing:\n    domain: app.home.lab\n    aliases:\n" + aliasesYAML)
+}
+
+func TestParseApplication_RoutingAlias_TLS_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantTLS bool
+	}{
+		{
+			name:    "tls: true",
+			yaml:    "      - host: x.example.com\n        tls: true\n",
+			wantTLS: true,
+		},
+		{
+			name:    "tls: false",
+			yaml:    "      - host: x.example.com\n        tls: false\n",
+			wantTLS: false,
+		},
+		{
+			name:    "tls omitted",
+			yaml:    "      - host: x.example.com\n",
+			wantTLS: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := parseBytes(appYAMLWithAliases(tc.yaml))
+			if err != nil {
+				t.Fatalf("parseBytes returned error: %v", err)
+			}
+			aliases := m.Application.Spec.Routing.Aliases
+			if len(aliases) != 1 {
+				t.Fatalf("len(Aliases) = %d, want 1", len(aliases))
+			}
+			if aliases[0].TLS != tc.wantTLS {
+				t.Errorf("Aliases[0].TLS = %v, want %v", aliases[0].TLS, tc.wantTLS)
+			}
+		})
+	}
+}
+
+func TestParseApplication_RoutingAlias_TLS_RejectsNonBoolean(t *testing.T) {
+	// yaml.v3 rejects !!int and !!str values for a Go bool field.
+	// Quoted "yes"/"no" are treated as YAML booleans and accepted silently;
+	// only explicit non-boolean types (integers, quoted strings like "true")
+	// produce unmarshal errors.
+	cases := []struct {
+		name        string
+		aliasYAML   string
+		errContains string
+	}{
+		{
+			name:        "tls as quoted string true",
+			aliasYAML:   "      - host: x.example.com\n        tls: \"true\"\n",
+			errContains: "!!str",
+		},
+		{
+			name:        "tls as integer 1",
+			aliasYAML:   "      - host: x.example.com\n        tls: 1\n",
+			errContains: "!!int",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseBytes(appYAMLWithAliases(tc.aliasYAML))
+			if err == nil {
+				t.Fatalf("expected parse error for non-boolean tls, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+			}
+		})
+	}
+}
+
+func TestParseApplication_Routing_TLS_RejectsTopLevelField(t *testing.T) {
+	data := []byte("apiVersion: shrine/v1\nkind: Application\nmetadata:\n  name: test-app\n  owner: team-a\nspec:\n  image: myapp\n  port: 8080\n  routing:\n    domain: app.home.lab\n    tls: true\n")
+
+	if _, err := parseBytes(data); err == nil {
+		t.Fatal("expected error rejecting tls at spec.routing top level, got nil")
+	} else if !strings.Contains(err.Error(), "tls") || !strings.Contains(err.Error(), "spec.routing") {
+		t.Errorf("error message must name the offending field path; got: %v", err)
 	}
 }

--- a/internal/manifest/parser_test.go
+++ b/internal/manifest/parser_test.go
@@ -362,5 +362,7 @@ func TestParseApplication_Routing_TLS_RejectsTopLevelField(t *testing.T) {
 		t.Fatal("expected error rejecting tls at spec.routing top level, got nil")
 	} else if !strings.Contains(err.Error(), "tls") || !strings.Contains(err.Error(), "spec.routing") {
 		t.Errorf("error message must name the offending field path; got: %v", err)
+	} else if !strings.Contains(err.Error(), "test-app") {
+		t.Errorf("error message must name the offending application; got: %v", err)
 	}
 }

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -40,6 +40,7 @@ type RoutingAlias struct {
 	Host        string `yaml:"host"`
 	PathPrefix  string `yaml:"pathPrefix,omitempty"`
 	StripPrefix *bool  `yaml:"stripPrefix,omitempty"`
+	TLS         bool   `yaml:"tls,omitempty"`
 }
 
 // Used in Application spec

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -330,6 +330,66 @@ func TestValidate_RoutingAliasRules(t *testing.T) {
 	}
 }
 
+func TestValidateRoutingAliases_TLS_DoesNotAffectCollisionKey(t *testing.T) {
+	validBase := func(routing Routing) *Manifest {
+		return &Manifest{
+			TypeMeta: TypeMeta{Kind: ApplicationKind, APIVersion: "shrine/v1"},
+			Application: &ApplicationManifest{
+				Metadata: Metadata{Name: "a", Owner: "team-a"},
+				Spec:     ApplicationSpec{Image: "img", Port: 80, Routing: routing},
+			},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		routing Routing
+		wantErr string
+	}{
+		{
+			// FR-006: tls flag is not a uniqueness key; same host+pathPrefix with
+			// different tls values is still a duplicate collision.
+			name: "same host+pathPrefix different tls is still a duplicate",
+			routing: Routing{
+				Domain: "app.home.lab",
+				Aliases: []RoutingAlias{
+					{Host: "x.example.com", PathPrefix: "/api", TLS: false},
+					{Host: "x.example.com", PathPrefix: "/api", TLS: true},
+				},
+			},
+			wantErr: "alias[1]",
+		},
+		{
+			// Different hosts with both tls:true must not collide.
+			name: "different hosts both tls true is valid",
+			routing: Routing{
+				Domain: "app.home.lab",
+				Aliases: []RoutingAlias{
+					{Host: "a.example.com", TLS: true},
+					{Host: "b.example.com", TLS: true},
+				},
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := validBase(tc.routing)
+			err := Validate(m)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestValidate_InvalidTeam(t *testing.T) {
 	m, err := Parse(testdataPath("invalid-team.yml"))
 	if err != nil {

--- a/internal/plugins/gateway/traefik/plugin.go
+++ b/internal/plugins/gateway/traefik/plugin.go
@@ -181,5 +181,5 @@ func (p *Plugin) RoutingBackend() (engine.RoutingBackend, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &RoutingBackend{routingDir: routingDir, observer: p.observer}, nil
+	return &RoutingBackend{routingDir: routingDir, staticConfigPath: filepath.Join(routingDir, "traefik.yml"), observer: p.observer}, nil
 }

--- a/internal/plugins/gateway/traefik/routing.go
+++ b/internal/plugins/gateway/traefik/routing.go
@@ -39,7 +39,7 @@ func stripMiddlewareName(team, service string, aliasIndex int) string {
 
 func formatAliasEntry(ar engine.AliasRoute) string {
 	if ar.PathPrefix != "" {
-		return ar.Host + ar.PathPrefix
+		return ar.Host + "+" + ar.PathPrefix
 	}
 	return ar.Host
 }

--- a/internal/plugins/gateway/traefik/routing.go
+++ b/internal/plugins/gateway/traefik/routing.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -15,8 +17,9 @@ var mkdirAllFn = os.MkdirAll
 var removeFileFn = os.Remove
 
 type RoutingBackend struct {
-	routingDir string
-	observer   engine.Observer
+	routingDir       string
+	staticConfigPath string
+	observer         engine.Observer
 }
 
 func (r *RoutingBackend) dynamicDir() string {
@@ -34,10 +37,64 @@ func stripMiddlewareName(team, service string, aliasIndex int) string {
 	return fmt.Sprintf("%s-%s-strip-%d", team, service, aliasIndex)
 }
 
+func formatAliasEntry(ar engine.AliasRoute) string {
+	if ar.PathPrefix != "" {
+		return ar.Host + ar.PathPrefix
+	}
+	return ar.Host
+}
+
+func emitAliasTLSNoWebsecureSignal(op engine.WriteRouteOp, staticConfigPath string, observer engine.Observer) {
+	var tlsAliases []engine.AliasRoute
+	for _, ar := range op.AdditionalRoutes {
+		if ar.TLS {
+			tlsAliases = append(tlsAliases, ar)
+		}
+	}
+	if len(tlsAliases) == 0 {
+		return
+	}
+
+	ok, err := hasWebsecureEntrypoint(staticConfigPath)
+	if err != nil {
+		observer.OnEvent(engine.Event{
+			Name:   "gateway.config.tls_port_probe_error",
+			Status: engine.StatusWarning,
+			Fields: map[string]string{
+				"path":  staticConfigPath,
+				"error": err.Error(),
+			},
+		})
+		return
+	}
+	if ok {
+		return
+	}
+
+	entries := make([]string, 0, len(tlsAliases))
+	for _, ar := range tlsAliases {
+		entries = append(entries, formatAliasEntry(ar))
+	}
+	sort.Strings(entries)
+
+	observer.OnEvent(engine.Event{
+		Name:   "gateway.alias.tls_no_websecure",
+		Status: engine.StatusWarning,
+		Fields: map[string]string{
+			"team":        op.Team,
+			"name":        op.ServiceName,
+			"path":        staticConfigPath,
+			"tls_aliases": strings.Join(entries, ","),
+			"hint":        "Set plugins.gateway.traefik.tlsPort to publish a websecure entrypoint, or add the entrypoint to your preserved traefik.yml.",
+		},
+	})
+}
+
 func (r *RoutingBackend) WriteRoute(op engine.WriteRouteOp) error {
 	if err := mkdirAllFn(r.dynamicDir(), 0o755); err != nil {
 		return fmt.Errorf("traefik routing: creating dynamic dir: %w", err)
 	}
+	emitAliasTLSNoWebsecureSignal(op, r.staticConfigPath, r.observer)
 
 	path := filepath.Join(r.dynamicDir(), routeFileName(op.Team, op.ServiceName))
 	present, err := isPathPresent(path)
@@ -90,6 +147,10 @@ func (r *RoutingBackend) WriteRoute(op engine.WriteRouteOp) error {
 			midKey := stripMiddlewareName(op.Team, op.ServiceName, i)
 			mids[midKey] = middleware{StripPrefix: &stripPrefix{Prefixes: []string{ar.PathPrefix}}}
 			r.Middlewares = []string{midKey}
+		}
+		if ar.TLS {
+			r.EntryPoints = []string{"web", "websecure"}
+			r.TLS = &tlsBlock{}
 		}
 		routers[aliasKey] = r
 	}

--- a/internal/plugins/gateway/traefik/routing_test.go
+++ b/internal/plugins/gateway/traefik/routing_test.go
@@ -727,7 +727,7 @@ func TestWriteRoute_AliasWithTLS_EmitsWarning_WhenStaticConfigLacksWebsecure(t *
 	if ev.Fields["path"] != "/fake/traefik.yml" {
 		t.Errorf("expected path=/fake/traefik.yml, got %q", ev.Fields["path"])
 	}
-	wantTLSAliases := "a.example.com,b.example.com/x"
+	wantTLSAliases := "a.example.com,b.example.com+/x"
 	if ev.Fields["tls_aliases"] != wantTLSAliases {
 		t.Errorf("expected tls_aliases=%q, got %q", wantTLSAliases, ev.Fields["tls_aliases"])
 	}
@@ -783,5 +783,50 @@ func TestWriteRoute_NoAliasHasTLS_NoWarning_RegardlessOfStaticConfig(t *testing.
 		if ev.Name == "gateway.alias.tls_no_websecure" {
 			t.Errorf("unexpected gateway.alias.tls_no_websecure event when no alias has TLS=true: %+v", ev)
 		}
+	}
+}
+
+func TestWriteRoute_AliasWithTLS_EmitsProbeError_WhenStaticConfigUnreadable(t *testing.T) {
+	stubLstatNotExist(t)
+	captureWriteFileFn(t)
+
+	origRead := readFileFn
+	t.Cleanup(func() { readFileFn = origRead })
+	readFileFn = func(string) ([]byte, error) {
+		return []byte("entryPoints:\n  web: ::: not yaml :::\n"), nil
+	}
+
+	rec := &recordingObserver{}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "a.example.com", TLS: true},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var probeErrors []engine.Event
+	for _, ev := range rec.events {
+		if ev.Name == "gateway.config.tls_port_probe_error" {
+			probeErrors = append(probeErrors, ev)
+		}
+		if ev.Name == "gateway.alias.tls_no_websecure" {
+			t.Errorf("must not emit gateway.alias.tls_no_websecure on probe error: %+v", ev)
+		}
+	}
+	if len(probeErrors) != 1 {
+		t.Fatalf("expected exactly 1 gateway.config.tls_port_probe_error event, got %d: %+v", len(probeErrors), rec.events)
+	}
+	ev := probeErrors[0]
+	if ev.Status != engine.StatusWarning {
+		t.Errorf("expected StatusWarning, got %q", ev.Status)
+	}
+	if ev.Fields["path"] != "/fake/traefik.yml" {
+		t.Errorf("expected path=/fake/traefik.yml, got %q", ev.Fields["path"])
+	}
+	if ev.Fields["error"] == "" {
+		t.Error("expected non-empty error field on probe-error event")
 	}
 }

--- a/internal/plugins/gateway/traefik/routing_test.go
+++ b/internal/plugins/gateway/traefik/routing_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/CarlosHPlata/shrine/internal/engine"
 )
 
@@ -63,7 +65,7 @@ func captureWriteFileFn(t *testing.T) *[]byte {
 }
 
 func newTestBackend() *RoutingBackend {
-	return &RoutingBackend{routingDir: "/fake", observer: engine.NoopObserver{}}
+	return &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: engine.NoopObserver{}}
 }
 
 func baseOp() engine.WriteRouteOp {
@@ -212,6 +214,12 @@ func TestWriteRoute_NoAliases(t *testing.T) {
 	if !strings.Contains(got, "team-a-hello-api:") {
 		t.Error("expected primary router key")
 	}
+	if strings.Contains(got, "websecure") {
+		t.Error("T025: expected no websecure in non-TLS alias output")
+	}
+	if strings.Contains(got, "tls:") {
+		t.Error("T025: expected no tls: in non-TLS alias output")
+	}
 }
 
 func TestWriteRoute_OneAlias_Strip(t *testing.T) {
@@ -240,6 +248,12 @@ func TestWriteRoute_OneAlias_Strip(t *testing.T) {
 	if !strings.Contains(got, "- team-a-hello-api-strip-0") {
 		t.Error("expected alias router to list strip middleware")
 	}
+	if strings.Contains(got, "websecure") {
+		t.Error("T025: expected no websecure in non-TLS alias output")
+	}
+	if strings.Contains(got, "tls:") {
+		t.Error("T025: expected no tls: in non-TLS alias output")
+	}
 }
 
 func TestWriteRoute_OneAlias_NoStrip(t *testing.T) {
@@ -265,6 +279,12 @@ func TestWriteRoute_OneAlias_NoStrip(t *testing.T) {
 	if !strings.Contains(got, "team-a-hello-api-alias-0:") {
 		t.Error("expected alias router")
 	}
+	if strings.Contains(got, "websecure") {
+		t.Error("T025: expected no websecure in non-TLS alias output")
+	}
+	if strings.Contains(got, "tls:") {
+		t.Error("T025: expected no tls: in non-TLS alias output")
+	}
 }
 
 func TestWriteRoute_HostOnlyAlias(t *testing.T) {
@@ -289,6 +309,12 @@ func TestWriteRoute_HostOnlyAlias(t *testing.T) {
 	}
 	if strings.Contains(got, "middlewares:") {
 		t.Error("expected no middlewares section for host-only alias")
+	}
+	if strings.Contains(got, "websecure") {
+		t.Error("T025: expected no websecure in non-TLS alias output")
+	}
+	if strings.Contains(got, "tls:") {
+		t.Error("T025: expected no tls: in non-TLS alias output")
 	}
 }
 
@@ -320,6 +346,12 @@ func TestWriteRoute_ThreeAliases_SparseStrip(t *testing.T) {
 	if strings.Contains(got, "team-a-hello-api-strip-2:") {
 		t.Error("expected no strip-2 middleware (StripPrefix=false at index 2)")
 	}
+	if strings.Contains(got, "websecure") {
+		t.Error("T025: expected no websecure in non-TLS alias output")
+	}
+	if strings.Contains(got, "tls:") {
+		t.Error("T025: expected no tls: in non-TLS alias output")
+	}
 }
 
 const wantPath = "/fake/dynamic/team-a-hello-api.yml"
@@ -343,7 +375,7 @@ func TestWriteRoute_FilePresent_Preserves(t *testing.T) {
 	})
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	if err := rb.WriteRoute(baseOp()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -378,7 +410,7 @@ func TestWriteRoute_FreshWrite_EmitsGenerated(t *testing.T) {
 	captured := captureWriteFileFn(t)
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	if err := rb.WriteRoute(baseOp()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -419,7 +451,7 @@ func TestWriteRoute_StatError_EmitsWarningAndContinues(t *testing.T) {
 	})
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	if err := rb.WriteRoute(baseOp()); err != nil {
 		t.Fatalf("expected nil error (deploy must continue), got %v", err)
@@ -449,7 +481,7 @@ func TestWriteRoute_AbsentAfterPreviousPresent_RegeneratesFromManifest(t *testin
 	captured := captureWriteFileFn(t)
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	op := baseOp()
 	op.AdditionalRoutes = []engine.AliasRoute{
@@ -487,7 +519,7 @@ func TestRemoveRoute_FilePresent_EmitsOrphanWarning(t *testing.T) {
 	captureRemoveFileFn(t)
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	if err := rb.RemoveRoute("team-a", "hello-api"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
@@ -516,7 +548,7 @@ func TestRemoveRoute_FileAbsent_IsNoOp(t *testing.T) {
 	captureRemoveFileFn(t)
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	if err := rb.RemoveRoute("team-a", "hello-api"); err != nil {
 		t.Fatalf("expected nil error, got %v", err)
@@ -532,7 +564,7 @@ func TestRemoveRoute_StatError_EmitsWarningAndContinues(t *testing.T) {
 	captureRemoveFileFn(t)
 
 	rec := &recordingObserver{}
-	rb := &RoutingBackend{routingDir: "/fake", observer: rec}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
 
 	if err := rb.RemoveRoute("team-a", "hello-api"); err != nil {
 		t.Fatalf("expected nil error (teardown must continue), got %v", err)
@@ -549,5 +581,207 @@ func TestRemoveRoute_StatError_EmitsWarningAndContinues(t *testing.T) {
 	}
 	if !strings.Contains(ev.Fields["error"], "permission denied") {
 		t.Errorf("expected error field to contain 'permission denied', got %q", ev.Fields["error"])
+	}
+}
+
+// stubReadFileWebsecurePresent stubs readFileFn to return YAML with both web and websecure entrypoints.
+func stubReadFileWebsecurePresent(t *testing.T) {
+	t.Helper()
+	orig := readFileFn
+	t.Cleanup(func() { readFileFn = orig })
+	readFileFn = func(string) ([]byte, error) {
+		return []byte("entryPoints:\n  web:\n    address: \":80\"\n  websecure:\n    address: \":443\"\n"), nil
+	}
+}
+
+// stubReadFileWebsecureMissing stubs readFileFn to return YAML with only the web entrypoint.
+func stubReadFileWebsecureMissing(t *testing.T) {
+	t.Helper()
+	orig := readFileFn
+	t.Cleanup(func() { readFileFn = orig })
+	readFileFn = func(string) ([]byte, error) {
+		return []byte("entryPoints:\n  web:\n    address: \":80\"\n"), nil
+	}
+}
+
+// T011: alias with TLS=true must produce entryPoints:[web,websecure] and a tls:{} block.
+// The primary-domain router must keep entryPoints:[web] with no tls key.
+func TestWriteRoute_AliasWithTLS_AddsWebsecureAndTLSBlock(t *testing.T) {
+	stubLstatNotExist(t)
+	stubReadFileWebsecurePresent(t)
+	captured := captureWriteFileFn(t)
+
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: engine.NoopObserver{}}
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "alias.shrine.lab", TLS: true},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var doc struct {
+		HTTP httpConfig `yaml:"http"`
+	}
+	if err := yaml.Unmarshal(*captured, &doc); err != nil {
+		t.Fatalf("unmarshal failed: %v\nYAML:\n%s", err, *captured)
+	}
+
+	aliasRouter, ok := doc.HTTP.Routers["team-a-hello-api-alias-0"]
+	if !ok {
+		t.Fatalf("alias router key 'team-a-hello-api-alias-0' not found in routers")
+	}
+	if len(aliasRouter.EntryPoints) != 2 || aliasRouter.EntryPoints[0] != "web" || aliasRouter.EntryPoints[1] != "websecure" {
+		t.Errorf("alias router entryPoints: got %v, want [web websecure]", aliasRouter.EntryPoints)
+	}
+	if aliasRouter.TLS == nil {
+		t.Error("alias router: expected tls block to be present, got nil")
+	}
+
+	primary, ok := doc.HTTP.Routers["team-a-hello-api"]
+	if !ok {
+		t.Fatalf("primary router key 'team-a-hello-api' not found")
+	}
+	if len(primary.EntryPoints) != 1 || primary.EntryPoints[0] != "web" {
+		t.Errorf("primary router entryPoints: got %v, want [web]", primary.EntryPoints)
+	}
+	if primary.TLS != nil {
+		t.Error("primary router: expected no tls block, got non-nil")
+	}
+}
+
+// T012: primary-domain router must never gain a TLS block regardless of alias mix.
+func TestWriteRoute_AliasWithTLS_PreservesPrimaryRouterShape(t *testing.T) {
+	stubLstatNotExist(t)
+	stubReadFileWebsecurePresent(t)
+	captured := captureWriteFileFn(t)
+
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: engine.NoopObserver{}}
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "tls-alias.lab", TLS: true},
+		{Host: "plain-alias.lab", TLS: false},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var doc struct {
+		HTTP httpConfig `yaml:"http"`
+	}
+	if err := yaml.Unmarshal(*captured, &doc); err != nil {
+		t.Fatalf("unmarshal failed: %v\nYAML:\n%s", err, *captured)
+	}
+
+	primary, ok := doc.HTTP.Routers["team-a-hello-api"]
+	if !ok {
+		t.Fatalf("primary router key 'team-a-hello-api' not found")
+	}
+	if len(primary.EntryPoints) != 1 || primary.EntryPoints[0] != "web" {
+		t.Errorf("primary router entryPoints: got %v, want [web]", primary.EntryPoints)
+	}
+	if primary.TLS != nil {
+		t.Error("primary router: must not have a tls block regardless of alias TLS flags")
+	}
+}
+
+// T013: when static config lacks websecure, a warning is emitted for TLS-enabled aliases.
+func TestWriteRoute_AliasWithTLS_EmitsWarning_WhenStaticConfigLacksWebsecure(t *testing.T) {
+	stubLstatNotExist(t)
+	stubReadFileWebsecureMissing(t)
+	captureWriteFileFn(t)
+
+	rec := &recordingObserver{}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "a.example.com", TLS: true},
+		{Host: "b.example.com", PathPrefix: "/x", TLS: true},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var warningEvents []engine.Event
+	for _, ev := range rec.events {
+		if ev.Name == "gateway.alias.tls_no_websecure" {
+			warningEvents = append(warningEvents, ev)
+		}
+	}
+	if len(warningEvents) != 1 {
+		t.Fatalf("expected exactly 1 gateway.alias.tls_no_websecure event, got %d: %+v", len(warningEvents), rec.events)
+	}
+	ev := warningEvents[0]
+	if ev.Status != engine.StatusWarning {
+		t.Errorf("expected StatusWarning, got %q", ev.Status)
+	}
+	if ev.Fields["team"] != "team-a" {
+		t.Errorf("expected team=team-a, got %q", ev.Fields["team"])
+	}
+	if ev.Fields["name"] != "hello-api" {
+		t.Errorf("expected name=hello-api, got %q", ev.Fields["name"])
+	}
+	if ev.Fields["path"] != "/fake/traefik.yml" {
+		t.Errorf("expected path=/fake/traefik.yml, got %q", ev.Fields["path"])
+	}
+	wantTLSAliases := "a.example.com,b.example.com/x"
+	if ev.Fields["tls_aliases"] != wantTLSAliases {
+		t.Errorf("expected tls_aliases=%q, got %q", wantTLSAliases, ev.Fields["tls_aliases"])
+	}
+	if !strings.Contains(ev.Fields["hint"], "websecure") {
+		t.Errorf("hint should contain 'websecure', got %q", ev.Fields["hint"])
+	}
+}
+
+// T014: no warning emitted when websecure IS present and aliases use TLS.
+func TestWriteRoute_AliasWithTLS_NoWarning_WhenWebsecurePresent(t *testing.T) {
+	stubLstatNotExist(t)
+	stubReadFileWebsecurePresent(t)
+	captureWriteFileFn(t)
+
+	rec := &recordingObserver{}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "a.example.com", TLS: true},
+		{Host: "b.example.com", PathPrefix: "/x", TLS: true},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, ev := range rec.events {
+		if ev.Name == "gateway.alias.tls_no_websecure" {
+			t.Errorf("unexpected gateway.alias.tls_no_websecure event when websecure is present: %+v", ev)
+		}
+	}
+}
+
+// T015: no warning emitted when no alias has TLS=true, regardless of static config.
+func TestWriteRoute_NoAliasHasTLS_NoWarning_RegardlessOfStaticConfig(t *testing.T) {
+	stubLstatNotExist(t)
+	stubReadFileWebsecureMissing(t)
+	captureWriteFileFn(t)
+
+	rec := &recordingObserver{}
+	rb := &RoutingBackend{routingDir: "/fake", staticConfigPath: "/fake/traefik.yml", observer: rec}
+	op := baseOp()
+	op.AdditionalRoutes = []engine.AliasRoute{
+		{Host: "a.example.com", TLS: false},
+		{Host: "b.example.com", PathPrefix: "/p", TLS: false},
+	}
+
+	if err := rb.WriteRoute(op); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, ev := range rec.events {
+		if ev.Name == "gateway.alias.tls_no_websecure" {
+			t.Errorf("unexpected gateway.alias.tls_no_websecure event when no alias has TLS=true: %+v", ev)
+		}
 	}
 }

--- a/internal/plugins/gateway/traefik/spec.go
+++ b/internal/plugins/gateway/traefik/spec.go
@@ -43,11 +43,14 @@ type stripPrefix struct {
 }
 
 type router struct {
-	Rule        string   `yaml:"rule"`
-	Service     string   `yaml:"service"`
-	EntryPoints []string `yaml:"entryPoints"`
-	Middlewares []string `yaml:"middlewares,omitempty"`
+	Rule        string    `yaml:"rule"`
+	Service     string    `yaml:"service"`
+	EntryPoints []string  `yaml:"entryPoints"`
+	Middlewares []string  `yaml:"middlewares,omitempty"`
+	TLS         *tlsBlock `yaml:"tls,omitempty"`
 }
+
+type tlsBlock struct{}
 
 type service struct {
 	LoadBalancer loadBalancer `yaml:"loadBalancer"`

--- a/internal/ui/terminal_logger.go
+++ b/internal/ui/terminal_logger.go
@@ -68,6 +68,9 @@ func (t *TerminalObserver) OnEvent(e engine.Event) {
 	case "gateway.config.tls_port_no_websecure":
 		fmt.Fprintf(t.out, "  ⚠️  tlsPort set but traefik.yml is missing websecure entrypoint at %s — %s\n", e.Fields["path"], e.Fields["hint"])
 
+	case "gateway.alias.tls_no_websecure":
+		fmt.Fprintf(t.out, "  ⚠️  alias tls: true but websecure entrypoint missing in %s for %s.%s (%s) — %s\n", e.Fields["path"], e.Fields["team"], e.Fields["name"], e.Fields["tls_aliases"], e.Fields["hint"])
+
 	case "gateway.config.legacy_probe_error":
 		fmt.Fprintf(t.out, "  ⚠️  Could not probe traefik.yml for legacy http block (deploy continues): %s (%s)\n", e.Fields["path"], e.Fields["error"])
 

--- a/specs/012-tls-alias-routers/checklists/requirements.md
+++ b/specs/012-tls-alias-routers/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Per-Alias TLS Opt-In for Routing Aliases
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Spec references implementation-adjacent terms (`tls: {}`, `entryPoints: [web, websecure]`) because they are the issue's literal vocabulary and the operator's manifest surface — not framework internals. Validation kept these because removing them would erase the contract the issue asks for.
+- Cross-spec dependencies (006 alias semantics, 008 per-alias log marker, 009 per-app file preservation, 011 `tlsPort`) are explicitly named so the planner inherits the constraints rather than rediscovering them.

--- a/specs/012-tls-alias-routers/contracts/observer-events.md
+++ b/specs/012-tls-alias-routers/contracts/observer-events.md
@@ -1,0 +1,78 @@
+# Contract: Observer Events for Per-Alias TLS Publishing
+
+**Feature**: Per-Alias TLS Opt-In for Routing Aliases
+**Audience**: Downstream consumers of `engine.Observer` events emitted by the Traefik plugin (terminal logger, structured deploy logs, future UI surfaces).
+
+This is the only operator-visible programmatic contract this feature introduces. There is no public Go API change beyond the additive struct fields documented in `data-model.md`, no new manifest kind, no new CLI flag. The feature surfaces one new event name on the existing `engine.Observer` channel — `gateway.alias.tls_no_websecure` — and extends one existing event's `aliases` field to include a per-alias `(tls)` marker. Every existing event name and field set is unchanged.
+
+## Event namespace
+
+Events live under the existing `gateway.` namespace already used by the plugin. This feature opens a new sub-namespace `gateway.alias.*` parallel to the established `gateway.config.*` and `gateway.route.*` sub-namespaces. The existing `routing.configure` event (emitted by the engine, not the plugin) is unchanged in name; only the rendering of one of its fields is extended.
+
+## Events introduced
+
+### `gateway.alias.tls_no_websecure`
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `team` | string | yes | Owner team of the application whose manifest declared at least one alias with `tls: true`. |
+| `name` | string | yes | Application name (the value of `metadata.name` in the manifest). |
+| `path` | string | yes | Absolute filesystem path of the static Traefik config (`<routing-dir>/traefik.yml`) whose `entryPoints.websecure` key was probed and found missing. |
+| `tls_aliases` | string | yes | Comma-separated list of the TLS-requesting aliases on the application, formatted as `host[+pathPrefix]` (mirrors `formatAliasesForLog`'s shape so operators can grep for the offending alias). Sorted alphabetically for stable diffing. |
+| `hint` | string | yes | One-line, actionable cleanup instruction (e.g., `"Set plugins.gateway.traefik.tlsPort to publish a websecure entrypoint, or add it to the preserved traefik.yml."`). |
+
+| Status | Emitted when |
+|--------|--------------|
+| `engine.StatusWarning` | At least one alias in the application's `routing.aliases` has `tls: true` AND probing the active static Traefik config (`<routing-dir>/traefik.yml`) shows no `entryPoints.websecure` key. Emitted on every deploy where the mismatch persists; emitted in addition to (not instead of) the existing `gateway.config.tls_port_no_websecure` event from spec 011 if both mismatches happen to be present at once. The deploy is **not** blocked — the alias router is still written. |
+
+The probe error path (e.g., the static config is unreadable or contains malformed YAML) reuses spec 011's existing `gateway.config.tls_port_probe_error` event verbatim — no new probe-error event is needed because the underlying probe is the same `hasWebsecureEntrypoint` helper, and a probe failure that prevents this feature from emitting its warning is structurally the same failure that already concerns spec 011's machinery.
+
+## Events extended (rendering only)
+
+### `routing.configure` (existing event, unchanged in name and emission conditions)
+
+The `aliases` field, formatted by `engine.formatAliasesForLog`, gains a new optional `(tls)` marker. The marker composes with the existing `(no strip)` marker introduced by spec 008.
+
+| Alias shape | Old `aliases` field render | New `aliases` field render |
+|-------------|---------------------------|----------------------------|
+| `host=a.example.com` | `a.example.com` | (unchanged) |
+| `host=a.example.com, pathPrefix=/x` (default strip true) | `a.example.com+/x` | (unchanged) |
+| `host=a.example.com, pathPrefix=/x, stripPrefix=false` | `a.example.com+/x (no strip)` | (unchanged) |
+| `host=a.example.com, tls=true` | n/a | `a.example.com (tls)` |
+| `host=a.example.com, pathPrefix=/x, tls=true` | n/a | `a.example.com+/x (tls)` |
+| `host=a.example.com, pathPrefix=/x, stripPrefix=false, tls=true` | n/a | `a.example.com+/x (no strip) (tls)` |
+
+The marker order is fixed: `(no strip)` first (matching its existing position), `(tls)` second. Multiple aliases continue to be comma-joined and alphabetically sorted as before, so the field stays diff-stable.
+
+## Compatibility expectations
+
+- **Consumers MUST treat unknown event names as ignorable.** The terminal logger already does this; new consumers added to the codebase MUST follow the same rule.
+- **No existing event name is renamed or removed.** `gateway.config.*`, `gateway.dashboard.*`, `gateway.route.*`, `routing.configure`, `dns.register`, `container.create`, etc. all continue to behave exactly as today.
+- **Field set is additive-only.** Future feature work on the plugin MAY add new fields to existing events; consumers MUST tolerate unknown fields. The `aliases` field on `routing.configure` is a single human-formatted string by contract — its render is a stable text format, not a parser-friendly structure, so consumers who need machine-readable per-alias data should consume the future structured-log surface, not parse this string.
+- **No new event fields are added to existing events.** The `routing.configure` event's `aliases` field gains content (the `(tls)` marker) but does not gain a new key.
+
+## Non-events (intentionally not emitted)
+
+- There is no `gateway.alias.tls_published` or similar success event. The existing `gateway.route.generated` event already signals successful regeneration of a per-app dynamic config file (which now includes the `tls: {}` block when at least one alias sets `tls: true`); no separate "alias TLS now published" event is needed.
+- There is no `gateway.alias.tls_removed` event. Removal flows through the same `gateway.route.generated` path (the file is regenerated without the TLS block); no special signal is needed.
+- The websecure probe reuses spec 011's existing `gateway.config.tls_port_probe_error` event for I/O failures (file unreadable, malformed YAML) rather than introducing a parallel `gateway.alias.tls_probe_error`. The error contract is identical, the underlying probe is identical, and adding a parallel event would force operators to handle two equivalent error surfaces.
+
+## Terminal logger rendering
+
+`internal/ui/terminal_logger.go` adds one new `case` clause:
+
+```go
+case "gateway.alias.tls_no_websecure":
+    fmt.Fprintf(t.out, "  ⚠️  alias tls: true but websecure entrypoint missing in %s for %s.%s (%s) — %s\n",
+        e.Fields["path"], e.Fields["team"], e.Fields["name"], e.Fields["tls_aliases"], e.Fields["hint"])
+```
+
+The `⚠️` glyph and indentation match the sibling `gateway.config.legacy_http_block` and `gateway.config.tls_port_no_websecure` renderings.
+
+The `routing.configure` renderer is unchanged structurally — it already prints `↳ Aliases: <field>` when the `aliases` field is non-empty. The new `(tls)` marker flows through that path unmodified.
+
+## Verification
+
+- `gateway.alias.tls_no_websecure` emission and field shape are asserted by the integration scenario `should warn when alias sets tls: true but static config lacks websecure entrypoint` in `tests/integration/traefik_plugin_test.go`. Unit-level emission is asserted in `internal/plugins/gateway/traefik/routing_test.go` against a fake observer with the existing `readFileFn` injection point used to stub the static-config probe.
+- `routing.configure` `aliases` field rendering for `(tls)` is asserted at the unit level in `internal/engine/engine_aliases_test.go` (extending the existing `formatAliasesForLog` cases).
+- The `routing.configure` end-to-end render including `(tls)` is asserted in the integration scenarios alongside the dynamic-config-shape assertions, so a regression in either layer surfaces in the same test run.

--- a/specs/012-tls-alias-routers/data-model.md
+++ b/specs/012-tls-alias-routers/data-model.md
@@ -1,0 +1,242 @@
+# Data Model: Per-Alias TLS Opt-In for Routing Aliases
+
+**Feature**: 012-tls-alias-routers
+**Phase**: 1 (Design)
+**Date**: 2026-05-02
+
+This feature does not introduce any persistent data store, new manifest kind, or new state-package fields. The "data model" here is limited to the operator-facing manifest schema delta, three small in-memory Go struct deltas (manifest → engine → traefik), and the deterministic projection table from manifest input to generated dynamic config.
+
+## 1. Operator-facing manifest schema
+
+### Before this feature (spec 006 + spec 008 contract)
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: personal-finances
+  owner: shrine-team
+spec:
+  image: example/finances:1.0
+  port: 8080
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+        stripPrefix: false
+```
+
+### After this feature
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: personal-finances
+  owner: shrine-team
+spec:
+  image: example/finances:1.0
+  port: 8080
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+        stripPrefix: false
+        tls: true                 # NEW — optional, default false
+```
+
+### Field contract
+
+| Field | Type | Required | Default | Constraints |
+|-------|------|----------|---------|-------------|
+| `spec.routing.aliases[].tls` | bool | no | `false` | None at the validator layer beyond YAML structural type. Non-boolean values are rejected by `yaml.Unmarshal` with a path-bearing error (e.g., `routing.aliases[1].tls: cannot unmarshal !!str into bool`). |
+
+When unset (omitted entirely), behavior is identical to the pre-feature release — alias router attaches to `web` only, no `tls: {}` block emitted. When set to `false` explicitly, behavior is identical to omission (no error, no warning).
+
+The field is **only** valid inside a `routing.aliases[]` entry. Declaring `tls` at `spec.routing.tls` (top level) or anywhere outside an alias entry is rejected by `yaml.Unmarshal` because the field is not declared on the `Routing` struct — the rejection produces a clear `field tls not found in type manifest.Routing` error from the parser. This satisfies FR-005 structurally; no validator code is needed.
+
+## 2. In-memory Go struct deltas
+
+### `internal/manifest/types.go`
+
+```go
+type RoutingAlias struct {
+    Host        string `yaml:"host"`
+    PathPrefix  string `yaml:"pathPrefix,omitempty"`
+    StripPrefix *bool  `yaml:"stripPrefix,omitempty"`
+    TLS         bool   `yaml:"tls,omitempty"`              // NEW
+}
+```
+
+One field added (`TLS bool`). Plain bool, not `*bool`, because there are only two semantic states (omitted/false collapse). YAML tag is lowercase `tls` matching the issue's exemplar; Go field is uppercase `TLS` per the project's MixedCaps convention for acronyms (the same convention used by `TLSPort` in spec 011).
+
+### `internal/engine/backends.go`
+
+```go
+type AliasRoute struct {
+    Host        string
+    PathPrefix  string
+    StripPrefix bool
+    TLS         bool                                       // NEW
+}
+```
+
+One field added. Field is populated by `resolveAliasRoutes` in `engine.go` directly from `manifest.RoutingAlias.TLS`. `WriteRouteOp.AdditionalRoutes []AliasRoute` carries the new field for free; no `WriteRouteOp` change.
+
+### `internal/plugins/gateway/traefik/spec.go`
+
+```go
+type router struct {
+    Rule        string   `yaml:"rule"`
+    Service     string   `yaml:"service"`
+    EntryPoints []string `yaml:"entryPoints"`
+    Middlewares []string `yaml:"middlewares,omitempty"`
+    TLS         *tlsBlock `yaml:"tls,omitempty"`           // NEW
+}
+
+type tlsBlock struct{}                                     // NEW — marshals to {}
+```
+
+One field added on `router` (a pointer so `omitempty` works), plus one new empty-struct type. The empty struct is the YAML-marshal-friendly way to produce literal `tls: {}`.
+
+### `internal/plugins/gateway/traefik/routing.go`
+
+```go
+type RoutingBackend struct {
+    routingDir       string
+    staticConfigPath string                                 // NEW — for hasWebsecureEntrypoint probe
+    observer         engine.Observer
+}
+```
+
+One field added. Populated by `Plugin.RoutingBackend()` as `filepath.Join(routingDir, "traefik.yml")`. Used only by the new `emitAliasTLSNoWebsecureSignal` helper.
+
+## 3. Manifest → engine projection (resolveAliasRoutes)
+
+```go
+// internal/engine/engine.go (extended)
+func resolveAliasRoutes(aliases []manifest.RoutingAlias) []AliasRoute {
+    routes := make([]AliasRoute, 0, len(aliases))
+    for _, alias := range aliases {
+        prefix := strings.TrimRight(alias.PathPrefix, "/")
+        var strip bool
+        if alias.StripPrefix != nil {
+            strip = *alias.StripPrefix
+        } else {
+            strip = prefix != ""
+        }
+        routes = append(routes, AliasRoute{
+            Host:        alias.Host,
+            PathPrefix:  prefix,
+            StripPrefix: strip,
+            TLS:         alias.TLS,                         // NEW — straight pass-through
+        })
+    }
+    return routes
+}
+```
+
+The pass-through is deliberate: the engine is a projection, not a policy layer. The Traefik plugin decides what to do with `TLS == true`.
+
+## 4. Engine → Traefik dynamic-config projection
+
+For each application with at least one alias, `WriteRoute` produces one router per alias. The router's shape is the only thing that changes per-alias:
+
+| `ar.TLS` | Generated alias router fields |
+|----------|-------------------------------|
+| `false` (omitted or explicit false) | `rule: Host(...)[ && PathPrefix(...)]`, `service: <team>-<svc>`, `entryPoints: [web]`, optional `middlewares: [<strip-key>]`, no `tls` field. |
+| `true` | `rule: Host(...)[ && PathPrefix(...)]`, `service: <team>-<svc>`, `entryPoints: [web, websecure]`, optional `middlewares: [<strip-key>]`, `tls: {}`. |
+
+**The primary-domain router shape is invariant under alias `tls` flips.** It always declares `entryPoints: [web]` and never carries a `tls` field, regardless of how many aliases on the same application set `tls: true`. This is the structural guarantee behind FR-003.
+
+### Generated dynamic config example (mixed TLS-on / TLS-off)
+
+For a manifest with `routing.domain: finances.home.lab`, alias[0] = `host: a.example.com` (no tls), alias[1] = `host: b.example.com, pathPrefix: /finances, stripPrefix: false, tls: true`:
+
+```yaml
+http:
+  routers:
+    shrine-team-personal-finances:
+      rule: Host(`finances.home.lab`)
+      service: shrine-team-personal-finances
+      entryPoints:
+        - web
+    shrine-team-personal-finances-alias-0:
+      rule: Host(`a.example.com`)
+      service: shrine-team-personal-finances
+      entryPoints:
+        - web
+    shrine-team-personal-finances-alias-1:
+      rule: Host(`b.example.com`) && PathPrefix(`/finances`)
+      service: shrine-team-personal-finances
+      entryPoints:
+        - web
+        - websecure
+      tls: {}
+  services:
+    shrine-team-personal-finances:
+      loadBalancer:
+        servers:
+          - url: http://shrine-team.personal-finances:8080
+```
+
+The middlewares block is empty here because alias[0] is host-only (no strip needed) and alias[1] sets `stripPrefix: false`.
+
+## 5. Edge-case truth table
+
+For an application with one alias entry, holding `host` and `pathPrefix` constant:
+
+| `stripPrefix` | `tls` | Generated alias router YAML shape |
+|---------------|-------|------------------------------------|
+| omitted, `pathPrefix` set | omitted | `entryPoints: [web]`, has strip middleware, no tls |
+| omitted, `pathPrefix` set | `false` | (same as above) |
+| omitted, `pathPrefix` set | `true` | `entryPoints: [web, websecure]`, has strip middleware, `tls: {}` |
+| `false`, `pathPrefix` set | `true` | `entryPoints: [web, websecure]`, no strip middleware, `tls: {}` |
+| `false`, `pathPrefix` set | omitted | `entryPoints: [web]`, no strip middleware, no tls |
+| omitted, `pathPrefix` unset | `true` | `entryPoints: [web, websecure]`, no strip middleware, `tls: {}` |
+| omitted, `pathPrefix` unset | omitted | `entryPoints: [web]`, no strip middleware, no tls |
+
+`stripPrefix` and `tls` compose without conflict — the middleware decision is independent of the entrypoint/TLS decision.
+
+## 6. Validation pipeline (unchanged)
+
+```
+application.yml
+    │ YAML parse (tls accepted as bool; non-bool rejected with path-bearing error per FR-004)
+    │ a top-level routing.tls is rejected as "field tls not found" per FR-005
+    ▼
+ApplicationManifest{Spec.Routing.Aliases: [...]}
+    │ manifest.Validate(...)
+    │   └─ validateRoutingAliases (UNCHANGED — keys on (host, normalizedPathPrefix); ignores tls per FR-006)
+    ▼
+ResolvePlan → engine.resolveAliasRoutes
+    │ → engine.AliasRoute{..., TLS: <pass-through>}
+    ▼
+plugin RoutingBackend.WriteRoute(op)
+    │ For each ar in op.AdditionalRoutes:
+    │   if ar.TLS == true → router.EntryPoints=[web, websecure], router.TLS=&tlsBlock{}
+    │   else → router.EntryPoints=[web], router.TLS=nil
+    │ If any ar.TLS == true AND !hasWebsecureEntrypoint(staticConfigPath) → emit gateway.alias.tls_no_websecure
+    ▼
+Generated dynamic config file: <routing-dir>/dynamic/<team>-<service>.yml
+```
+
+No new validation functions, no new error types, no new error namespaces. The collision check defined by spec 006 (FR-008/008a) inherits unchanged — `tls` is invisible to it.
+
+## 7. State transitions across deploys
+
+| Previous deploy | Current manifest | Resulting actions |
+|-----------------|------------------|-------------------|
+| Alias has no `tls` | Alias has no `tls` | No-op for this feature; existing alias-shape semantics apply. |
+| Alias has no `tls` | Alias gains `tls: true` | Dynamic config regenerated with `tls: {}` block on the alias router (subject to spec 009 preservation — if file is operator-owned, no rewrite). |
+| Alias has `tls: true` | Alias has no `tls` (or `tls: false`) | Dynamic config regenerated without `tls: {}` block; alias router returns to `entryPoints: [web]` only. |
+| Any | New alias added with `tls: true` | New alias router emitted with TLS shape; primary domain unchanged. |
+| Any | Alias removed | Alias router disappears from generated file (subject to spec 009 preservation). |
+
+All file rewrites flow through the existing `RoutingBackend.WriteRoute` path — no new lifecycle is introduced. Spec 009's preservation regime applies unchanged: once an operator has marked a per-app dynamic config file as operator-owned, Shrine does NOT rewrite it in response to `tls` flips (FR-008). The operator must delete the file (or hand-edit it) for `tls` changes to take effect on a preserved file.
+
+## 8. No persisted state
+
+This feature does NOT add any new files to the state directory, no entries to `DeploymentStore`, no sidecar config, no new fields to existing state types, and no new event-store entries. The only state-adjacent surface is the in-memory `RoutingBackend.staticConfigPath` field, which is computed once per `Plugin.RoutingBackend()` call and never persisted.

--- a/specs/012-tls-alias-routers/plan.md
+++ b/specs/012-tls-alias-routers/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Per-Alias TLS Opt-In for Routing Aliases
+
+**Branch**: `012-tls-alias-routers` | **Date**: 2026-05-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/012-tls-alias-routers/spec.md`
+
+## Summary
+
+Add an optional boolean `tls` field to each entry of `routing.aliases` in the application manifest so an operator can declare per-alias HTTPS publishing inline instead of hand-editing the generated dynamic config (which became operator-owned in spec 009 — turning the workaround durable but invisible to the manifest). When `tls: true`, the generated alias router attaches to both `web` and `websecure` entrypoints and carries an empty `tls: {}` block; when omitted or `false`, the alias router shape is byte-identical to today (FR-009 regression guard). Per-application TLS certificate provisioning, ACME, redirects, and `websecure`-entrypoint wiring stay entirely operator-owned (FR-012, mirroring 011 FR-010); this feature only opens the routing/entrypoint side at the per-alias granularity.
+
+The implementation is four narrow changes:
+
+1. **`internal/manifest/types.go`**: add `TLS bool \`yaml:"tls,omitempty"\`` to `RoutingAlias`. Field is a plain bool, not a pointer — `tls: false` and an omitted field both produce `false`, which is the desired semantic per the spec's "tls: false behaves identically to omission" edge case. (No three-state ambiguity, unlike `StripPrefix` whose default depends on whether `pathPrefix` is set.)
+2. **`internal/engine/backends.go` + `internal/engine/engine.go`**: extend `engine.AliasRoute` with a `TLS bool` field; populate it inside `resolveAliasRoutes`; extend `formatAliasesForLog` to append a `" (tls)"` suffix on TLS-enabled aliases so FR-010's per-alias log marker is honored without inventing a new event.
+3. **`internal/plugins/gateway/traefik/spec.go` + `routing.go`**: extend the `router` struct with an optional `TLS *tlsBlock \`yaml:"tls,omitempty"\`` pointer (where `tlsBlock struct{}` marshals to `tls: {}`); inside `WriteRoute`, when `ar.TLS == true`, set `EntryPoints: []string{"web", "websecure"}` and `TLS: &tlsBlock{}` on the alias router (primary-domain router shape unchanged); add a `staticConfigPath` field to `RoutingBackend` so it can call the existing `hasWebsecureEntrypoint(path)` probe and emit a new `gateway.alias.tls_no_websecure` warning per FR-007 when an alias declares TLS but the active static config lacks the `websecure` entrypoint.
+4. **`internal/manifest/validate.go`**: no new validation logic for the boolean shape itself (YAML unmarshal already rejects non-boolean values into a `bool` field with a clear error per FR-004 — this is verified by a unit test rather than reimplemented). The existing `validateRoutingAliases` collision check (spec 006) is unchanged: it still keys on `(host, normalizedPathPrefix)` and ignores the new `tls` field, satisfying FR-006 ("TLS flag is a routing decoration, not a uniqueness key"). FR-005's "tls is only valid inside an alias entry" guarantee falls out of the schema for free — `tls` is declared only on `RoutingAlias`, never on `Routing`, so YAML unmarshal will reject a top-level `routing.tls` with `field tls not found in type manifest.Routing`.
+
+A new testutils helper is **not** needed — the existing `tc.AssertFileContains` and `tc.AssertFileDoesNotContain` cover all router-shape assertions byte-by-byte. Three integration scenarios in `tests/integration/traefik_plugin_test.go` cover the user-story acceptance criteria. Unit tests in `internal/plugins/gateway/traefik/routing_test.go` are extended to cover the new router shape, the `tls: false` regression guard, and the warning emission path. A new integration scenario for the warning case lives alongside the existing alias scenarios.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (`github.com/CarlosHPlata/shrine`)
+**Primary Dependencies**: `gopkg.in/yaml.v3` (already used by the plugin and by the manifest parser); `internal/engine.Observer` for the new warning event; the existing `hasWebsecureEntrypoint` probe shipped by spec 011 — reused verbatim.
+**Storage**: Filesystem only — `<routing-dir>/dynamic/<team>-<service>.yml` per-app file already managed by `RoutingBackend.WriteRoute`. No new files; no new state-store entries; no new state-package signature change.
+**Testing**: `go test ./...` for unit tests (no filesystem touches per project convention; uses the existing `writeFileFn`/`mkdirAllFn`/`readFileFn` injection points). `make test-integration` (build tag `integration`) for the end-to-end gate using `NewDockerSuite` against a live Docker daemon.
+**Target Platform**: Linux server (homelab operator host running Docker).
+**Project Type**: CLI (single Go module under `cmd/`, internal packages under `internal/`).
+**Performance Goals**: N/A — this feature adds at most one extra YAML probe (`hasWebsecureEntrypoint`) per `WriteRoute` call when at least one alias has `tls: true`; the probe is `os.ReadFile` on a small static config and is short-circuited when no alias requests TLS. Cost is bounded by the same single deploy-cycle cost as the existing 011 probe.
+**Constraints**: Must not regress any existing alias test (006/008 contracts unchanged); must produce byte-identical generated dynamic config when no alias sets `tls` (FR-009 regression guard verified by extending the existing `TestWriteRoute_NoAliases` and `TestWriteRoute_OneAlias_Strip` table-driven coverage); must not modify operator-preserved per-app dynamic config files (spec 009 regime — FR-008 inherits unchanged); `entryPoints` list order MUST be `[web, websecure]` to match the issue's exemplar and keep the byte-comparison-friendly assertion in tests.
+**Scale/Scope**: One struct-field addition on the manifest side, one struct-field addition on the engine side, one struct-field addition on the traefik routing struct, one new YAML helper struct (`tlsBlock`), one extension of `formatAliasesForLog`, one new observer event (`gateway.alias.tls_no_websecure`) plus its terminal-logger renderer, one new field on `RoutingBackend`. Estimated total delta: ~80 LOC of production code and ~200 LOC of test code across 6 production files and 4 test files.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Question | Status |
+|-----------|---------------|--------|
+| I. Declarative Manifest-First | Does this feature expose new capabilities via manifest fields (not CLI flags)? | [x] Pass — exposed as a single new YAML field `spec.routing.aliases[].tls` in the application manifest. No new CLI flags. The new field is field-level and validated structurally by YAML unmarshal (rejects non-boolean values with a clear error naming the offending path), satisfying the constitution's "field-level constraints MUST be enforced at parse/validate time" rule. |
+| II. Kubectl-Style CLI | Do new commands follow verb-first convention and include `--dry-run`? | [x] N/A — no new commands. Existing `shrine deploy --dry-run` continues to work because `tls` flows through the same `WriteRouteOp` path that the dry-run routing backend already prints; the new `EntryPoints: [web, websecure]` and `TLS: &tlsBlock{}` fields appear in the dry-run output verbatim. |
+| III. Pluggable Backend | Is new infrastructure logic behind a backend interface (not engine core)? | [x] Pass — Traefik-specific logic (router shape with `tls: {}`, `web`+`websecure` entrypoints, websecure-probe warning) lives entirely inside `internal/plugins/gateway/traefik/`. The engine-side changes are limited to (a) carrying the new `TLS bool` through `engine.AliasRoute` and `WriteRouteOp` so plugin code can read it, and (b) extending the human-facing log formatter — neither contains routing-specific decisions. The collision check in `internal/manifest/validate.go` is plugin-agnostic and remains keyed only on host+path; the new `tls` field is invisible to it. |
+| IV. Simplicity & YAGNI | Is every abstraction justified by ≥3 concrete usages? | [x] Pass — no new abstractions, interfaces, factories, or types beyond the unavoidable: the manifest `RoutingAlias.TLS` field, the engine `AliasRoute.TLS` field, the traefik `router.TLS` pointer field, and the empty `tlsBlock struct{}` whose only job is to marshal to `tls: {}` (which an `interface{}` or `map[string]any` would do less safely). The new `gateway.alias.tls_no_websecure` event reuses the existing `Observer.OnEvent` channel and `engine.Event` shape — no new event-type abstraction. The `RoutingBackend` gains one field (`staticConfigPath string`), not a new dependency injection surface. |
+| V. Integration-Test Gate | Does this phase map to an integration test phase using `NewDockerSuite` against a real binary? | [x] Pass — three new scenarios in `tests/integration/traefik_plugin_test.go` cover all three user stories' acceptance criteria, plus one scenario for the FR-007 warning path. Listed in research.md Decision 7 and detailed in the Project Structure section below. The integration suite continues to use `NewDockerSuite` with `BeforeEach`/`AfterEach` cleanup per the harness convention. |
+| VI. Docker-Authoritative State | Does state update happen *after* Docker operations complete? | [x] N/A — no state-record or container-recreation changes. This feature touches the dynamic-config file writer only; the Traefik container is unaffected (its static config gained `websecure` in spec 011 and its port bindings gained `tlsPort` in spec 011 — this feature consumes both as preconditions). |
+| VII. Clean Code & Readability | Is repeated logic extracted into named helpers? Are names self-documenting (no WHAT comments)? | [x] Pass — `tlsBlock` is a pure type; the new branch in `WriteRoute` is six lines and reads as a single sentence (`if ar.TLS { r.EntryPoints = []string{"web", "websecure"}; r.TLS = &tlsBlock{} }`), no comment needed. The new `emitAliasTLSNoWebsecureSignal` helper mirrors the naming of the existing `emitTLSPortNoWebsecureSignal` from spec 011 — same `emit{Cause}{Effect}` shape. The `formatAliasesForLog` extension adds one `if` branch matching the existing "(no strip)" precedent. |
+
+> Violations MUST be documented in the Complexity Tracking table below.
+
+**Result**: All seven principles pass with no violations. The feature is a pure additive extension of the spec-006 alias surface and the spec-011 TLS surface; no engine core touched, no state schema changes, no new directories.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-tls-alias-routers/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output — 7 design decisions resolved
+├── data-model.md        # Phase 1 output — schema delta + router-shape projection table + edge-case truth table
+├── quickstart.md        # Phase 1 output — 6-step manual operator validation script
+├── contracts/
+│   └── observer-events.md  # Phase 1 output — single new event `gateway.alias.tls_no_websecure`
+├── checklists/
+│   └── requirements.md  # Created by /speckit-specify
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/manifest/
+├── types.go                         # MODIFIED — add `TLS bool \`yaml:"tls,omitempty"\`` to RoutingAlias struct
+├── parser_test.go                   # MODIFIED — add cases asserting tls round-trips for true/false/omitted
+├── validate.go                      # UNCHANGED — collision key remains (host, normalizedPathPrefix); tls is not a uniqueness input (FR-006)
+└── validate_test.go                 # MODIFIED — add a parser-level case asserting non-boolean tls is rejected by yaml.Unmarshal with a path-bearing error message (FR-004)
+
+internal/engine/
+├── backends.go                      # MODIFIED — add `TLS bool` to engine.AliasRoute (no change to WriteRouteOp shape; AliasRoute is the per-alias struct)
+├── engine.go                        # MODIFIED — populate AliasRoute.TLS in resolveAliasRoutes; extend formatAliasesForLog to append " (tls)" when r.TLS is true
+└── engine_aliases_test.go           # MODIFIED — extend resolveAliasRoutes coverage and formatAliasesForLog coverage with tls cases
+
+internal/plugins/gateway/traefik/
+├── spec.go                          # MODIFIED — add `TLS *tlsBlock \`yaml:"tls,omitempty"\`` to router struct; add new `tlsBlock struct{}` type
+├── routing.go                       # MODIFIED — when ar.TLS, set router.EntryPoints=[web, websecure] and router.TLS=&tlsBlock{}; add emitAliasTLSNoWebsecureSignal called once when at least one alias has TLS=true and probe returns false
+├── plugin.go                        # MODIFIED — RoutingBackend constructor now passes staticConfigPath = filepath.Join(routingDir, "traefik.yml") into the new RoutingBackend.staticConfigPath field
+├── routing_test.go                  # MODIFIED — extend existing TestWriteRoute_* with tls cases; add new TestWriteRoute_AliasWithTLS_AddsWebsecureAndTLSBlock; add TestWriteRoute_AliasTLS_NoEffect_OnPrimaryRouter (regression guard); add TestWriteRoute_AliasTLS_EmitsWarning_WhenStaticConfigLacksWebsecure
+└── routing.go                       # see above (single file edited twice)
+
+internal/ui/
+└── terminal_logger.go               # MODIFIED — add `case "gateway.alias.tls_no_websecure"` clause; renders alongside the existing gateway.config.* warnings in the same ⚠️ style
+
+tests/integration/
+└── traefik_plugin_test.go           # MODIFIED — three new scenarios (one alias with tls; mixed TLS-on/TLS-off aliases; FR-009 regression — manifest with no tls field produces byte-identical config); one new scenario for FR-007 warning when static config lacks websecure
+
+tests/integration/fixtures/
+├── traefik-alias-tls/               # NEW — fixture: one alias with tls: true
+│   ├── application.yml
+│   └── team.yml
+└── traefik-alias-tls-mixed/         # NEW — fixture: two aliases, first without tls, second with tls: true
+    ├── application.yml
+    └── team.yml
+
+AGENTS.md                            # MODIFIED — add the tls field to the routing.aliases example block; one-line note that tls only opens the entrypoint side and does not configure certs (mirrors spec 011's analogous note)
+```
+
+**Structure Decision**: The feature lives in three layers — manifest schema (`internal/manifest/`), engine-side alias projection (`internal/engine/`), and Traefik-specific router generation (`internal/plugins/gateway/traefik/`). The manifest layer adds a single bool; the engine layer threads it through to plugins via `engine.AliasRoute`; the plugin layer renders it as the YAML shape Traefik expects. No new top-level packages, no new directories, no new state files. The probe used for the FR-007 warning (`hasWebsecureEntrypoint`) is reused from spec 011 — no duplicate implementation. Test layout mirrors the existing two-tier split (unit tests beside production code with the project's no-filesystem-in-unit-tests convention; integration tests under `tests/integration/` with the `integration` build tag and the `NewDockerSuite` harness). The new observer event extends the existing `gateway.` namespace under a new `gateway.alias.*` sub-namespace, parallel to the established `gateway.config.*` and `gateway.route.*` sub-namespaces, keeping the contract for downstream UI/log consumers stable.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+The Constitution Check has no violations. The single design decision worth surfacing is the choice to introduce a new sub-namespace `gateway.alias.*` for the warning event rather than reusing `gateway.config.tls_port_no_websecure`:
+
+| Item | Why included in this feature's scope | Simpler alternative rejected because |
+|------|--------------------------------------|--------------------------------------|
+| New event name `gateway.alias.tls_no_websecure` (parallel to spec 011's `gateway.config.tls_port_no_websecure`) | The two events fire on different surfaces (per-app dynamic config vs. cluster-wide static config), carry different fields (per-alias context vs. file-level context), and have different operator remediations (turn off `tls: true` per alias vs. set `tlsPort` cluster-wide). Reusing the 011 event name would conflate the two and force a conditional in the renderer to figure out which kind of mismatch the operator hit. | (a) Reusing `gateway.config.tls_port_no_websecure` would require carrying per-alias context in fields the existing renderer doesn't print, producing a confusing operator log line. (b) Suppressing the warning entirely would silently break FR-007's contract — operators who set `tls: true` without wiring `tlsPort` would see "TLS routes published" in the log but no inbound TLS traffic, exactly the failure mode this feature is meant to surface. The new event is one renderer case in `terminal_logger.go` and one Decision in research.md; the cost is a single line of contract surface. |

--- a/specs/012-tls-alias-routers/quickstart.md
+++ b/specs/012-tls-alias-routers/quickstart.md
@@ -1,0 +1,174 @@
+# Quickstart: Per-Alias TLS Opt-In for Routing Aliases
+
+**Feature**: 012-tls-alias-routers
+**Audience**: Operator (homelab, multi-network deploy)
+**Prerequisites**: Shrine release containing this feature; Traefik gateway plugin enabled; the `websecure` entrypoint already wired (via spec 011's `tlsPort: 443` config, or via an operator-edited preserved `traefik.yml`); a working application manifest with at least one `routing.aliases` entry.
+
+This quickstart walks through the manual end-to-end flow for declaring an alias as HTTPS-published. It is the operator-facing companion to the integration scenarios in `tests/integration/traefik_plugin_test.go`.
+
+## 1. Pre-flight: confirm the websecure entrypoint is wired
+
+Before adding `tls: true` to any alias, confirm Traefik has a `websecure` entrypoint listening. Either:
+
+a. **Shrine-generated path (recommended)**: confirm `~/.config/shrine/config.yml` declares `tlsPort: 443` (or another host port) under `plugins.gateway.traefik`. Run `shrine deploy` on a deploy that touches Traefik (e.g., a dummy app re-deploy). Verify `<routing-dir>/traefik.yml` now contains:
+
+   ```yaml
+   entryPoints:
+     web:
+       address: ":80"
+     websecure:
+       address: ":443"
+   ```
+
+b. **Operator-preserved path**: if you've hand-edited `<routing-dir>/traefik.yml` to add a `websecure` entrypoint, confirm the file still contains it. Shrine treats this file as preserved per spec 004 and will not modify it.
+
+If neither is true, this quickstart still works — Shrine will write the alias router with the TLS shape regardless, but inbound HTTPS traffic will not land on it until the entrypoint is wired. You will see a `gateway.alias.tls_no_websecure` warning in the deploy log (see step 5).
+
+## 2. Add `tls: true` to the alias entry
+
+Edit your application manifest. For an existing alias:
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: personal-finances
+  owner: shrine-team
+spec:
+  image: example/finances:1.0
+  port: 8080
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+        stripPrefix: false
+        tls: true                # NEW — single line opt-in
+```
+
+`tls: true` is the only edit required. The other alias fields (`host`, `pathPrefix`, `stripPrefix`) keep their existing semantics from spec 006.
+
+## 3. Apply the manifest
+
+```sh
+shrine apply application -f path/to/personal-finances.yml
+```
+
+Or if your workflow re-deploys all manifests in a directory:
+
+```sh
+shrine deploy
+```
+
+The deploy log should show a line for the application's routing configuration. With `tls: true` set, you'll see the new per-alias log marker:
+
+```text
+  🔗 Configuring routing: finances.home.lab -> port 8080
+    ↳ Aliases: gateway.tail9a6ddb.ts.net+/finances (no strip) (tls)
+```
+
+The `(tls)` marker is the FR-010 signal that Shrine recognized the field. If you don't see it, recheck the manifest indentation — `tls: true` must be a sibling of `host` and `pathPrefix`, not nested under another key.
+
+## 4. Inspect the generated dynamic config
+
+The per-app dynamic config lives at:
+
+```text
+<routing-dir>/dynamic/<team>-<service>.yml
+```
+
+For our example: `<routing-dir>/dynamic/shrine-team-personal-finances.yml`. Open it. The alias router should now look like:
+
+```yaml
+http:
+  routers:
+    shrine-team-personal-finances:
+      rule: Host(`finances.home.lab`)
+      service: shrine-team-personal-finances
+      entryPoints:
+        - web
+    shrine-team-personal-finances-alias-0:
+      rule: Host(`gateway.tail9a6ddb.ts.net`) && PathPrefix(`/finances`)
+      service: shrine-team-personal-finances
+      entryPoints:
+        - web
+        - websecure
+      tls: {}
+  services:
+    shrine-team-personal-finances:
+      loadBalancer:
+        servers:
+          - url: http://shrine-team.personal-finances:8080
+```
+
+Confirm:
+
+- The primary-domain router (`shrine-team-personal-finances`) declares `entryPoints: [web]` only and has no `tls` field.
+- The alias router (`shrine-team-personal-finances-alias-0`) declares `entryPoints: [web, websecure]` and has `tls: {}`.
+
+If the file does NOT show this shape, check whether the file has been marked operator-owned per spec 009 (you'll see a `Preserving operator-owned route file:` line in the deploy log). When the file is preserved, Shrine does not rewrite it in response to manifest changes — delete the file and re-deploy to regenerate it with the new shape.
+
+## 5. Confirm Traefik is serving HTTPS on the alias
+
+Send an HTTPS request to the alias address. With Traefik's TLS configuration (separate from this feature — operator-owned per FR-012):
+
+```sh
+curl -k https://gateway.tail9a6ddb.ts.net/finances
+```
+
+The `-k` flag skips cert verification — fine for a homelab confirmation. The response should match what `curl http://finances.home.lab` returns: same backend, same body.
+
+If the connection fails at the TLS layer (handshake error, no cert), the issue is in your Traefik TLS configuration (cert resolver, default cert, ACME setup), not in this feature. Per FR-012, Shrine emits `tls: {}` and nothing else — TLS termination is configured entirely outside Shrine. Consult Traefik's docs for cert resolvers and the static-config TLS surface.
+
+## 6. Mixing TLS-on and TLS-off aliases
+
+For applications that need different protocols on different aliases, declare each alias entry independently:
+
+```yaml
+spec:
+  routing:
+    domain: finances.home.lab
+    aliases:
+      - host: lan-only.shrine.lab
+        pathPrefix: /finances
+        # no tls field — internal HTTP only
+      - host: gateway.tail9a6ddb.ts.net
+        pathPrefix: /finances
+        stripPrefix: false
+        tls: true                 # external HTTPS via Tailscale
+```
+
+After `shrine deploy`, the dynamic config will contain two alias routers — the first attaching only to `web`, the second attaching to both `web` and `websecure` with `tls: {}`. The deploy log will show:
+
+```text
+    ↳ Aliases: gateway.tail9a6ddb.ts.net+/finances (no strip) (tls),lan-only.shrine.lab+/finances
+```
+
+(The list is alphabetically sorted.)
+
+## Reverting
+
+To revert an alias from HTTPS to HTTP-only, remove the `tls: true` line (or set `tls: false` explicitly — they behave identically). Re-deploy:
+
+```sh
+shrine deploy
+```
+
+The alias router is regenerated with `entryPoints: [web]` only and no `tls` block. Operator-preserved dynamic config files (per spec 009) are NOT rewritten — delete the file first if you need the regenerate-from-manifest behavior.
+
+## What this feature does NOT do
+
+- **Certificate provisioning**: Shrine does not generate, validate, distribute, or reference TLS certificates. Configure cert resolvers, ACME, or default certs directly in Traefik (preserved `traefik.yml` or external cert management). FR-012 makes this explicit.
+- **HTTP→HTTPS redirects**: not configured by this feature. If you want redirect-from-HTTP behavior, configure it in Traefik's static or dynamic config directly.
+- **Primary-domain HTTPS**: the `tls` field is only valid inside `routing.aliases[]`. To publish the primary `routing.domain` over HTTPS, the existing pre-spec-012 workaround applies — edit the preserved per-app dynamic config file directly. Per-primary-domain TLS opt-in is a deferred conversation (see spec assumptions).
+- **Per-route cert overrides**: Shrine emits an empty `tls: {}` block. Adding `certResolver`, `domains`, or `options` to the block requires hand-editing the dynamic config file (which then becomes operator-preserved per spec 009). FR-012 prohibits Shrine from injecting these keys.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Deploy log shows `⚠️ alias tls: true but websecure entrypoint missing in <path>` | Manifest declares `tls: true` but the active static config has no `websecure` entrypoint. | Set `tlsPort` per spec 011, OR add `entryPoints.websecure: { address: ":443" }` to a preserved `traefik.yml`, OR delete the preserved static config so Shrine regenerates it. |
+| Generated dynamic config does not show `tls: {}` after re-deploy | The file is operator-preserved per spec 009. Manifest changes do not rewrite preserved files. | Delete the preserved file at `<routing-dir>/dynamic/<team>-<service>.yml` and re-deploy. |
+| Manifest deploy fails with `cannot unmarshal !!str into bool` (or similar) | `tls` field has a non-boolean value (e.g., `"yes"`, `1`, an object). | Use bare YAML `true` or `false`. Quoting (`tls: "true"`) is rejected by design. |
+| Manifest deploy fails with `field tls not found in type manifest.Routing` | `tls` field placed at `spec.routing.tls` (top level) instead of inside an alias entry. | Move `tls: true` to be a sibling of `host` and `pathPrefix` inside the relevant `routing.aliases[]` entry. |
+| HTTPS connection succeeds at TCP but fails at TLS handshake | Traefik's `websecure` entrypoint has no cert resolver / default cert configured. | Configure cert resolvers in Traefik directly — out of scope for this feature per FR-012. |

--- a/specs/012-tls-alias-routers/research.md
+++ b/specs/012-tls-alias-routers/research.md
@@ -1,0 +1,98 @@
+# Research: Per-Alias TLS Opt-In for Routing Aliases
+
+**Feature**: 012-tls-alias-routers
+**Phase**: 0 (Outline & Research)
+**Date**: 2026-05-02
+
+This document resolves the open design questions for the `tls` per-alias field before Phase 1 design begins. There were no `NEEDS CLARIFICATION` markers in the Technical Context; the items below are decisions that emerged from reading the existing alias surface (`internal/manifest/`, `internal/engine/`, `internal/plugins/gateway/traefik/routing.go`), the spec-006 collision regime, the spec-008 per-alias log marker, the spec-009 per-app file preservation, and the spec-011 `tlsPort` warning machinery.
+
+## Decision 1 — Where to add the `tls` field on the manifest
+
+**Decision**: Add `TLS bool \`yaml:"tls,omitempty"\`` to `manifest.RoutingAlias` in `internal/manifest/types.go`. Plain bool, not `*bool`.
+
+**Rationale**: The alias spec already uses a flat struct with `Host`, `PathPrefix`, and `StripPrefix *bool`. The `*bool` on `StripPrefix` is necessary because its default depends on whether `pathPrefix` is set (true when set, false when unset) — i.e., it has three meaningful states. The new `tls` field has only two states (`true` / not-true), with `omitted` and `false` collapsing to the same semantic per the spec's edge-case "tls: false behaves identically to omission". A plain `bool` captures this exactly: YAML unmarshal produces `false` for both omission and explicit `false`, which is what we want. `omitempty` so unset alias entries round-trip to byte-identical YAML for FR-009.
+
+**Alternatives considered**:
+- `*bool` to distinguish unset from `false`. Rejected — no semantic difference between the two (per spec); the pointer would just leak a meaningless distinction into every consumer.
+- A new sibling field `tls.entrypoint: websecure` enum. Rejected — over-engineered; the issue's example pins `tls: true` as the operator vocabulary, and "which entrypoint" is a Traefik configuration knob, not a manifest concern.
+
+## Decision 2 — Where to add the `TLS` field on the engine-side alias projection
+
+**Decision**: Extend `engine.AliasRoute` in `internal/engine/backends.go` with `TLS bool`, populated by `resolveAliasRoutes` in `internal/engine/engine.go`. Do not change `WriteRouteOp` (its `AdditionalRoutes []AliasRoute` already carries the new field for free).
+
+**Rationale**: `AliasRoute` is the canonical engine-side projection of a manifest alias entry. The existing fields (`Host`, `PathPrefix`, `StripPrefix`) are passed by value to plugins via `WriteRouteOp.AdditionalRoutes`. Adding `TLS bool` to the same struct is the smallest surface change and keeps every plugin's view of an alias consistent — DNS plugins, future gateway plugins, etc. all see the same record. `resolveAliasRoutes` is already the single point of conversion from `manifest.RoutingAlias` to `engine.AliasRoute`, so populating the new field is a one-line addition.
+
+**Alternatives considered**:
+- Add `TLS bool` only to a Traefik-private struct, not to `engine.AliasRoute`. Rejected — would force the plugin to re-read the manifest, breaking the engine-as-projection contract; the engine is supposed to hand the plugin a fully-resolved view.
+- Add a parallel `WriteRouteTLSOp` carrying the TLS info separately. Rejected — splits one record into two for no benefit; future fields on aliases (port mappings, middleware refs) would compound the split.
+
+## Decision 3 — Router shape for `tls: true` aliases
+
+**Decision**: Extend the `traefik.router` struct in `spec.go` with `TLS *tlsBlock \`yaml:"tls,omitempty"\``, where `tlsBlock` is a new empty struct `type tlsBlock struct{}`. When `ar.TLS == true`, `WriteRoute` sets `EntryPoints: []string{"web", "websecure"}` and `TLS: &tlsBlock{}` on the alias router; otherwise both fields are unset (and the YAML `omitempty` keeps the output byte-identical to today). The primary-domain router shape is **never** affected by any alias's `tls` flag.
+
+**Rationale**: The issue's exemplar pins this exact YAML output:
+
+```yaml
+entryPoints:
+  - web
+  - websecure
+tls: {}
+```
+
+The `entryPoints` list order matches the issue's exemplar and Traefik treats the list as a set, so order is not semantically meaningful at runtime — but it IS meaningful for byte-identical-comparison tests, where pinning the order makes assertions stable across YAML library updates. The empty `tlsBlock struct{}` marshals to `{}` in YAML 1.2 (verified against `gopkg.in/yaml.v3`), which is the literal token Traefik expects to mean "terminate TLS on this route using the default cert resolver / static-config TLS settings". An `interface{}` or `map[string]any` would also marshal to `{}`, but the typed empty struct (a) makes future extension explicit (if Traefik ever needs a per-route `certResolver` we'd add the field with explicit consideration) and (b) prevents accidental nil-vs-empty confusion in tests.
+
+**Alternatives considered**:
+- Use `map[string]any{}` for the TLS block. Rejected — typed struct is safer and self-documenting; the empty-struct pattern matches the YAML-marshal-friendly convention used elsewhere in the codebase (e.g., the existing `apiConfig`).
+- Embed a `tls: true` boolean shorthand in the router and let the renderer expand to the YAML block. Rejected — Traefik's schema is `tls: <object>`, not `tls: <bool>`; matching Traefik's vocabulary literally minimizes surprise for operators reading the generated file.
+- Reorder `entryPoints` alphabetically (`[web, websecure]` happens to be alphabetical, but the rule should be explicit). Rejected — pinning the literal order matches the issue exemplar; we don't need a sort rule for a 2-element list.
+
+## Decision 4 — Where to emit the FR-007 warning ("alias has tls but websecure not declared")
+
+**Decision**: Emit from inside `RoutingBackend.WriteRoute` in `internal/plugins/gateway/traefik/routing.go`, once per `WriteRoute` call (i.e., per application), when (a) at least one alias in `op.AdditionalRoutes` has `TLS == true` AND (b) `hasWebsecureEntrypoint(staticConfigPath)` returns false. The new event name is `gateway.alias.tls_no_websecure`. Emission is idempotent — every deploy re-emits while the mismatch persists (mirrors `gateway.config.legacy_http_block`'s precedent and satisfies FR-007's "MUST be emitted on every deploy where the mismatch is still present").
+
+`RoutingBackend` gains one new field — `staticConfigPath string` — passed in by `Plugin.RoutingBackend()` as `filepath.Join(routingDir, "traefik.yml")`. This keeps `WriteRoute` self-contained; it does not need to reach back into `Plugin.cfg` or run a second `New()` round-trip.
+
+**Rationale**: FR-007 names per-application context (alias index/host+path), so the warning must be emitted from a code path that has access to the application's alias list. `WriteRoute` is the only place inside the plugin where that is true. The `hasWebsecureEntrypoint` probe already exists (shipped by spec 011); reusing it is one line. Per-app emission rather than per-alias emission keeps the deploy log readable when an application has many aliases — operators see "this application's TLS aliases need a websecure entrypoint" once, not three times in a row. The fields included in the event name the application (team + service) plus the count of TLS-requesting aliases, which gives operators everything they need to triage without overflowing the renderer.
+
+**Alternatives considered**:
+- Emit from `Plugin.Deploy()` instead of `WriteRoute`. Rejected — `Deploy()` runs once at start of deploy and does not have access to per-application alias data (it runs before the engine iterates applications); moving alias info to `Deploy()` would require new plumbing.
+- Emit per alias rather than per application. Rejected — for an app with many TLS aliases, this floods the log; the per-app event already carries enough context to find the misconfigured alias.
+- Reuse `gateway.config.tls_port_no_websecure` from spec 011. Rejected per Complexity Tracking — different cause, different remediation, different fields; conflating them would force a conditional renderer that printed the wrong text half the time.
+- Block the deploy when the mismatch is detected. Rejected — operators may legitimately stage the manifest change first and the `tlsPort` change second (or the reverse); the alias router is still written so the deploy is safe to land before the static config catches up.
+
+## Decision 5 — Validation surface for the new field
+
+**Decision**: Rely entirely on YAML unmarshal for the structural validation of the `tls` field — non-boolean values are rejected with a path-bearing error from `gopkg.in/yaml.v3` automatically (verified against the existing parser tests, which assert error-message shapes for similar `*bool`/`bool` fields). Add no new code in `validate.go`. The "tls is only valid inside an alias entry" guarantee (FR-005) is enforced by the schema for free — the field is declared only on `RoutingAlias`, never on `Routing`, so a top-level `routing.tls` is rejected by `yaml.Unmarshal` with `"field tls not found in type manifest.Routing"`.
+
+**Rationale**: Adding redundant string-checking logic in `validate.go` would duplicate what the YAML decoder already does, and would push us toward multi-error reporting at the wrong layer (the `Validate` function is for semantic rules; structural type errors belong in the parse step). The test that asserts "non-boolean tls is rejected" lives in `parser_test.go` so the contract is captured next to the parser, not next to the validator.
+
+The `validateRoutingAliases` collision check is unchanged: it keys on `(host, normalizedPathPrefix)`, which is the right uniqueness rule per FR-006 ("TLS flag is a routing decoration, not a uniqueness key"). Two aliases with the same host+path collide regardless of `tls` flags; aliases that differ only by `tls` are NOT a collision (one's HTTP, one's HTTPS — but they'd produce identical Traefik routes because Traefik routers are keyed by rule, not by entrypoint set, so this would be a real collision and the existing check correctly flags it).
+
+**Alternatives considered**:
+- Add an explicit "tls must be a boolean" check in `validateRoutingAliases`. Rejected — duplicates the parser's structural check; the parser-level error is already clear and includes the YAML path.
+- Add a positive-allow-list "field tls is only valid here" check. Rejected — Go's struct-tag-driven `yaml.Unmarshal` already enforces this at zero cost; an explicit allow-list would be redundant.
+
+## Decision 6 — Per-alias log marker for FR-010
+
+**Decision**: Extend `formatAliasesForLog` in `engine.go` to append `" (tls)"` to an alias's log string when `r.TLS == true`. The marker composes with the existing `" (no strip)"` marker, so an alias with `pathPrefix: /foo, stripPrefix: false, tls: true` logs as `"alias.example.com+/foo (no strip) (tls)"`. The marker is appended in a fixed order — `(no strip)` first (existing position) then `(tls)` — so the log line is stable under sort.
+
+**Rationale**: The spec's FR-010 ("operators MUST be able to confirm at a glance which aliases were published with HTTPS") is satisfied by extending the existing per-alias log marker introduced by spec 008. Adding one `if r.TLS` branch to `formatAliasesForLog` is the smallest possible change; no new event needed (the existing `routing.configure` event already prints the formatted alias list per app). The marker shape `" (tls)"` matches the existing `" (no strip)"` precedent literally — same parenthesized lowercase keyword, same leading space.
+
+**Alternatives considered**:
+- Emit a separate `routing.alias.tls` event per TLS-enabled alias. Rejected — duplicates the info already in `routing.configure` and floods the log.
+- Use a `🔒` emoji marker in the existing log line. Rejected — terminal logger conventions in this codebase use literal text in marker fields; emoji are reserved for the `t.out` renderer side, not for the field strings.
+
+## Decision 7 — Integration test scenarios
+
+**Decision**: Add four new scenarios to `tests/integration/traefik_plugin_test.go`:
+
+1. **`should publish alias router with tls block when alias sets tls: true`** — covers User Story 1's acceptance scenarios 1 and 3. Deploys a manifest with one alias `tls: true`, asserts the generated dynamic config contains `entryPoints: [web, websecure]` and `tls: {}` on the alias router, and `entryPoints: [web]` (no `tls`) on the primary-domain router.
+2. **`should produce mixed TLS-on / TLS-off router shapes when only some aliases set tls`** — covers User Story 2. Deploys a manifest with two aliases (first without `tls`, second with `tls: true`), asserts the generated dynamic config contains exactly two alias routers with the expected differentiated shapes.
+3. **`should produce byte-identical dynamic config when no alias sets tls`** — covers User Story 3 / FR-009. Deploys a manifest with one alias and no `tls` field, captures the generated dynamic config, then re-deploys the same manifest and asserts the file is unchanged. Also asserts the file does NOT contain the strings `"websecure"` or `"tls:"`.
+4. **`should warn when alias sets tls: true but static config lacks websecure entrypoint`** — covers FR-007. Deploys a manifest with `tls: true` on an alias against a Traefik plugin configured WITHOUT `tlsPort` (so the generated `traefik.yml` has no `websecure`), asserts (a) the deploy succeeds, (b) the alias router is still written with the TLS block, and (c) the deploy log contains the `gateway.alias.tls_no_websecure` event with the expected fields.
+
+**Rationale**: Each scenario maps 1:1 to an FR or acceptance scenario in the spec. The `NewDockerSuite` harness builds the real `shrine` binary and runs it as a subprocess against a live Docker daemon, so each assertion is end-to-end including the YAML emission of the new `tls: {}` block. Fixtures are stored under `tests/integration/fixtures/traefik-alias-tls*/` mirroring the existing `traefik-alias-host-only/` and `traefik-alias-prefix/` precedents.
+
+**Alternatives considered**:
+- One mega-scenario covering all three router shapes plus the warning. Rejected — `NewDockerSuite` cleanup is per-test-case, and the constitution favors separate scenarios per acceptance criterion for clear regression reporting.
+- A scenario that actually issues an HTTPS request and validates the response body. Rejected as out-of-scope — per FR-012, Shrine does not configure TLS termination; an HTTPS-from-the-client integration would require a wired-up cert resolver and a trusted-cert chain, which is outside this feature's surface. A future end-to-end TLS test belongs in a separate spec that owns the cert flow.

--- a/specs/012-tls-alias-routers/spec.md
+++ b/specs/012-tls-alias-routers/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Per-Alias TLS Opt-In for Routing Aliases
+
+**Feature Branch**: `012-tls-alias-routers`
+**Created**: 2026-05-02
+**Status**: Draft
+**Input**: GitHub issue [#13](https://github.com/CarlosHPlata/shrine/issues/13) — "App manifest should support websecure entrypoint on alias routers"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Operator publishes a single alias over HTTPS via the manifest (Priority: P1)
+
+An operator runs an application — say, a personal-finance app — that they reach over HTTP at `finances.home.lab` from inside their LAN. They also want to reach the same app from outside the LAN over their Tailscale tailnet at `https://gateway.tail9a6ddb.ts.net/finances`. Today, the alias generated for the Tailscale host attaches only to the `web` entrypoint, so reaching it over HTTPS requires the operator to hand-edit the generated dynamic config to add `websecure` and `tls: {}` on every alias they want served over TLS — a workaround that survives across redeploys (per spec 009) but means the manifest no longer reflects the full routing intent. With per-alias TLS opt-in, the operator declares the intent inline:
+
+```yaml
+routing:
+  domain: finances.home.lab
+  aliases:
+    - host: gateway.tail9a6ddb.ts.net
+      pathPrefix: /finances
+      stripPrefix: false
+      tls: true
+```
+
+After `shrine deploy`, the alias router published in the application's dynamic config attaches to both the `web` and `websecure` entrypoints and carries an empty TLS block (`tls: {}`), causing Traefik to terminate TLS on that route using its existing TLS configuration. The primary `routing.domain` and any aliases without `tls: true` keep behaving exactly as they do today.
+
+**Why this priority**: This is the entire point of the feature. Without it, the manifest cannot express "publish this alias over HTTPS," so multi-network operators (LAN + Tailscale, internal + public) must keep hand-editing generated config to recover routing intent that ought to live in the manifest. P1 because nothing else in this feature delivers value on its own.
+
+**Independent Test**: Author a manifest with `routing.domain` plus one alias that sets `tls: true`. With the Traefik gateway plugin active and a `websecure` entrypoint already configured (per spec 011's `tlsPort` flow or via operator-edited `traefik.yml`), run `shrine deploy`. Inspect the generated dynamic config file for the application: the alias router declares `entryPoints: [web, websecure]` and contains `tls: {}`; the primary-domain router still declares only `entryPoints: [web]` and has no `tls` block. Send an HTTPS request to the alias address; it reaches the running container.
+
+**Acceptance Scenarios**:
+
+1. **Given** a manifest with `routing.domain` and one alias entry setting `tls: true`, **When** `shrine deploy` runs with the Traefik plugin active, **Then** the generated dynamic config's alias router declares both `web` and `websecure` entrypoints and contains `tls: {}`, while the primary-domain router declares only `web` and has no `tls` block.
+2. **Given** the same manifest, **When** an HTTPS request is sent to the alias host (and Traefik has a `websecure` entrypoint listening), **Then** the request is routed to the same backend service as the primary-domain HTTP request, producing identical response bodies.
+3. **Given** a manifest with `routing.domain` and one alias entry that omits `tls` (or sets `tls: false`), **When** `shrine deploy` runs, **Then** the generated alias router declares only the `web` entrypoint and contains no `tls` block — byte-identical to the pre-feature output for the same input.
+
+---
+
+### User Story 2 - Mixed TLS-on / TLS-off aliases on the same application (Priority: P1)
+
+An operator runs the same app with two aliases: one internal (HTTP-only on the LAN) and one external (must be HTTPS over Tailscale). They declare both aliases in the same `routing.aliases` list, set `tls: true` on the external one only, and leave the internal one untouched. After `shrine deploy`, the application's dynamic config contains one alias router that attaches to `web` only, and a second alias router (the external one) that attaches to both `web` and `websecure` and carries `tls: {}`. The primary domain remains HTTP-only.
+
+**Why this priority**: This is the realistic deployment shape the issue points at — at least one alias keeps HTTP, at least one needs HTTPS, and the manifest must express both without ambiguity. P1 because the feature is incomplete if `tls: true` cannot be applied per-alias-entry; uniform-on-all and uniform-off-all are not viable substitutes for the multi-network operator.
+
+**Independent Test**: Author a manifest with `routing.domain` and two aliases — first alias has no `tls` field (or `tls: false`), second alias has `tls: true`. Run `shrine deploy`. Inspect the generated dynamic config: the first alias router has `entryPoints: [web]` and no TLS block; the second alias router has `entryPoints: [web, websecure]` and `tls: {}`. Both aliases route to the same backend service as the primary domain.
+
+**Acceptance Scenarios**:
+
+1. **Given** a manifest with two alias entries where the first omits `tls` and the second sets `tls: true`, **When** `shrine deploy` completes, **Then** the generated dynamic config contains exactly two alias routers, one HTTP-only and one HTTPS-enabled, and both point to the same backend service.
+2. **Given** the same manifest, **When** the operator removes `tls: true` from the second alias and re-deploys, **Then** the second alias router is regenerated without `tls: {}` and attaches only to `web` — the dynamic config returns to a fully HTTP-only state.
+
+---
+
+### User Story 3 - Existing manifests without `tls` keep working unchanged (Priority: P1)
+
+An operator who has not opted into per-alias TLS leaves all alias entries unchanged (no `tls` field present). After `shrine deploy`, the generated dynamic config is byte-identical (modulo unrelated, already-shipped changes) to the file produced by the previous Shrine release for the same input. No new entrypoints, no `tls` blocks, no log noise.
+
+**Why this priority**: Backward compatibility with the existing fleet of Shrine deployments is non-negotiable. Adding a new optional alias field MUST NOT alter behavior for operators who do not adopt it. P1 because a regression here would break every existing deployment on upgrade — including the operator-preserved files protected by spec 009.
+
+**Independent Test**: On a host with a previously-deployed application whose manifest declares aliases without `tls`, capture the current dynamic config file. Upgrade to the release containing this feature. Run `shrine deploy` with the unchanged manifest. Compare the dynamic config: it must be byte-identical to the captured baseline. (When spec 009 has marked the file as operator-owned, `shrine deploy` MUST NOT rewrite it; the assertion on byte-equality applies to the file Shrine would have generated, not necessarily to a regenerated file.)
+
+**Acceptance Scenarios**:
+
+1. **Given** a manifest with one or more alias entries, none of which set `tls`, **When** `shrine deploy` completes after upgrading to this release, **Then** the dynamic config Shrine would generate for that manifest is byte-identical to the file generated by the previous release for the same input.
+2. **Given** a manifest with no `routing.aliases` field at all, **When** `shrine deploy` completes, **Then** behavior is identical to today and no `tls`-related artefact appears anywhere in the generated config.
+
+---
+
+### Edge Cases
+
+- **`tls: true` is set but the active Traefik static configuration has no `websecure` entrypoint**: Shrine writes the alias router with `web` + `websecure` entrypoints and `tls: {}` regardless. Traefik will start successfully but routes attached to the missing `websecure` entrypoint will not receive HTTPS traffic until the operator wires the entrypoint (via spec 011's `tlsPort` config, or by editing a preserved `traefik.yml`). Shrine SHOULD emit a deploy-time warning that names the application, the alias index, and the missing `websecure` entrypoint, instructing the operator to set `tlsPort` or add the entrypoint manually. (This mirrors the warning pattern established by spec 011 for the static-config side.)
+- **`tls` is omitted entirely**: Treated as `tls: false`. The alias router is generated with only the `web` entrypoint and no `tls` block, exactly as today.
+- **`tls: false` is set explicitly**: Behaves identically to omission. No error, no warning. The field is accepted as harmless because operators may flip the field on/off across deploys and authoring `tls: false` explicitly is a legitimate signal of intent.
+- **`tls: true` on an alias that has only `host` (no `pathPrefix`)**: The alias router matches the host on every path, attaches to `web` + `websecure`, and carries `tls: {}`. No interaction with `stripPrefix` (which is a no-op when there is no prefix; see spec 006).
+- **`tls: true` combined with `stripPrefix: false` (or `stripPrefix: true`)**: The two fields are independent. `stripPrefix` continues to control whether the matched prefix is removed before the request reaches the backend; `tls` controls whether `websecure` is published and `tls: {}` is emitted. Both effects compose without conflict.
+- **`tls: true` on the primary `routing.domain`**: Out of scope for this feature. The `tls` field is only valid inside `routing.aliases` entries; declaring `tls: true` at the `routing.*` top level (or anywhere outside an alias entry) MUST fail manifest validation with a clear error naming the application and the offending field path. Operators who need HTTPS on the primary domain do so via spec 011's `tlsPort` plus their own Traefik TLS configuration, exactly as before. (Adding per-primary-domain TLS opt-in is a separate, larger conversation about migration; this feature deliberately does not pre-empt it.)
+- **`tls` set to a non-boolean value** (e.g., a string `"yes"`, an integer, an object): The manifest is invalid and the deploy fails with a clear YAML-shape error naming the application, the alias index, and the offending value. Validation does not coerce truthy strings into booleans.
+- **Operator preserves the dynamic config file (per spec 009) and then later flips `tls: true` on an alias**: Shrine MUST NOT rewrite the preserved file. The flip in the manifest has no effect until the operator either deletes the file (so Shrine regenerates it including the new `tls: true` semantics) or hand-edits the preserved file to mirror the new intent. This matches the regime established by spec 009 — manifest fields are advisory once a file is operator-owned. Shrine SHOULD emit the same `gateway.route.preserved` info-level signal it emits today, so the operator can spot the divergence in the deploy log without a separate warning.
+- **Primary-domain HTTPS via the issue's old workaround**: Some operators may have edited their preserved dynamic config to put `tls: {}` on the primary-domain router as well. Per the previous bullet, that file remains preserved; this feature does not regenerate it. The new manifest field affects only newly-generated dynamic config files, never preserved ones.
+- **`routing.aliases` is empty or omitted**: Behavior is identical to today. The `tls` field has no surface area when there are no alias entries.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The application manifest schema MUST accept an optional boolean `tls` field on each entry of `routing.aliases`. The field defaults to `false` when omitted.
+- **FR-002**: When the Traefik gateway plugin is active and an alias entry sets `tls: true`, Shrine MUST generate the alias router in the application's dynamic config file with the `entryPoints` list `[web, websecure]` (in that order) and MUST emit an empty `tls: {}` block on the router.
+- **FR-003**: When the Traefik gateway plugin is active and an alias entry sets `tls: false` or omits the `tls` field, Shrine MUST generate the alias router exactly as today — `entryPoints: [web]` only, no `tls` block, no other 443-related artefact. The primary-domain router MUST remain unchanged regardless of any alias's `tls` value.
+- **FR-004**: Manifest parsing MUST reject a `tls` value that is not a YAML boolean (i.e., reject strings, numbers, objects, lists), surfacing a clear error that names the offending application and alias index.
+- **FR-005**: Manifest parsing MUST reject a `tls` field declared anywhere outside a `routing.aliases` entry (e.g., at the `routing` top level). The error MUST name the application and the offending field path. This forecloses an ambiguity where operators could appear to opt the primary domain into HTTPS via this feature.
+- **FR-006**: The cross-application collision check (per spec 006 FR-008a) MUST treat host+path collisions independently of the `tls` flag — two aliases on different applications with the same host+path collide regardless of whether either sets `tls: true`. The TLS flag is a routing decoration, not a uniqueness key.
+- **FR-007**: When `tls: true` is set on at least one alias of an application AND the active Traefik static configuration (Shrine-generated or operator-preserved) does not declare a `websecure` entrypoint, Shrine MUST emit a deploy-time warning naming the application, the alias index/host+path, and instructing the operator to wire `websecure` (via spec 011's `tlsPort` or an operator-edited static config). The warning MUST be emitted on every deploy where the mismatch is still present and MUST NOT block the deploy — the alias router is still written so operators can land both changes in any order.
+- **FR-008**: When the application's dynamic config file is operator-preserved (per spec 009), Shrine MUST NOT rewrite the file in response to `tls` field changes in the manifest, in line with the existing preservation regime. Shrine MUST emit the same `gateway.route.preserved` info-level signal it emits today; no new warning is required for `tls`-specific drift between manifest and preserved file.
+- **FR-009**: Manifests that omit `tls` from every alias entry (including manifests with no `routing.aliases` field at all) MUST produce dynamic config that is byte-identical (modulo unrelated, already-shipped changes) to the file generated by the previous release for the same input. This is the regression guard for the existing fleet.
+- **FR-010**: The deploy log MUST include an observable signal (info-level or equivalent, consistent with the existing per-alias log marker established by spec 008) indicating, for each alias, whether `tls` is enabled. Operators inspecting the log MUST be able to confirm at a glance which aliases were published with HTTPS without reading the generated dynamic config file.
+- **FR-011**: The new `tls` field MUST be documented on the same surface that already documents `routing.aliases`, `host`, `pathPrefix`, and `stripPrefix`. The documentation MUST state that `tls: true` only opens the routing/entrypoint side — TLS certificate provisioning and termination configuration on the `websecure` entrypoint remain entirely operator-owned via standard Traefik mechanisms (mirroring spec 011 FR-010).
+- **FR-012**: Shrine MUST NOT generate, validate, reference, distribute, or otherwise interact with TLS certificates, certificate file paths, certificate resolvers, ACME providers, default-cert configuration, HTTP→HTTPS redirects, or any other TLS-termination concern as part of this feature. The `tls: {}` block emitted on alias routers MUST be empty — Shrine MUST NOT inject `certResolver`, `domains`, `options`, or any sibling key into it. Operators configure TLS termination on the `websecure` entrypoint exclusively through standard Traefik mechanisms outside this feature's surface.
+
+### Key Entities
+
+- **Alias entry (manifest field)**: Already defined by spec 006 as a triple of `host`, `pathPrefix`, `stripPrefix`. This feature adds a fourth optional boolean field `tls` (default `false`). The field is a routing decoration: it controls which entrypoints the generated alias router attaches to and whether an empty `tls: {}` block is emitted.
+- **Alias router (gateway dynamic config)**: Already defined by spec 006 as the per-alias entry in the generated dynamic config. This feature extends the alias router's shape: when the source alias sets `tls: true`, the router declares `entryPoints: [web, websecure]` and carries `tls: {}`; otherwise the router shape is unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator who needs to expose an existing alias over HTTPS can do so by adding a single `tls: true` line to the existing alias entry — no second manifest, no hand-edit of generated config, no extra commands beyond a normal `shrine deploy`.
+- **SC-002**: After deploying a manifest with `tls: true` on N of M alias entries, the generated dynamic config contains exactly N alias routers attached to `web` + `websecure` with `tls: {}`, and exactly M − N alias routers attached to `web` only with no `tls` block. The primary-domain router is unchanged.
+- **SC-003**: 100% of existing Shrine deployments whose manifests do NOT use `tls` on any alias continue to deploy successfully after upgrading to the release containing this feature, with byte-identical generated dynamic config (modulo unrelated, already-shipped changes).
+- **SC-004**: A manifest with an invalid `tls` value (non-boolean, or set outside an alias entry) is rejected at validation time with a single clear error naming the offending field; no dynamic config file is written or mutated for that application.
+- **SC-005**: Removing `tls: true` from an alias and re-deploying causes the corresponding alias router to lose its `websecure` entrypoint and `tls: {}` block within one deploy cycle (subject to spec 009 preservation, which is unchanged here). Operators do not need to hand-edit the generated dynamic config to revert.
+- **SC-006**: Zero new GitHub issues filed against Shrine in the 30 days following the release reporting "had to hand-edit dynamic config to publish an alias over HTTPS" or "tls: true on an alias did not produce the expected router shape."
+
+## Assumptions
+
+- The `websecure` entrypoint exists in the active Traefik static configuration. Whether it was put there by spec 011's `tlsPort` flow, by an operator hand-edit of a preserved `traefik.yml`, or by some future Shrine surface, is out of scope for this feature. When the entrypoint is missing, Shrine still writes the alias router as specified (FR-002) and emits a warning (FR-007) — it does not block the deploy or fall back to a different router shape.
+- TLS certificate provisioning and termination are entirely operator-owned, exactly as established by spec 011 FR-010. Shrine emits an empty `tls: {}` block to mark "Traefik should terminate TLS on this route using whatever it already knows," and contributes nothing else to the TLS layer. Operators wanting per-route certs, resolvers, or options configure them via standard Traefik mechanisms (preserved `traefik.yml`, separately-managed dynamic config, external cert management).
+- Spec 009's operator-edit preservation regime for per-app dynamic config files applies unchanged. The new `tls` field is advisory once a dynamic config file is operator-owned; Shrine MUST NOT rewrite preserved files in response to `tls` flips. Operators who want the new generated shape on a preserved file delete the file and let Shrine regenerate it.
+- Spec 006's manifest validation surface (host shape, pathPrefix shape, cross-application collision detection) applies unchanged; `tls` is a separate field added to the existing entry shape and inherits the existing validation pipeline for everything else on the alias entry.
+- The `tls` field is intentionally scoped to alias entries (FR-005). Adding `tls: true` semantics for the primary `routing.domain` is a larger conversation — it would interact with default-router behavior, with the issue's existing workaround, and with the migration story for the existing fleet — and this spec defers that conversation rather than pre-empting it.
+- The `entryPoints` list order `[web, websecure]` is chosen for stability with the example in the GitHub issue and for ease of byte-comparison in tests; Traefik treats the list as a set, so the order is not semantically meaningful at runtime.
+- This feature does not introduce a separate flag, env var, or migration. The new field is additive and optional; existing manifests are unaffected.

--- a/specs/012-tls-alias-routers/tasks.md
+++ b/specs/012-tls-alias-routers/tasks.md
@@ -1,0 +1,214 @@
+---
+
+description: "Task list for tls-alias-routers"
+---
+
+# Tasks: Per-Alias TLS Opt-In for Routing Aliases
+
+**Input**: Design documents from `/specs/012-tls-alias-routers/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/observer-events.md](./contracts/observer-events.md), [quickstart.md](./quickstart.md)
+
+**Tests**: REQUIRED — Constitution Principle V mandates that integration tests are written before the implementation they cover. Unit tests follow the project's strict no-filesystem rule (use the existing `writeFileFn` / `mkdirAllFn` / `readFileFn` injection points and in-memory YAML bytes only).
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently. All three stories are P1 — together they form the feature, but each is independently testable. US1 delivers the headline capability (single alias over HTTPS); US2 verifies the realistic mixed-TLS deployment shape; US3 is the byte-identical regression guard for the existing fleet.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel — different files OR different test functions in the same file with no dependency on an incomplete task
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- File paths in every task are repo-root-relative
+
+## Path Conventions
+
+- Manifest schema: `internal/manifest/types.go` + `internal/manifest/parser_test.go` + `internal/manifest/validate_test.go`
+- Engine alias projection: `internal/engine/backends.go` + `internal/engine/engine.go` + `internal/engine/engine_aliases_test.go`
+- Plugin code: `internal/plugins/gateway/traefik/` (modify in place)
+- Terminal logger: `internal/ui/terminal_logger.go`
+- Unit tests: same package as the code under test; no filesystem touches; reuse the existing `writeFileFn` / `readFileFn` injection points and the `engine.NoopObserver` / recording-observer scaffolding already in `routing_test.go`
+- Integration tests: `tests/integration/traefik_plugin_test.go` (build tag `integration`; uses `NewDockerSuite`)
+- Integration fixtures: `tests/integration/fixtures/traefik-alias-tls*/` (mirror existing `traefik-alias-host-only/` layout)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a known-green baseline before any code change.
+
+- [X] T001 Confirm baseline `go build ./...` and `go test ./...` succeed on branch `012-tls-alias-routers` with no pre-existing failures, and confirm the latest `make test-integration` run on `main` passed (snapshot the SHA for comparison if a fresh local run is too slow per the user's auto-memory rule on integration-test cost). Record the snapshot SHA in the PR description. — Verified `go build ./...` clean before any edit; integration suite delegated to CI per user instruction.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Land the manifest field, the engine-side projection field, and the YAML-shape primitives. Every story's tests reference these; no story-level test compiles until these land.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T002 [P] Add the `TLS bool \`yaml:"tls,omitempty"\`` field to `RoutingAlias` in `internal/manifest/types.go`, placed immediately after the existing `StripPrefix *bool` field. Plain `bool`, not `*bool` — the field has only two semantic states and `tls: false` is required to behave identically to omission per the spec's edge-case section ([data-model.md §1](./data-model.md), [research.md Decision 1](./research.md)). Do NOT add a field on `Routing`; FR-005's "tls only valid inside an alias entry" is enforced structurally by `yaml.Unmarshal` because the field exists only on `RoutingAlias`.
+- [X] T003 Add the `TLS bool` field to `engine.AliasRoute` in `internal/engine/backends.go`, placed immediately after the existing `StripPrefix bool` field. Then extend `resolveAliasRoutes` in `internal/engine/engine.go` (around line 322) to populate the new field as a straight pass-through: `TLS: alias.TLS`. Do NOT change `WriteRouteOp` — its `AdditionalRoutes []AliasRoute` carries the new field for free. T003 reads the new manifest field, so it sequences after T002.
+- [X] T004 [P] Add the new YAML-shape primitives to `internal/plugins/gateway/traefik/spec.go`: (a) define `type tlsBlock struct{}` immediately after the existing `loadBalancer` / `server` types; (b) add `TLS *tlsBlock \`yaml:"tls,omitempty"\`` as the last field of the existing `router` struct. Verify by `go build ./...` that the package compiles. The pointer + `omitempty` ensures FR-009's byte-identical regression behaviour for routers without TLS — `nil` produces no `tls:` key in the marshalled output.
+
+**Checkpoint**: Foundation ready — every user story's tests can now compile against the new manifest field, the new engine field, and the new router shape.
+
+---
+
+## Phase 3: User Story 1 - Operator publishes a single alias over HTTPS via the manifest (Priority: P1) 🎯 MVP
+
+**Goal**: Adding a single `tls: true` line to an existing `routing.aliases[]` entry results in (a) the generated alias router declaring `entryPoints: [web, websecure]` and carrying `tls: {}`, while (b) the primary-domain router stays HTTP-only, and (c) when the active static Traefik config has no `websecure` entrypoint, a `gateway.alias.tls_no_websecure` warning fires (deploy still succeeds — the alias router is still written so operators can land both edits in any order). Manifest validation rejects non-boolean values and rejects `tls` declared outside an alias entry.
+
+**Independent Test**: Author a manifest with `routing.domain` plus one alias setting `tls: true`. With the Traefik gateway plugin active (and any working `websecure` wiring — via spec 011's `tlsPort` or a preserved `traefik.yml`), run `shrine deploy`. The generated `<routing-dir>/dynamic/<team>-<service>.yml` contains an alias router with `entryPoints: [web, websecure]` and `tls: {}`; the primary-domain router contains `entryPoints: [web]` and no `tls` field. The deploy log includes `↳ Aliases: <host>+<path> (tls)`. A non-boolean `tls` value or a top-level `routing.tls` key fails parse with a path-bearing error and no dynamic config is written.
+
+### Tests for User Story 1 ⚠️ Write FIRST and confirm they FAIL before T017–T021
+
+- [X] T005 [P] [US1] Manifest parser test `TestParseApplication_RoutingAlias_TLS_RoundTrip` in `internal/manifest/parser_test.go` — three sub-cases: (a) YAML with `tls: true` round-trips to `RoutingAlias.TLS == true`; (b) YAML with `tls: false` round-trips to `RoutingAlias.TLS == false`; (c) YAML with the `tls` field omitted entirely round-trips to `RoutingAlias.TLS == false`. All three must produce no error from `Parse(...)`.
+- [X] T006 [P] [US1] Manifest parser test `TestParseApplication_RoutingAlias_TLS_RejectsNonBoolean` in `internal/manifest/parser_test.go` — feed YAML where one alias's `tls` field is the string `"yes"` (and a sibling sub-case for an integer `1`); assert `Parse(...)` returns a non-nil error whose message contains the alias path (e.g., `routing.aliases[1].tls`) and indicates a boolean type was expected. Covers FR-004.
+- [X] T007 [P] [US1] Manifest parser test `TestParseApplication_Routing_TLS_RejectsTopLevelField` in `internal/manifest/parser_test.go` — feed YAML where `tls: true` is declared at `spec.routing.tls` (sibling to `domain`, not inside an `aliases[]` entry). Assert `Parse(...)` returns a non-nil error containing `field tls not found` and `manifest.Routing` (or substring `Routing`). Covers FR-005.
+- [X] T008 [P] [US1] Manifest validate test `TestValidateRoutingAliases_TLS_DoesNotAffectCollisionKey` in `internal/manifest/validate_test.go` — two sub-cases: (a) two aliases with the same `host`+`pathPrefix` but one has `tls: true` and the other does not — must still be rejected as a duplicate (the `tls` flip is not a uniqueness key per FR-006); (b) two aliases with different `host`s but both with `tls: true` — must validate clean. Reuse the existing `validateRoutingAliases` test scaffolding in the file.
+- [X] T009 [P] [US1] Engine test `TestResolveAliasRoutes_CarriesTLS` in `internal/engine/engine_aliases_test.go` — feed a `[]manifest.RoutingAlias` containing one entry with `TLS: true` and one with `TLS: false`; assert `resolveAliasRoutes(...)` returns a `[]AliasRoute` whose `TLS` fields match the inputs index-for-index. Covers the engine projection of FR-001.
+- [X] T010 [P] [US1] Engine test `TestFormatAliasesForLog_AppendsTLSMarker` in `internal/engine/engine_aliases_test.go` — table-driven cases mirroring the existing `(no strip)` precedent: (a) `{Host:"a.example.com", TLS:true}` → `"a.example.com (tls)"`; (b) `{Host:"a.example.com", PathPrefix:"/x", TLS:true}` (default strip true) → `"a.example.com+/x (tls)"`; (c) `{Host:"a.example.com", PathPrefix:"/x", StripPrefix:false, TLS:true}` → `"a.example.com+/x (no strip) (tls)"`; (d) two aliases mixed — assert alphabetic sort puts the `(tls)`-marked entry in the right position. Covers FR-010.
+- [X] T011 [P] [US1] Traefik routing test `TestWriteRoute_AliasWithTLS_AddsWebsecureAndTLSBlock` in `internal/plugins/gateway/traefik/routing_test.go` — extend the existing `baseOp()` helper (or write inline) with an `engine.AliasRoute{Host:"a.example.com", TLS:true}` in `AdditionalRoutes`. Stub `writeFileFn` to capture the bytes written. Stub `readFileFn` to return YAML containing a `websecure` entrypoint (so no warning fires). Assert the captured bytes contain (i) the alias router with `entryPoints:` block listing both `web` and `websecure` AND a `tls: {}` line; (ii) the primary-domain router still has `entryPoints:` listing only `web` and NO `tls` line. Covers FR-002, FR-003 (primary-domain invariant).
+- [X] T012 [P] [US1] Traefik routing test `TestWriteRoute_AliasWithTLS_PreservesPrimaryRouterShape` in `internal/plugins/gateway/traefik/routing_test.go` — capture the bytes for an op with one `TLS: true` alias and one `TLS: false` alias; assert the primary-domain router YAML block (lookup by router name `<team>-<svc>`) is byte-identical to the byte block produced by `TestWriteRoute_OneAlias_NoStrip`'s primary-domain router for the same `Domain`/`Team`/`ServiceName` inputs. This is the surgical regression guard for "primary-domain router MUST remain unchanged regardless of any alias's `tls` value" (FR-003). Stub `readFileFn` to return YAML with `websecure` so warning emission is silent.
+- [X] T013 [P] [US1] Traefik routing test `TestWriteRoute_AliasWithTLS_EmitsWarning_WhenStaticConfigLacksWebsecure` in `internal/plugins/gateway/traefik/routing_test.go` — construct a `RoutingBackend{routingDir:"/fake", staticConfigPath:"/fake/traefik.yml", observer: rec}` (recording observer); stub `readFileFn` to return YAML with only a `web` entrypoint (no `websecure`); call `WriteRoute` with `AdditionalRoutes` containing two TLS-enabled aliases. Assert exactly one event with `Name == "gateway.alias.tls_no_websecure"`, `Status == engine.StatusWarning`, `Fields["team"] == op.Team`, `Fields["name"] == op.ServiceName`, `Fields["path"] == "/fake/traefik.yml"`, `Fields["tls_aliases"]` is a comma-separated alphabetically-sorted list of the two TLS aliases formatted as `host[+pathPrefix]`, and `Fields["hint"]` contains the substring `websecure`. Covers FR-007.
+- [X] T014 [P] [US1] Traefik routing test `TestWriteRoute_AliasWithTLS_NoWarning_WhenWebsecurePresent` in `internal/plugins/gateway/traefik/routing_test.go` — same fixture as T013 but stub `readFileFn` to return YAML containing `entryPoints.websecure`; assert the recorder captures zero `gateway.alias.tls_no_websecure` events. The router-shape side of the assertion is already covered by T011; this test is purely the warning-suppression branch.
+- [X] T015 [P] [US1] Traefik routing test `TestWriteRoute_NoAliasHasTLS_NoWarning_RegardlessOfStaticConfig` in `internal/plugins/gateway/traefik/routing_test.go` — call `WriteRoute` with `AdditionalRoutes` containing only `TLS: false` (or omitted) aliases; stub `readFileFn` to return YAML lacking `websecure` (i.e., the warning's preconditions are otherwise met except no alias requested TLS). Assert zero `gateway.alias.tls_no_websecure` events. Guards against the warning firing spuriously when the operator has not opted in.
+- [~] T016 [US1] (DEFERRED TO CI) Create integration fixture `tests/integration/fixtures/traefik-alias-tls/{application.yml, team.yml}` mirroring the existing `traefik-alias-prefix/` layout. The application manifest declares `metadata.name: whoami-tls`, `spec.image: traefik/whoami:v1.10.1`, `spec.port: 80`, `spec.routing.domain: primary.shrine.lab`, `spec.routing.aliases: [{host: alias.shrine.lab, pathPrefix: /tls, stripPrefix: false, tls: true}]`, and `spec.networking.exposeToPlatform: true`. The team manifest reuses the existing `aliasTestTeam` value (`shrine-alias-test`) so `BeforeEach`/`AfterEach` cleanup paths in the existing alias scenarios cover this fixture too.
+- [~] T017 [US1] (DEFERRED TO CI) Integration test scenario `should publish alias router with tls block when alias sets tls: true` in `tests/integration/traefik_plugin_test.go` (alongside existing US-006 alias scenarios). Apply the team and application fixtures from T016 with the Traefik plugin active and `tlsPort: 8444` configured (so `websecure` is wired and no warning fires). Read `<routing-dir>/dynamic/shrine-alias-test-whoami-tls.yml`; parse to `map[string]any`; assert: (a) the alias router (`shrine-alias-test-whoami-tls-alias-0`) has `entryPoints` equal to the slice `[web, websecure]` AND has a key `tls` whose value is an empty map; (b) the primary-domain router (`shrine-alias-test-whoami-tls`) has `entryPoints` equal to `[web]` and has NO `tls` key. Assert the deploy stdout contains the substring `(tls)` (FR-010 log marker) by `tc.AssertOutputContains("(tls)")`.
+
+### Implementation for User Story 1
+
+- [X] T018 [US1] Extend `formatAliasesForLog` in `internal/engine/engine.go` (around line 331) to append `" (tls)"` to each alias's log string when `r.TLS == true`. Order is fixed: append `(no strip)` first (existing behaviour, preserves current diffs), then `(tls)` second. The function continues to alphabetically sort the joined entry list. One-line `if r.TLS { entry += " (tls)" }` immediately after the existing `if r.PathPrefix != "" && !r.StripPrefix` block. Covers FR-010.
+- [X] T019 [US1] Add a `staticConfigPath string` field to `RoutingBackend` in `internal/plugins/gateway/traefik/routing.go` (place after `routingDir`, before `observer`). Update the constructor in `internal/plugins/gateway/traefik/plugin.go` (around line 184) — `Plugin.RoutingBackend()` — to pass `staticConfigPath: filepath.Join(routingDir, "traefik.yml")`. Update every call-site of `&RoutingBackend{...}` in `routing_test.go` to thread the new field (use `"/fake/traefik.yml"` for the existing tests where the value does not matter).
+- [X] T020 [US1] Extend the alias-loop body inside `WriteRoute` in `internal/plugins/gateway/traefik/routing.go` (the loop currently spans lines 82–95). Inside the loop where the alias router `r` is constructed, add — after the existing strip-middleware branch — a TLS branch: `if ar.TLS { r.EntryPoints = []string{"web", "websecure"}; r.TLS = &tlsBlock{} }`. The order matters: keep the strip-middleware block first (it touches `r.Middlewares`), then the TLS block (it touches `r.EntryPoints` + `r.TLS`). Verify via `go test ./internal/plugins/gateway/traefik/...` that T011 and T012 pass.
+- [X] T021 [US1] Add the `emitAliasTLSNoWebsecureSignal(op engine.WriteRouteOp, staticConfigPath string, observer engine.Observer)` helper in `internal/plugins/gateway/traefik/routing.go`, modelled on spec 011's `emitTLSPortNoWebsecureSignal`. Early-return when `op.AdditionalRoutes` contains zero entries with `TLS == true`. Otherwise call the existing `hasWebsecureEntrypoint(staticConfigPath)` (already defined in `config_gen.go`); on probe error reuse spec 011's `gateway.config.tls_port_probe_error` event verbatim ([contracts/observer-events.md "Non-events"](./contracts/observer-events.md)) and return; on `(true, nil)` return silently; on `(false, nil)` build the alphabetically-sorted `tls_aliases` field by collecting `formatAliasEntry(ar)` (extract a small helper if not already present — produces `host[+pathPrefix]`) for every TLS-enabled alias and emitting `engine.Event{Name:"gateway.alias.tls_no_websecure", Status:engine.StatusWarning, Fields: {"team":op.Team, "name":op.ServiceName, "path":staticConfigPath, "tls_aliases":joined, "hint":"Set plugins.gateway.traefik.tlsPort to publish a websecure entrypoint, or add the entrypoint to your preserved traefik.yml."}}`. Wire the call into `WriteRoute` at the very top of the function (immediately after the existing `mkdirAllFn` call and before the `path := filepath.Join(...)` line, OR after `path` is computed but BEFORE the `present` check returns) so the warning fires on EVERY `WriteRoute` invocation regardless of dynamic-file preservation state. The decision is purely a function of (a) manifest intent (`op.AdditionalRoutes` TLS flags) and (b) static config state (the websecure probe) — both observable independently of the per-app dynamic file. The warning fires on the preserved branch too, because operators who set `tls: true` in the manifest deserve the same nudge even if Shrine isn't currently rewriting their preserved per-app dynamic file (they may have copied the TLS shape into the preserved file or may not have — Shrine cannot tell, but the static-config mismatch is independently a problem worth flagging).
+- [X] T022 [US1] Add a `case "gateway.alias.tls_no_websecure":` clause to `internal/ui/terminal_logger.go` immediately after the existing `gateway.config.tls_port_no_websecure` case. Render as `fmt.Fprintf(t.out, "  ⚠️  alias tls: true but websecure entrypoint missing in %s for %s.%s (%s) — %s\n", e.Fields["path"], e.Fields["team"], e.Fields["name"], e.Fields["tls_aliases"], e.Fields["hint"])`. Match the indentation and `⚠️` glyph already used by sibling warnings.
+
+**Checkpoint**: User Story 1 is complete and shippable as MVP. T005–T017 must all pass. The headline issue from GitHub #13 is resolved end-to-end: `tls: true` on an alias produces the expected router shape and the manifest is the source of truth.
+
+---
+
+## Phase 4: User Story 2 - Mixed TLS-on / TLS-off aliases on the same application (Priority: P1)
+
+**Goal**: An application can declare two or more aliases where some set `tls: true` and others do not. The generated dynamic config contains the right per-alias router shape for each entry, and the primary-domain router remains HTTP-only regardless of alias mix. Removing `tls: true` from an alias and re-deploying restores the alias router to HTTP-only.
+
+**Independent Test**: Apply a manifest with `routing.domain` and two aliases — first omits `tls`, second sets `tls: true`. After `shrine deploy`, the generated dynamic config has exactly two alias routers: the first with `entryPoints: [web]` and no `tls` key, the second with `entryPoints: [web, websecure]` and `tls: {}`. Both alias routers `service:` field points to the same backend service as the primary-domain router. Edit the manifest to remove `tls: true` from the second alias; re-deploy; confirm both alias routers now declare `entryPoints: [web]` and contain no `tls` block.
+
+### Tests for User Story 2 ⚠️ Write FIRST
+
+- [~] T023 [US2] (DEFERRED TO CI) Create integration fixture `tests/integration/fixtures/traefik-alias-tls-mixed/{application.yml, team.yml}` mirroring the T016 layout. Application name `whoami-tls-mixed`; aliases list contains TWO entries: (i) `{host: lan.shrine.lab, pathPrefix: /lan}` (no `tls` field); (ii) `{host: ext.shrine.lab, pathPrefix: /ext, stripPrefix: false, tls: true}`. Reuse `aliasTestTeam`.
+- [~] T024 [US2] (DEFERRED TO CI) Integration test scenario `should produce mixed TLS-on / TLS-off router shapes when only some aliases set tls` in `tests/integration/traefik_plugin_test.go`. Apply T023's fixtures with `tlsPort: 8445` configured. Read `<routing-dir>/dynamic/shrine-alias-test-whoami-tls-mixed.yml`; parse to `map[string]any`; assert: (a) router `shrine-alias-test-whoami-tls-mixed-alias-0` (the lan alias) has `entryPoints == [web]` and NO `tls` key; (b) router `shrine-alias-test-whoami-tls-mixed-alias-1` (the ext alias) has `entryPoints == [web, websecure]` and a `tls` key whose value is the empty map; (c) both aliases' `service` field equals the primary-domain router's `service` field, proving they all share the same backend. Then rewrite the application manifest with the second alias's `tls: true` removed; re-deploy; re-read the dynamic file; assert alias-1 now has `entryPoints == [web]` and NO `tls` key (the alias router reverts cleanly).
+
+### Implementation for User Story 2
+
+User Story 2 introduces no new production code. The conditional added in T020 (`if ar.TLS { r.EntryPoints = []string{"web", "websecure"}; r.TLS = &tlsBlock{} }`) is per-alias, so a mix of `TLS: true` and `TLS: false` aliases automatically produces the differentiated router shapes covered by T024. If T024 fails, the bug is in the US1 conditional branch, not in new US2 code.
+
+**Checkpoint**: User Story 2 verified — operators can declare per-alias TLS independently and the manifest is the source of truth across re-deploys. T023–T024 must pass.
+
+---
+
+## Phase 5: User Story 3 - Existing manifests without `tls` keep working unchanged (Priority: P1)
+
+**Goal**: Manifests that do NOT use `tls` on any alias produce dynamic config that is byte-identical (modulo unrelated, already-shipped changes) to the file generated by the previous Shrine release for the same input. No new entrypoints, no `tls` blocks, no log noise on the no-TLS path.
+
+**Independent Test**: Apply a manifest with one or more aliases, none of which set `tls`. Capture the generated dynamic config bytes. Re-deploy the same manifest a second time. Assert the file's bytes are unchanged. Inspect the file: it contains no occurrence of the strings `"websecure"` or `"tls:"`. Repeat with a manifest that has no `routing.aliases` field at all — same byte-stable result, no `(tls)` marker in the deploy log, no `gateway.alias.tls_no_websecure` event.
+
+### Tests for User Story 3 ⚠️ Write FIRST
+
+- [X] T025 [US3] Extend the existing `TestWriteRoute_NoAliases`, `TestWriteRoute_OneAlias_Strip`, `TestWriteRoute_OneAlias_NoStrip`, `TestWriteRoute_HostOnlyAlias`, and `TestWriteRoute_ThreeAliases_SparseStrip` in `internal/plugins/gateway/traefik/routing_test.go` to assert that the captured `writeFileFn` bytes do NOT contain the substrings `"websecure"` or `"tls:"`. The assertion is one line per test added at the end of the existing assertion block. Stub `readFileFn` (where not already stubbed) to return YAML lacking `websecure` so the new warning would fire IF any alias had `TLS: true` — proving by absence that no warning is emitted when no alias opts in. Collectively this is the FR-009 byte-identical regression guard at the unit-test layer.
+- [~] T026 [US3] (DEFERRED TO CI) Integration test scenario `should produce byte-stable dynamic config and emit no tls warnings when no alias sets tls` in `tests/integration/traefik_plugin_test.go`. Reuse the existing `traefik-alias-prefix` fixture (one alias with `pathPrefix`, no `tls`). Deploy with `tlsPort` UNSET (so the static config has no `websecure` either — the worst-case configuration for accidental warning emission). Read `<routing-dir>/dynamic/shrine-alias-test-whoami-prefix.yml`; capture the bytes. Re-deploy with the identical manifest; re-read the file; assert `bytes.Equal(first, second)`. Inspect the captured bytes: assert they do NOT contain `"websecure"` or `"tls:"`. Inspect the deploy stdout via `tc.AssertOutputContains` / `tc.AssertOutputDoesNotContain` (or equivalent): assert the substring `(tls)` is absent and the warning rendering `"alias tls: true but websecure entrypoint missing"` is absent. Covers FR-009 + FR-010 (no log noise) + the structural guarantee from FR-007 (warning is opt-in via at least one `tls: true`).
+
+### Implementation for User Story 3
+
+User Story 3 introduces no new production code. The byte-identical regression behaviour falls out of (a) the `omitempty` YAML tag on `RoutingAlias.TLS` (T002), `engine.AliasRoute.TLS` carrying false through (T003), the `*tlsBlock` pointer on `router.TLS` being `nil` for non-TLS aliases (T004), and the warning early-return when no alias has `TLS == true` (T021). T025 + T026 are the regression guards that lock these properties in. If either fails, the bug is in the foundational layer or the US1 conditional, not in new US3 code.
+
+**Checkpoint**: All three user stories are independently verified end-to-end. T025–T026 must pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T027 [P] Update `AGENTS.md` to add the new `tls` field to the `routing.aliases` example in the Traefik plugin section. Place it as a sibling of `host`, `pathPrefix`, `stripPrefix`, with a one-line trailing comment matching the existing alignment style. Add one short prose sentence: "`tls: true` opens the routing/entrypoint side only; certificate provisioning, ACME, and HTTPS redirects remain operator-owned via standard Traefik mechanisms (mirrors spec 011's `tlsPort` contract)." Covers FR-011.
+- [X] T028 [P] Cross-check that the existing alias integration scenarios in `tests/integration/traefik_plugin_test.go` (the `host-only`, `prefix`, `multi`, and any spec 008/009 scenarios) still pass byte-for-byte after the new `RoutingBackend.staticConfigPath` field lands. These scenarios do not declare `tls: true` on any alias and so MUST observe the FR-009 regression guard. If any pre-existing scenario is byte-equality-asserting on the dynamic config, verify the assertion still holds. Run `go test ./internal/plugins/gateway/traefik/...` to confirm the full unit suite stays green; flag any drift that requires a structural rewrite (likely none — the existing assertions use `AssertFileContains`, which is substring-based and unaffected).
+- [~] T029 (DEFERRED INTEGRATION TO CI) Final regression gate: from a clean checkout of branch `012-tls-alias-routers`, run `go build ./...`, `go test ./...`, and `make test-integration` (or rely on the CI pipeline's integration run per the user's auto-memory rule on integration-test cost). All three must pass green; no flakes accepted on this branch. Manual quickstart sanity ([quickstart.md](./quickstart.md)) is OPTIONAL — the integration scenarios T017, T024, and T026 collectively cover every step of the quickstart against a real Docker daemon, so the manual run is operational sanity rather than a merge gate. Record any drift in a follow-up commit before merging.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories. T002 (manifest field) blocks T003 (engine pass-through reads it). T004 (traefik spec primitives) is independent of T002+T003 and may land in parallel.
+- **User Story 1 (Phase 3, P1 MVP)**: Depends on Phase 2 completing T002 + T003 + T004. Internally: T005–T015 (unit tests) can be authored in parallel; T016 (fixture) blocks T017 (integration test); T018–T022 (implementation) make all these tests pass. The implementation order T018 → T019 → T020 → T021 → T022 is loosely sequential — T020 depends on T004 (router struct) plus T019 (RoutingBackend field), T021 depends on T020 (the loop it observes), T022 depends on the event name fixed by T021.
+- **User Story 2 (Phase 4, P1)**: Depends on Phase 2 + US1 implementation (T020 + T021) since US2 has no new production code — its tests assert per-alias differentiated behaviour of the conditionals added in US1.
+- **User Story 3 (Phase 5, P1)**: Depends on Phase 2 + US1 implementation (specifically T020's `if ar.TLS` branch, whose `else` path is what US3 verifies) since US3 has no new production code — its tests assert the no-`tls`-anywhere regression behaviour. T025 can be authored against the unit harness as soon as T011 lands; T026 needs the full US1 implementation chain green.
+- **Polish (Phase 6)**: Depends on US1 + US2 + US3 complete. T027 and T028 are independent — parallel. T029 is the gating final check.
+
+### Within Each User Story
+
+- Tests come before implementation (TDD per Constitution Principle V; the user's auto-memory rule that integration tests are slow makes "write once, run sparingly" the default).
+- Manifest tests (T005–T008) are independent of engine tests (T009–T010) and traefik routing tests (T011–T015); all eleven can be authored together.
+- The integration fixture T016 must land before the integration test T017; same for T023 → T024.
+- Implementation tasks T018–T022 are sequential within `internal/plugins/gateway/traefik/`: T019 (struct field) → T020 (loop body) → T021 (warning helper + wiring) → T022 (logger renderer). T018 (engine.go log marker) is independent and may land first or last.
+
+### Parallel Opportunities
+
+- T005 / T006 / T007 / T008 (manifest unit tests, two files): **safe to author together**.
+- T009 / T010 (engine unit tests, single file but different test functions): **safe to author together**.
+- T011 / T012 / T013 / T014 / T015 (traefik routing unit tests, single file but different test functions): **safe to author together**.
+- T002 / T004 (foundational, different files, no dependency): **parallel**.
+- T027 / T028 (polish): **parallel** — different surfaces.
+- US1 and US2 fixture files (T016, T023): **parallel** — different directories.
+- US3 unit-test extension T025 can be authored alongside the US1 unit tests since both touch `routing_test.go` but at different test-function scopes.
+
+---
+
+## Parallel Example: User Story 1 unit tests
+
+```bash
+# Author US1 unit tests together (different test functions, three files):
+Task: "TestParseApplication_RoutingAlias_TLS_RoundTrip in parser_test.go"
+Task: "TestParseApplication_RoutingAlias_TLS_RejectsNonBoolean in parser_test.go"
+Task: "TestParseApplication_Routing_TLS_RejectsTopLevelField in parser_test.go"
+Task: "TestValidateRoutingAliases_TLS_DoesNotAffectCollisionKey in validate_test.go"
+Task: "TestResolveAliasRoutes_CarriesTLS in engine_aliases_test.go"
+Task: "TestFormatAliasesForLog_AppendsTLSMarker in engine_aliases_test.go"
+Task: "TestWriteRoute_AliasWithTLS_AddsWebsecureAndTLSBlock in routing_test.go"
+Task: "TestWriteRoute_AliasWithTLS_PreservesPrimaryRouterShape in routing_test.go"
+Task: "TestWriteRoute_AliasWithTLS_EmitsWarning_WhenStaticConfigLacksWebsecure in routing_test.go"
+Task: "TestWriteRoute_AliasWithTLS_NoWarning_WhenWebsecurePresent in routing_test.go"
+Task: "TestWriteRoute_NoAliasHasTLS_NoWarning_RegardlessOfStaticConfig in routing_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Complete Phase 1 (T001).
+2. Complete Phase 2 (T002 + T004 in parallel → T003).
+3. Complete Phase 3 (T005–T015 in parallel → T016 → T017 → T018–T022 sequentially).
+4. **STOP and VALIDATE**: Run the US1 unit + integration tests; manually walk [quickstart.md](./quickstart.md) Steps 1–5 and confirm `tls: true` on a single alias produces a working alias router with `entryPoints: [web, websecure]` and `tls: {}`.
+5. At this point, the headline ask from GitHub #13 is resolved and shippable on its own.
+
+### Incremental Delivery
+
+1. Foundation (T001 → T002 + T004 → T003).
+2. US1 (MVP) → ship → close GitHub issue #13 with the per-alias HTTPS confirmation.
+3. US2 → ship → mixed-deployment regression suite is in CI.
+4. US3 → ship → byte-identical regression guard for the existing fleet is in CI.
+5. Polish (Phase 6) → AGENTS.md docs, full regression sweep, final gate.
+
+### Parallel Team Strategy
+
+Single-developer feature; the constitution's "small, commit-able increments" rule applies. No parallel-team strategy needed. If two developers were available, the natural split is: Dev A owns Phases 2 + 3 (foundational + MVP); Dev B owns Phases 4 + 5 fixture/test authoring (T023, T026), picking up after Dev A merges T020+T021. Phase 6 polish is shared.
+
+---
+
+## Notes
+
+- All tasks comply with the user's auto-memory rules: unit tests reuse the existing `writeFileFn` / `readFileFn` injection points and the `engine.NoopObserver` / recording-observer scaffolding already in `routing_test.go` (no filesystem touches); integration tests run sparingly via `make test-integration` against a real binary and a real Docker daemon (Constitution Principle V).
+- The `tlsBlock struct{}` type is intentionally empty — its single purpose is to marshal to literal `tls: {}` in YAML 1.2 and to structurally guarantee that no `certResolver`, `domains`, or `options` keys can leak into the generated alias router. This satisfies FR-012 at the type-system level. Future extension (if Traefik ever requires per-route TLS configuration that Shrine should generate) would be an explicit addition to this struct, never an accidental one.
+- The new event name `gateway.alias.tls_no_websecure` is the only new entry on the observer contract; reuse of spec 011's `gateway.config.tls_port_probe_error` for probe-failure I/O errors is intentional and documented in [contracts/observer-events.md "Non-events"](./contracts/observer-events.md).
+- Manifest validation rejections at parse time mean callers in `cmd/` get an error before any container or filesystem mutation happens — covered structurally by `yaml.Unmarshal` rather than by new code in `validate.go`. T006 + T007 lock this in at the unit-test layer.
+- Spec 009's per-app dynamic config preservation regime applies unchanged. When the file is operator-owned, `WriteRoute` early-returns at the `present` check (see `routing.go` lines 56–68) BEFORE building any router; the new TLS branch in T020 is in the build path, so preserved files remain untouched in response to manifest `tls` flips (FR-008). The new warning helper T021 is wired at the very top of `WriteRoute` (BEFORE the `present` check returns), so the warning still fires on preserved-file deploys when at least one alias requests TLS and the static config lacks `websecure` — operators get a useful nudge even when the file write itself is skipped.


### PR DESCRIPTION
## What

Operators can now declare `tls: true` on individual `routing.aliases` entries in the application manifest. Aliases marked TLS-on get generated as Traefik routers attached to both `web` and `websecure` entrypoints with an empty `tls: {}` block, so Traefik terminates TLS on that route using its existing configuration. Aliases without `tls` (or with `tls: false`) keep producing byte-identical generated config — existing manifests are unaffected.

## Why

Closes #13. Before this change, the manifest had no way to opt an alias into HTTPS, so multi-network operators (LAN + Tailscale, internal + public) had to hand-edit the generated dynamic config to add `websecure` and `tls: {}` on every alias they wanted served over TLS. Spec 009 made that workaround durable across redeploys, but the manifest no longer reflected the full routing intent. This PR brings the intent back into the manifest.

## How to test

- `go test ./...` — full unit suite, including the new manifest parser/validator tests, engine alias projection tests, and traefik routing tests with TLS branches and the new `gateway.alias.tls_no_websecure` warning.
- Manifest contract: parse an Application with `spec.routing.aliases[0].tls: true` — round-trips to `RoutingAlias.TLS == true`. Setting `tls` to a non-boolean (`"true"` quoted, or `1`) is rejected. Setting `tls` at `spec.routing` top level (outside an alias entry) is rejected with a path-bearing error.
- Generated config shape (unit-level via stubbed `writeFileFn`): an alias with `tls: true` produces a router with `entryPoints: [web, websecure]` and `tls: {}`; an alias without `tls` produces a router with `entryPoints: [web]` and no `tls` key; the primary-domain router is invariant under any alias's `tls` value.
- Warning emission: when at least one alias sets `tls: true` and the active static `traefik.yml` has no `websecure` entrypoint, the deploy emits `gateway.alias.tls_no_websecure` (warning) without blocking. Suppressed when `websecure` is present, or when no alias requested TLS.
- Integration scenarios (T016, T017, T023, T024, T026) are deferred to CI for end-to-end coverage against a real Docker daemon.

## Checklist

- [x] Tests added or updated
- [x] `go test ./...` passes locally
- [x] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)