### PR TITLE
feat: add registry alias support with reg:<alias> image prefix

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/013-docs-site"
+  "feature_directory": "specs/014-registry-alias"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/013-docs-site/plan.md
+at specs/014-registry-alias/plan.md
 <!-- SPECKIT END -->

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -13,3 +13,4 @@ Learn how to accomplish specific tasks with Shrine. These guides walk through re
 - [Traefik gateway](traefik/) — Configure the Traefik plugin to expose your apps publicly.
 - [Routing & aliases](routing-and-aliases/) — Multiple hostnames and path prefixes per app.
 - [TLS / HTTPS](tls/) — Terminate HTTPS at Traefik for any aliased route.
+- [Custom registries](custom-registries/) — Pull from private registries and use short aliases in manifests.

--- a/docs/content/guides/custom-registries.md
+++ b/docs/content/guides/custom-registries.md
@@ -1,0 +1,157 @@
+---
+title: "Custom registries"
+description: "Pull images from private registries and reference them with short aliases in manifests."
+weight: 25
+---
+
+## What custom registries are
+
+By default Shrine pulls images from Docker Hub. A **custom registry** is any private or self-hosted image registry — a Gitea Container Registry, Harbor instance, AWS ECR, or any other OCI-compatible host — that requires a non-default hostname and, optionally, credentials.
+
+Custom registries are declared in `config.yml`. Shrine passes the configured credentials to Docker when pulling images, so manifests themselves never need to include auth details.
+
+## Configuring a custom registry
+
+Add a `registries` list to `config.yml`. Each entry targets one registry host:
+
+```yaml
+registries:
+  - host: registry.home.lab:5000
+    username: admin
+    password: s3cr3t
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `host` | yes | Registry hostname (and port if non-default). |
+| `username` | no | Pull credential username. |
+| `password` | no | Pull credential password or token. |
+
+Shrine looks up the host from the image reference on every pull. Entries without credentials enable authenticated lookups where the registry allows anonymous access.
+
+You can configure multiple registries:
+
+```yaml
+registries:
+  - host: registry.home.lab:5000
+    username: admin
+    password: s3cr3t
+  - host: ghcr.io
+    username: github-user
+    password: ghp_xxxxxxxxxxxx
+```
+
+## Using an alias for a registry
+
+Embedding raw hostnames like `registry.home.lab:5000` directly in every manifest leaks your internal network layout to every team author. **Registry aliases** solve this: give a registry a short, memorable name in `config.yml`, then use that name in manifests via the `reg:` prefix.
+
+Add an `alias` field to any registry entry:
+
+```yaml
+registries:
+  - host: registry.home.lab:5000
+    alias: homelab
+    username: admin
+    password: s3cr3t
+```
+
+Alias rules:
+- Must contain only alphanumeric characters, hyphens (`-`), and underscores (`_`).
+- Dots are not allowed (to avoid ambiguity with hostnames).
+- Each alias must be unique across all registry entries.
+- An entry without an `alias` field is valid and behaves as before.
+
+Shrine validates aliases at startup. A duplicate or malformed alias causes the command to exit with a clear error before any manifest is processed.
+
+## Referencing an alias in a manifest
+
+Use `reg:<alias>/` as the image prefix in any Application or Resource manifest:
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: my-api
+  owner: my-team
+spec:
+  image: reg:homelab/my-api:v1.2.0
+  port: 8080
+```
+
+```yaml
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: app-db
+  owner: my-team
+spec:
+  type: postgres
+  version: "16"
+  image: reg:homelab/postgres:16
+  port: 5432
+  outputs:
+    - name: host
+    - name: port
+```
+
+At **dry-run time** Shrine validates that the alias exists in config and reports an error if it does not — the raw `reg:homelab/` form is preserved in dry-run output so you can confirm the alias before deploying:
+
+```
+[DOCKER] ContainerCreate: name=my-team.my-api image=reg:homelab/my-api:v1.2.0
+```
+
+At **live deployment time** Shrine expands `reg:homelab/` to the configured host before passing the reference to Docker:
+
+```
+Docker pulls → registry.home.lab:5000/my-api:v1.2.0
+```
+
+The raw hostname never appears in your manifest files.
+
+## Verifying the setup
+
+Run a dry-run to confirm alias resolution before deploying:
+
+```bash
+shrine deploy --dry-run --path ./specs/my-team
+```
+
+If the alias is not defined in config, the error will name the alias and the manifest:
+
+```
+app "my-api": image "reg:homelab/my-api:v1.2.0": alias "homelab" is not defined in config registries
+```
+
+Fix: add or correct the alias in `config.yml`, then re-run.
+
+## Full example
+
+`config.yml`:
+```yaml
+registries:
+  - host: registry.home.lab:5000
+    alias: homelab
+    username: admin
+    password: s3cr3t
+```
+
+`specs/my-team/app.yml`:
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: my-api
+  owner: my-team
+spec:
+  image: reg:homelab/my-api:latest
+  port: 8080
+  networking:
+    exposeToPlatform: true
+```
+
+Deploy:
+```bash
+shrine deploy --path ./specs/my-team
+```
+
+Shrine pulls `registry.home.lab:5000/my-api:latest` using the configured credentials. Team authors see only `reg:homelab/my-api:latest` in the manifest — internal hostnames stay private to the operator.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,15 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 
 	"gopkg.in/yaml.v3"
 )
+
+var validAliasPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // Config represents the global configuration for shrine.
 type Config struct {
@@ -27,6 +31,7 @@ type GatewayPluginsConfig struct {
 // RegistryConfig holds credentials and host information for a Docker registry.
 type RegistryConfig struct {
 	Host     string `yaml:"host,omitempty"`
+	Alias    string `yaml:"alias,omitempty"`
 	Username string `yaml:"username,omitempty"`
 	Password string `yaml:"password,omitempty"`
 }
@@ -54,6 +59,25 @@ func Load(configFile string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// ValidateRegistries checks that all registry aliases are unique and well-formed.
+// Entries without an alias are skipped. Must be called explicitly by callers after Load.
+func (c *Config) ValidateRegistries() error {
+	seen := make(map[string]struct{}, len(c.Registries))
+	for _, r := range c.Registries {
+		if r.Alias == "" {
+			continue
+		}
+		if !validAliasPattern.MatchString(r.Alias) {
+			return fmt.Errorf("registries: alias %q contains invalid characters (alphanumeric, hyphens, underscores only)", r.Alias)
+		}
+		if _, dup := seen[r.Alias]; dup {
+			return fmt.Errorf("registries: alias %q is defined more than once", r.Alias)
+		}
+		seen[r.Alias] = struct{}{}
+	}
+	return nil
 }
 
 // ResolveSpecsDir returns the specs directory to use, with the following priority:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,79 @@ import (
 	"testing"
 )
 
+func TestValidateRegistries(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "no registries is valid",
+			cfg:  Config{},
+		},
+		{
+			name: "registry without alias is valid",
+			cfg:  Config{Registries: []RegistryConfig{{Host: "ghcr.io"}}},
+		},
+		{
+			name: "valid alias passes",
+			cfg:  Config{Registries: []RegistryConfig{{Host: "192.168.1.1:3000", Alias: "myregistry"}}},
+		},
+		{
+			name: "hyphens and underscores in alias are valid",
+			cfg:  Config{Registries: []RegistryConfig{{Host: "192.168.1.1:3000", Alias: "my-registry_prod"}}},
+		},
+		{
+			name: "multiple unique aliases pass",
+			cfg: Config{Registries: []RegistryConfig{
+				{Host: "192.168.1.1:3000", Alias: "reg-a"},
+				{Host: "192.168.1.2:3000", Alias: "reg-b"},
+			}},
+		},
+		{
+			name: "duplicate alias returns error",
+			cfg: Config{Registries: []RegistryConfig{
+				{Host: "192.168.1.1:3000", Alias: "myregistry"},
+				{Host: "192.168.1.2:3000", Alias: "myregistry"},
+			}},
+			wantErr: `alias "myregistry" is defined more than once`,
+		},
+		{
+			name:    "dot in alias returns invalid characters error",
+			cfg:     Config{Registries: []RegistryConfig{{Host: "192.168.1.1:3000", Alias: "my.registry"}}},
+			wantErr: `alias "my.registry" contains invalid characters`,
+		},
+		{
+			name:    "space in alias returns invalid characters error",
+			cfg:     Config{Registries: []RegistryConfig{{Host: "192.168.1.1:3000", Alias: "my registry"}}},
+			wantErr: `alias "my registry" contains invalid characters`,
+		},
+		{
+			name:    "slash in alias returns invalid characters error",
+			cfg:     Config{Registries: []RegistryConfig{{Host: "192.168.1.1:3000", Alias: "my/registry"}}},
+			wantErr: `alias "my/registry" contains invalid characters`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.ValidateRegistries()
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ValidateRegistries succeeded, want error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q should contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateRegistries returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestResolveSpecsDir(t *testing.T) {
 	const fakeHome = "/home/test-user"
 

--- a/internal/engine/local/dockercontainer/docker_image.go
+++ b/internal/engine/local/dockercontainer/docker_image.go
@@ -10,6 +10,11 @@ import (
 )
 
 func (backend *DockerBackend) ensureImage(ctx context.Context, ref string) error {
+	var err error
+	if ref, err = expandRegistryAlias(ref, backend.registries); err != nil {
+		return backend.emitErr("registry.alias", map[string]string{"ref": ref}, err)
+	}
+
 	args := filters.NewArgs()
 	args.Add("reference", ref)
 	existing, err := backend.client.ImageList(ctx, image.ListOptions{Filters: args})
@@ -49,6 +54,11 @@ func (backend *DockerBackend) ensureImage(ctx context.Context, ref string) error
 }
 
 func (backend *DockerBackend) resolveImage(ctx context.Context, ref string, policy string) (string, error) {
+	var err error
+	if ref, err = expandRegistryAlias(ref, backend.registries); err != nil {
+		return "", backend.emitErr("registry.alias", map[string]string{"ref": ref}, err)
+	}
+
 	if policy != "Always" {
 		args := filters.NewArgs()
 		args.Add("reference", ref)

--- a/internal/engine/local/dockercontainer/registry_auth.go
+++ b/internal/engine/local/dockercontainer/registry_auth.go
@@ -3,11 +3,44 @@ package dockercontainer
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/CarlosHPlata/shrine/internal/config"
 	"github.com/docker/docker/api/types/registry"
 )
+
+// hasRegistryAliasPrefix reports whether ref starts with the reg: scheme.
+func hasRegistryAliasPrefix(ref string) bool {
+	return strings.HasPrefix(ref, "reg:")
+}
+
+// expandRegistryAlias replaces a reg:<alias>/ prefix with the corresponding
+// registry host. Returns the ref unchanged if no reg: prefix is present.
+func expandRegistryAlias(ref string, registries []config.RegistryConfig) (string, error) {
+	if !hasRegistryAliasPrefix(ref) {
+		return ref, nil
+	}
+	rest := ref[len("reg:"):]
+	slash := strings.Index(rest, "/")
+	var alias, tail string
+	if slash == -1 {
+		alias = rest
+		tail = ""
+	} else {
+		alias = rest[:slash]
+		tail = rest[slash:]
+	}
+	if alias == "" {
+		return "", fmt.Errorf("image %q: alias name must not be empty", ref)
+	}
+	for _, r := range registries {
+		if r.Alias == alias {
+			return r.Host + tail, nil
+		}
+	}
+	return "", fmt.Errorf("image %q: alias %q is not defined in config registries", ref, alias)
+}
 
 // registryAuthFor returns the base64 encoded auth JSON Docker expects
 // on ImagePull for the registry implied by the image reference. Returns "" if

--- a/internal/engine/local/dockercontainer/registry_auth_test.go
+++ b/internal/engine/local/dockercontainer/registry_auth_test.go
@@ -1,0 +1,93 @@
+package dockercontainer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/config"
+)
+
+func TestHasRegistryAliasPrefix(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"reg:myregistry/image:tag", true},
+		{"reg:myregistry/", true},
+		{"ghcr.io/foo/bar:1.0", false},
+		{"nginx:latest", false},
+		{"192.168.1.1:3000/image:tag", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := hasRegistryAliasPrefix(tc.ref); got != tc.want {
+			t.Errorf("hasRegistryAliasPrefix(%q) = %v, want %v", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestExpandRegistryAlias(t *testing.T) {
+	registries := []config.RegistryConfig{
+		{Host: "192.168.1.1:3000", Alias: "myregistry"},
+		{Host: "10.0.0.5:5000", Alias: "prod"},
+	}
+
+	cases := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "expands known alias",
+			ref:  "reg:myregistry/postgres:15",
+			want: "192.168.1.1:3000/postgres:15",
+		},
+		{
+			name: "expands second alias",
+			ref:  "reg:prod/myapp:v1",
+			want: "10.0.0.5:5000/myapp:v1",
+		},
+		{
+			name: "plain image is unchanged",
+			ref:  "nginx:latest",
+			want: "nginx:latest",
+		},
+		{
+			name: "ip:port image is unchanged",
+			ref:  "192.168.1.1:3000/image:tag",
+			want: "192.168.1.1:3000/image:tag",
+		},
+		{
+			name:    "unknown alias returns error",
+			ref:     "reg:unknown/image:tag",
+			wantErr: `alias "unknown" is not defined`,
+		},
+		{
+			name:    "empty alias returns error",
+			ref:     "reg:/image:tag",
+			wantErr: "alias name must not be empty",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandRegistryAlias(tc.ref, registries)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expandRegistryAlias(%q) succeeded with %q, want error containing %q", tc.ref, got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error %q should contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expandRegistryAlias(%q) unexpected error: %v", tc.ref, err)
+			}
+			if got != tc.want {
+				t.Errorf("expandRegistryAlias(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/handler/apply.go
+++ b/internal/handler/apply.go
@@ -23,7 +23,11 @@ type ApplySingleOptions struct {
 }
 
 func ApplySingle(opts ApplySingleOptions) error {
-	result := planner.PlanSingle(opts.File, opts.ManifestDir, opts.Store.Teams)
+	if err := opts.Config.ValidateRegistries(); err != nil {
+		return err
+	}
+
+	result := planner.PlanSingle(opts.File, opts.ManifestDir, opts.Store.Teams, opts.Config.Registries)
 
 	if result.Error != nil {
 		return result.Error

--- a/internal/handler/deploy.go
+++ b/internal/handler/deploy.go
@@ -28,12 +28,15 @@ type DeployOptions struct {
 // operations instead of writing files.
 func DryRun(out io.Writer, manifestDir string, store *state.Store, cfg *config.Config) error {
 	if cfg != nil {
+		if err := cfg.ValidateRegistries(); err != nil {
+			return err
+		}
 		if _, err := traefik.New(cfg.Plugins.Gateway.Traefik, nil, "", nil); err != nil {
 			return err
 		}
 	}
 
-	result := planner.Plan(manifestDir, store.Teams)
+	result := planner.Plan(manifestDir, store.Teams, cfg.Registries)
 
 	if result.Error != nil {
 		return result.Error
@@ -61,6 +64,10 @@ func DryRun(out io.Writer, manifestDir string, store *state.Store, cfg *config.C
 }
 
 func Deploy(opts DeployOptions) error {
+	if err := opts.Config.ValidateRegistries(); err != nil {
+		return err
+	}
+
 	specsDir, _ := opts.Config.ResolveSpecsDir(opts.ManifestDir)
 
 	terminal := ui.NewTerminalObserver(opts.Out)
@@ -82,7 +89,7 @@ func Deploy(opts DeployOptions) error {
 		return err
 	}
 
-	result := planner.Plan(opts.ManifestDir, opts.Store.Teams)
+	result := planner.Plan(opts.ManifestDir, opts.Store.Teams, opts.Config.Registries)
 
 	if result.Error != nil {
 		return result.Error

--- a/internal/planner/loader_test.go
+++ b/internal/planner/loader_test.go
@@ -238,7 +238,7 @@ spec:
 		t.Fatal(err)
 	}
 
-	result := PlanSingle(typoFile, "", nullTeamStore{})
+	result := PlanSingle(typoFile, "", nullTeamStore{}, nil)
 	if result.Error == nil {
 		t.Fatal("expected PlanSingle to return an error for bad-kind manifest, got nil")
 	}

--- a/internal/planner/plan.go
+++ b/internal/planner/plan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/CarlosHPlata/shrine/internal/config"
 	"github.com/CarlosHPlata/shrine/internal/manifest"
 	"github.com/CarlosHPlata/shrine/internal/state"
 )
@@ -20,13 +21,13 @@ type PlanTeardownResult struct {
 	Error error
 }
 
-func Plan(dir string, store state.TeamStore) PlanResult {
+func Plan(dir string, store state.TeamStore, registries []config.RegistryConfig) PlanResult {
 	set, err := LoadDir(dir)
 	if err != nil {
 		return PlanResult{Error: err}
 	}
 
-	if errs := Resolve(set, store); len(errs) > 0 {
+	if errs := Resolve(set, store, registries); len(errs) > 0 {
 		return PlanResult{ValidationErr: errs}
 	}
 
@@ -41,7 +42,7 @@ func Plan(dir string, store state.TeamStore) PlanResult {
 // PlanSingle plans the deployment of a single manifest file.
 // If specsDir is non-empty it loads the full directory as resolution context;
 // otherwise a minimal ManifestSet containing only the parsed manifest is used.
-func PlanSingle(file, specsDir string, store state.TeamStore) PlanResult {
+func PlanSingle(file, specsDir string, store state.TeamStore, registries []config.RegistryConfig) PlanResult {
 	// Step 1: Parse and validate the target manifest.
 	m, err := manifest.Parse(file)
 	if err != nil {
@@ -98,8 +99,8 @@ func PlanSingle(file, specsDir string, store state.TeamStore) PlanResult {
 		}
 	}
 
-	// Step 3: Resolve dependencies, quotas, and access control.
-	if errs := Resolve(set, store); len(errs) > 0 {
+	// Step 3: Resolve dependencies, quotas, access control, and registry aliases.
+	if errs := Resolve(set, store, registries); len(errs) > 0 {
 		return PlanResult{ValidationErr: errs}
 	}
 

--- a/internal/planner/resolve.go
+++ b/internal/planner/resolve.go
@@ -5,13 +5,14 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/CarlosHPlata/shrine/internal/config"
 	"github.com/CarlosHPlata/shrine/internal/manifest"
 	"github.com/CarlosHPlata/shrine/internal/state"
 )
 
-// Resolve performs dependency resolution, access control checks, and quota enforcement
-// for a set of manifests. It returns a slice of all validation errors found.
-func Resolve(set *ManifestSet, store state.TeamStore) []error {
+// Resolve performs dependency resolution, access control checks, quota enforcement,
+// and registry alias validation for a set of manifests. It returns all errors found.
+func Resolve(set *ManifestSet, store state.TeamStore, registries []config.RegistryConfig) []error {
 	var errs []error
 
 	// 0. Name collision check
@@ -42,7 +43,63 @@ func Resolve(set *ManifestSet, store state.TeamStore) []error {
 	// 4. Check AllowedResourceTypes
 	errs = append(errs, allowedResourceTypes(set, teamCache)...)
 
+	// 5. Validate registry aliases in image references
+	errs = append(errs, validateRegistryImages(set, registries)...)
+
 	return errs
+}
+
+// validateRegistryImages checks that every image field using the reg:<alias> prefix
+// references an alias defined in the provided registry config.
+func validateRegistryImages(set *ManifestSet, registries []config.RegistryConfig) []error {
+	aliasMap := buildRegistryAliasMap(registries)
+	var errs []error
+
+	for _, app := range set.Applications {
+		if err := checkImageAlias(app.Spec.Image, "app", app.Metadata.Name, aliasMap); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, res := range set.Resources {
+		if res.Spec.Image == "" {
+			continue
+		}
+		if err := checkImageAlias(res.Spec.Image, "resource", res.Metadata.Name, aliasMap); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errs
+}
+
+func checkImageAlias(image, kind, name string, aliasMap map[string]string) error {
+	if !strings.HasPrefix(image, "reg:") {
+		return nil
+	}
+	rest := image[len("reg:"):]
+	slash := strings.Index(rest, "/")
+	var alias string
+	if slash == -1 {
+		alias = rest
+	} else {
+		alias = rest[:slash]
+	}
+	if alias == "" {
+		return fmt.Errorf(`%s %q: image %q: alias name must not be empty`, kind, name, image)
+	}
+	if _, ok := aliasMap[alias]; !ok {
+		return fmt.Errorf(`%s %q: image %q: alias %q is not defined in config registries`, kind, name, image, alias)
+	}
+	return nil
+}
+
+func buildRegistryAliasMap(registries []config.RegistryConfig) map[string]string {
+	m := make(map[string]string, len(registries))
+	for _, r := range registries {
+		if r.Alias != "" {
+			m[r.Alias] = r.Host
+		}
+	}
+	return m
 }
 
 // resolveDependencies resolves dependencies and performs access checks for a single Application.

--- a/internal/planner/resolve_test.go
+++ b/internal/planner/resolve_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/CarlosHPlata/shrine/internal/config"
 	"github.com/CarlosHPlata/shrine/internal/manifest"
 )
 
@@ -64,7 +65,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		if len(errs) > 0 {
 			t.Errorf("expected no errors, got %d: %v", len(errs), errs)
 		}
@@ -85,7 +86,7 @@ func TestResolve(t *testing.T) {
 			Resources: make(map[string]*manifest.ResourceManifest),
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		if len(errs) == 0 {
 			t.Error("expected missing dependency error, got none")
 		}
@@ -111,7 +112,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		if len(errs) == 0 {
 			t.Error("expected access denied error, got none")
 		}
@@ -137,7 +138,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		if len(errs) > 0 {
 			t.Errorf("expected no errors, got %d: %v", len(errs), errs)
 		}
@@ -162,7 +163,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		found := false
 		for _, err := range errs {
 			if strings.Contains(err.Error(), "owned by \"team-b\", but manifest specifies owner \"team-a\"") {
@@ -184,7 +185,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		found := false
 		for _, err := range errs {
 			if strings.Contains(err.Error(), "exceeds MaxApps quota") {
@@ -207,7 +208,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		found := false
 		for _, err := range errs {
 			if strings.Contains(err.Error(), "not allowed by quota") {
@@ -253,7 +254,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 
 		expectedErrors := []string{
 			"invalid valueFrom format \"resource.db1\"",
@@ -303,7 +304,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 
 		expectedErrors := []string{
 			"template output \"bad\" references unknown variable \"missing\"",
@@ -353,7 +354,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 
 		expectedErrors := []string{
 			"template env \"BAD\" references unknown variable \"ghost\"",
@@ -390,7 +391,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			if len(errs) > 0 {
 				t.Errorf("expected no errors, got: %v", errs)
 			}
@@ -413,7 +414,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			if len(errs) > 0 {
 				t.Errorf("expected no errors, got: %v", errs)
 			}
@@ -436,7 +437,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			found := false
 			for _, err := range errs {
 				if strings.Contains(err.Error(), "does not have access to application \"worker\"") {
@@ -462,7 +463,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			found := false
 			for _, err := range errs {
 				if strings.Contains(err.Error(), "depends on missing application \"ghost\"") {
@@ -492,7 +493,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			found := false
 			for _, err := range errs {
 				if strings.Contains(err.Error(), "application \"worker\" owned by \"team-a\", but manifest specifies owner \"team-b\"") {
@@ -522,7 +523,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			found := false
 			for _, err := range errs {
 				if strings.Contains(err.Error(), "is not reachable cross-team") {
@@ -552,7 +553,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			hasAccessErr := false
 			hasReachErr := false
 			for _, err := range errs {
@@ -592,7 +593,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			found := false
 			for _, err := range errs {
 				if strings.Contains(err.Error(), "is not reachable cross-team") {
@@ -624,7 +625,7 @@ func TestResolve(t *testing.T) {
 					},
 				},
 			}
-			errs := Resolve(set, store)
+			errs := Resolve(set, store, nil)
 			if len(errs) > 0 {
 				t.Errorf("expected no errors, got: %v", errs)
 			}
@@ -646,7 +647,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		// Should succeed, no "name collision" error
 		for _, err := range errs {
 			if strings.Contains(err.Error(), "name collision") {
@@ -665,7 +666,7 @@ func TestResolve(t *testing.T) {
 			},
 		}
 
-		errs := Resolve(set, store)
+		errs := Resolve(set, store, nil)
 		found := false
 		for _, err := range errs {
 			if strings.Contains(err.Error(), "application \"key-a\" has metadata name mismatch: \"mismatch-a\"") {
@@ -675,6 +676,133 @@ func TestResolve(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("expected metadata mismatch error, got: %v", errs)
+		}
+	})
+}
+
+func TestValidateRegistryImages(t *testing.T) {
+	registries := []config.RegistryConfig{
+		{Host: "192.168.1.1:3000", Alias: "myregistry"},
+	}
+
+	t.Run("plain image passes with no registries", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{
+				"app": {
+					Metadata: manifest.Metadata{Name: "app", Owner: "team"},
+					Spec:     manifest.ApplicationSpec{Image: "nginx:latest", Port: 80},
+				},
+			},
+			Resources: map[string]*manifest.ResourceManifest{},
+		}
+		errs := validateRegistryImages(set, nil)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got: %v", errs)
+		}
+	})
+
+	t.Run("reg: alias in app resolves against config", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{
+				"app": {
+					Metadata: manifest.Metadata{Name: "app", Owner: "team"},
+					Spec:     manifest.ApplicationSpec{Image: "reg:myregistry/postgres:15", Port: 80},
+				},
+			},
+			Resources: map[string]*manifest.ResourceManifest{},
+		}
+		errs := validateRegistryImages(set, registries)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got: %v", errs)
+		}
+	})
+
+	t.Run("reg: alias in resource resolves against config", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{},
+			Resources: map[string]*manifest.ResourceManifest{
+				"db": {
+					Metadata: manifest.Metadata{Name: "db", Owner: "team"},
+					Spec:     manifest.ResourceSpec{Image: "reg:myregistry/postgres:15"},
+				},
+			},
+		}
+		errs := validateRegistryImages(set, registries)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors, got: %v", errs)
+		}
+	})
+
+	t.Run("unknown alias in app returns error", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{
+				"app": {
+					Metadata: manifest.Metadata{Name: "app", Owner: "team"},
+					Spec:     manifest.ApplicationSpec{Image: "reg:unknown/postgres:15", Port: 80},
+				},
+			},
+			Resources: map[string]*manifest.ResourceManifest{},
+		}
+		errs := validateRegistryImages(set, registries)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0].Error(), `alias "unknown"`) {
+			t.Errorf("error %q should contain alias name", errs[0].Error())
+		}
+	})
+
+	t.Run("unknown alias in resource returns error", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{},
+			Resources: map[string]*manifest.ResourceManifest{
+				"db": {
+					Metadata: manifest.Metadata{Name: "db", Owner: "team"},
+					Spec:     manifest.ResourceSpec{Image: "reg:missing/postgres:15"},
+				},
+			},
+		}
+		errs := validateRegistryImages(set, registries)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0].Error(), `alias "missing"`) {
+			t.Errorf("error %q should contain alias name", errs[0].Error())
+		}
+	})
+
+	t.Run("empty alias after reg: returns error", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{
+				"app": {
+					Metadata: manifest.Metadata{Name: "app", Owner: "team"},
+					Spec:     manifest.ApplicationSpec{Image: "reg:/postgres:15", Port: 80},
+				},
+			},
+			Resources: map[string]*manifest.ResourceManifest{},
+		}
+		errs := validateRegistryImages(set, registries)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0].Error(), "alias name must not be empty") {
+			t.Errorf("error %q should mention empty alias", errs[0].Error())
+		}
+	})
+
+	t.Run("resource with no image is skipped", func(t *testing.T) {
+		set := &ManifestSet{
+			Applications: map[string]*manifest.ApplicationManifest{},
+			Resources: map[string]*manifest.ResourceManifest{
+				"db": {
+					Metadata: manifest.Metadata{Name: "db", Owner: "team"},
+					Spec:     manifest.ResourceSpec{},
+				},
+			},
+		}
+		errs := validateRegistryImages(set, registries)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors for empty image, got: %v", errs)
 		}
 	})
 }

--- a/specs/014-registry-alias/checklists/requirements.md
+++ b/specs/014-registry-alias/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Registry Aliases
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Specification is ready for `/speckit-plan`.

--- a/specs/014-registry-alias/contracts/registry-config.md
+++ b/specs/014-registry-alias/contracts/registry-config.md
@@ -1,0 +1,56 @@
+# Contract: Registry Config with Alias
+
+**Feature**: 014-registry-alias | **Date**: 2026-05-08
+
+## shrine.yml — registries entry (extended)
+
+```yaml
+registries:
+  - host: <string>         # required — registry hostname or IP:port
+    alias: <string>        # optional — short name for use in image: reg:<alias>/...
+    username: <string>     # optional — pull credential
+    password: <string>     # optional — pull credential
+```
+
+### Alias field rules
+
+| Rule | Detail |
+|------|--------|
+| Format | `^[a-zA-Z0-9_-]+$` — alphanumeric, hyphens, underscores only |
+| Uniqueness | All alias values across the `registries` list must be distinct (case-sensitive) |
+| Optional | Omitting `alias` is valid; the entry behaves as before |
+| Dots | Not permitted — avoids ambiguity with DNS hostnames in image paths |
+
+### Validation errors (config load time)
+
+| Condition | Error message |
+|-----------|---------------|
+| Duplicate alias `X` | `registries: alias "X" is defined more than once` |
+| Invalid characters in alias `X` | `registries: alias "X" contains invalid characters (alphanumeric, hyphens, underscores only)` |
+
+---
+
+## Application / Resource manifest — image field (extended)
+
+```yaml
+spec:
+  image: reg:<alias>/<image-name>:<tag>
+```
+
+### Image resolution errors (plan time)
+
+| Condition | Error message |
+|-----------|---------------|
+| Alias portion is empty (`reg:/image:tag`) | `app "<name>": image "reg:/image:tag": alias name must not be empty` |
+| Alias not found in config | `app "<name>": image "reg:X/...": alias "X" is not defined in config registries` |
+
+### Dry-run output
+
+Dry-run (`shrine deploy --dry-run`) prints the image value as written in the manifest
+(`reg:<alias>/image:tag`). Expansion to the real host is not shown in dry-run output.
+
+### Live execution
+
+The container backend replaces the `reg:<alias>` prefix with the corresponding `host`
+value before calling the Docker image pull API. The raw `reg:` string is never passed
+to Docker.

--- a/specs/014-registry-alias/data-model.md
+++ b/specs/014-registry-alias/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Registry Aliases
+
+**Feature**: 014-registry-alias | **Date**: 2026-05-08
+
+## Modified Entities
+
+### RegistryConfig (`internal/config/config.go`)
+
+Extended with a new optional `Alias` field.
+
+| Field    | Type   | Required | Constraints |
+|----------|--------|----------|-------------|
+| Host     | string | yes      | Non-empty; registry hostname or IP:port |
+| Username | string | no       | Credential for the registry |
+| Password | string | no       | Credential for the registry |
+| Alias    | string | no       | If provided: `[a-zA-Z0-9_-]+`; unique across all entries |
+
+**Validation rules** (enforced by `Config.ValidateRegistries()`):
+- If `Alias` is present and non-empty, it MUST match `^[a-zA-Z0-9_-]+$`.
+- All `Alias` values across the `Registries` slice MUST be unique (case-sensitive).
+- An entry with no `Alias` field is valid and unchanged from current behaviour.
+
+**YAML representation**:
+```yaml
+registries:
+  - host: 192.168.1.1:3000
+    alias: myregistry
+    username: admin
+    password: secret
+  - host: ghcr.io
+    # no alias — anonymous pull, no expansion
+```
+
+---
+
+## Image Reference Format
+
+The `image` field in Application and Resource manifests gains support for the
+`reg:<alias>` prefix:
+
+```
+reg:<alias>/<image-name>:<tag>
+```
+
+| Segment      | Description |
+|--------------|-------------|
+| `reg:`       | Reserved prefix signalling alias resolution |
+| `<alias>`    | Matches a defined `alias` in config `registries`; `[a-zA-Z0-9_-]+` |
+| `/`          | Required separator between alias and image path |
+| `<image-name>:<tag>` | Standard Docker image reference (name + optional tag) |
+
+**Examples**:
+
+| Manifest value                    | Config alias      | Resolved reference               |
+|-----------------------------------|-------------------|----------------------------------|
+| `reg:myregistry/postgres:15`      | `myregistry → 192.168.1.1:3000` | `192.168.1.1:3000/postgres:15` |
+| `reg:prod/myapp:v2.0`             | `prod → 10.0.0.5:5000`          | `10.0.0.5:5000/myapp:v2.0`     |
+| `nginx:latest`                    | (no prefix)       | `nginx:latest` (unchanged)       |
+
+**Constraints**:
+- The portion after `reg:` and before the first `/` is the alias.
+- An empty alias (`reg:/image:tag`) is invalid; the planner reports an error.
+- The alias MUST resolve to a configured registry; an unknown alias is a planner error.
+
+---
+
+## No New Persistent State
+
+Registry aliases are resolved at runtime from the config file. No new state files,
+database tables, or secrets entries are introduced by this feature.

--- a/specs/014-registry-alias/plan.md
+++ b/specs/014-registry-alias/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Registry Aliases
+
+**Branch**: `014-registry-alias` | **Date**: 2026-05-08 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Extend `RegistryConfig` with an optional `alias` field so operators can define
+short names for private registries in `shrine.yml`. Application and Resource manifests
+then use `image: reg:<alias>/image:tag` to reference those registries without embedding
+raw hostnames. Alias validation happens at plan time (catches errors in both dry-run and
+live paths); alias expansion to the real hostname happens inside the Docker container
+backend immediately before the image is pulled.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (`github.com/CarlosHPlata/shrine`)
+**Primary Dependencies**: Cobra CLI, Docker SDK, `gopkg.in/yaml.v3`
+**Storage**: N/A (no new state; config is read-only at plan time)
+**Testing**: `go test ./...`; integration via `make test-integration` / `go test -tags integration ./tests/integration/...`
+**Target Platform**: Linux server (homelab Docker daemon)
+**Project Type**: CLI tool
+**Performance Goals**: Alias lookup is O(n) over a small registry list — no measurable overhead
+**Constraints**: Zero regressions for manifests that do not use `reg:` prefix
+**Scale/Scope**: Typical config has ≤ 10 registry entries
+
+## Constitution Check
+
+| Principle | Gate Question | Status |
+|-----------|---------------|--------|
+| I. Declarative Manifest-First | Does this feature expose new capabilities via manifest fields (not CLI flags)? | ✅ Pass — new `alias` field in config YAML; `reg:` prefix in existing `image` manifest field |
+| II. Kubectl-Style CLI | Do new commands follow verb-first convention and include `--dry-run`? | N/A — no new commands |
+| III. Pluggable Backend | Is new infrastructure logic behind a backend interface (not engine core)? | ✅ Pass — alias expansion lives in `DockerBackend`; dry-run backend prints alias as-is with no code change |
+| IV. Simplicity & YAGNI | Is every abstraction justified by ≥3 concrete usages? | ✅ Pass — `expandRegistryAlias` is called from `ensureImage` and `resolveImage`; `validateRegistryImages` iterates both apps and resources |
+| V. Integration-Test Gate | Does this phase map to an integration test phase using `NewDockerSuite` against a real binary? | ✅ Pass — integration test scenario added to `tests/integration/deploy_test.go` before implementation |
+| VI. Docker-Authoritative State | Does state update happen after Docker operations complete? | N/A — feature does not change state management |
+| VII. Clean Code & Readability | Is repeated logic extracted into named helpers? Are names self-documenting? | ✅ Pass — `expandRegistryAlias`, `hasRegistryAliasPrefix`, `buildAliasMap`, `validateRegistryImages` |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-registry-alias/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 (generated below)
+├── data-model.md        ← Phase 1 (generated below)
+├── quickstart.md        ← Phase 1 (generated below)
+├── contracts/
+│   └── registry-config.md   ← Phase 1 (generated below)
+└── tasks.md             ← Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/config/
+  config.go                        ← add Alias field to RegistryConfig; add ValidateRegistries()
+
+internal/planner/
+  resolve.go                       ← add validateRegistryImages(set, registries)
+  plan.go                          ← extend Plan/PlanSingle to accept []config.RegistryConfig
+
+internal/handler/
+  deploy.go                        ← pass cfg.Registries to Plan and DryRun
+  apply.go                         ← pass cfg.Registries to PlanSingle
+
+internal/engine/local/dockercontainer/
+  registry_auth.go                 ← add expandRegistryAlias, hasRegistryAliasPrefix, buildAliasMap
+
+tests/integration/
+  deploy_test.go                   ← new registry alias scenario (TDD-first)
+```
+
+**Structure Decision**: Single Go module; all changes are additive extensions to
+existing files within the established package layout. No new packages required.

--- a/specs/014-registry-alias/quickstart.md
+++ b/specs/014-registry-alias/quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart: Registry Aliases
+
+**Feature**: 014-registry-alias
+
+## 1. Define an alias in shrine.yml
+
+```yaml
+registries:
+  - host: 192.168.1.1:3000
+    alias: myregistry
+    username: admin
+    password: s3cr3t
+```
+
+## 2. Use the alias in a manifest
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: myapp
+  owner: myteam
+spec:
+  image: reg:myregistry/myapp:latest
+  port: 8080
+```
+
+The `reg:myregistry/` prefix is resolved to `192.168.1.1:3000/` at deployment time.
+
+## 3. Verify with dry-run
+
+```bash
+shrine deploy --dry-run
+```
+
+Dry-run output preserves the alias form:
+
+```
+[DOCKER] ContainerCreate: name=myteam.myapp image=reg:myregistry/myapp:latest
+```
+
+This is expected — the alias is expanded only when the live container engine pulls
+the image. The dry-run confirms the alias is valid (no "alias not found" error) but
+does not show the resolved hostname.
+
+## 4. Deploy
+
+```bash
+shrine deploy
+```
+
+The container engine expands `reg:myregistry/` → `192.168.1.1:3000/` and pulls
+`192.168.1.1:3000/myapp:latest` using the configured credentials.
+
+## Error: unknown alias
+
+If you reference an alias that is not in the config:
+
+```yaml
+image: reg:typo/myapp:latest
+```
+
+The planner will report at plan or dry-run time:
+
+```
+app "myapp": image "reg:typo/myapp:latest": alias "typo" is not defined in config registries
+```
+
+Fix: add the missing registry entry in `shrine.yml` or correct the alias name.
+
+## Notes
+
+- Dots are not allowed in alias names. Use hyphens or underscores: `my-registry`, `registry_prod`.
+- One alias per registry entry. To have two names for the same host, add two entries with the same `host` but different `alias` values.
+- Plain image references (no `reg:` prefix) continue to work exactly as before.

--- a/specs/014-registry-alias/research.md
+++ b/specs/014-registry-alias/research.md
@@ -1,0 +1,88 @@
+# Research: Registry Aliases
+
+**Feature**: 014-registry-alias | **Date**: 2026-05-08
+
+## Findings
+
+### Decision 1 — Where does alias validation happen?
+
+**Decision**: In the planner (`internal/planner/resolve.go`), as a new
+`validateRegistryImages` step called from `Plan`/`PlanSingle` after the existing
+`Resolve` pass.
+
+**Rationale**: The planner is already the single gate for all manifest validation
+(dependency resolution, quota enforcement, access control). Placing alias validation
+here ensures it fires on both the dry-run path (`DryRun` calls `planner.Plan`) and
+the live path (`Deploy` calls `planner.Plan`). Errors surface before any Docker
+operation is attempted.
+
+**Alternatives considered**:
+- At config load time (`Config.Load`) — rejected: config load happens before any
+  manifests are read; there is nothing to validate aliases against.
+- Inside the resolver (`internal/resolver`) — rejected: the resolver is invoked
+  per-manifest during execution, not as a batch validation pass; errors would be
+  discovered later and only for the current manifest.
+- Inside the engine (`engine.go`) — rejected: the engine is execution-time only;
+  errors would not surface on dry-run.
+
+---
+
+### Decision 2 — Where does alias expansion happen?
+
+**Decision**: Inside `DockerBackend`, in both `ensureImage` and `resolveImage`,
+immediately before the image reference is passed to the Docker SDK.
+
+**Rationale**: This is the correct Constitution III placement — infrastructure logic
+in the backend, not in engine core. The dry-run backend (`DryRunContainerBackend`)
+receives the raw `reg:` string and prints it as-is with zero code changes, which is
+the desired dry-run behaviour confirmed in clarification Q1.
+
+**Alternatives considered**:
+- In `engine.go` before building `CreateContainerOp` — rejected: would expand the
+  alias for the dry-run path too (dry-run backend prints `op.Image`), contradicting
+  the user's requirement that dry-run shows the alias.
+- In `resolver.go` — rejected: the resolver handles env vars and output templates,
+  not image references; expanding there would couple image logic into the wrong layer.
+
+---
+
+### Decision 3 — Config validation: `ValidateRegistries()` method or inline in `Load`?
+
+**Decision**: New `ValidateRegistries() error` method on `*Config`, called explicitly
+by handlers after `Load`. This mirrors the existing pattern: `Load` unmarshals
+without side effects; callers validate as needed.
+
+**Rationale**: Keeps `Load` a pure unmarshal function (consistent with current
+behaviour). Handlers that deliberately want a partial or legacy config can skip
+validation; the main `cmd` path always calls it.
+
+**Alternatives considered**:
+- Inline validation in `Load` — rejected: breaks the established pattern; `Load`
+  currently returns an empty struct for missing files without error, suggesting it
+  intentionally avoids validation.
+
+---
+
+### Decision 4 — Alias lookup data structure
+
+**Decision**: Build a `map[string]string` (alias → host) once in the planner
+validation step and once in the docker backend. No shared cache.
+
+**Rationale**: The registry list is tiny (≤10 entries in practice). A map built
+inline from a slice is zero additional complexity and needs no global state.
+
+**Alternatives considered**:
+- Pre-computed map stored on `Config` — rejected: YAGNI; adds a derived field that
+  needs to stay in sync with the slice.
+- Linear scan — rejected: map lookup is idiomatic Go and clearer at the call site.
+
+---
+
+### Decision 5 — Alias format validation location
+
+**Decision**: `Config.ValidateRegistries()` validates alias format (alphanumeric,
+hyphens, underscores only; non-empty if provided) and uniqueness. This runs at
+startup before any manifest is loaded.
+
+**Rationale**: Config errors should be caught as early as possible. Format and
+uniqueness are config-layer concerns independent of manifests.

--- a/specs/014-registry-alias/spec.md
+++ b/specs/014-registry-alias/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: Registry Aliases
+
+**Feature Branch**: `014-registry-alias`
+**Created**: 2026-05-08
+**Status**: Draft
+
+## Clarifications
+
+### Session 2026-05-08
+
+- Q: When dry-run plan output contains a `reg:<alias>` image, what is shown — the alias or the resolved host? → A: The alias is preserved (`reg:myregistry/image:tag`). Dry-run uses the same planner path; actual host expansion happens only at live execution time (container engine layer).
+- Q: Should one registry entry support multiple aliases, or exactly one? → A: Exactly one alias per registry entry (single string field). Operators who need multiple names for the same host duplicate the entry.
+- Q: Should dots be permitted in alias names? → A: No. Aliases are restricted to alphanumeric characters, hyphens, and underscores only. Dots are excluded to avoid confusion with DNS hostnames and image path segments.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Define a Registry Alias in Config (Priority: P1)
+
+As a platform operator, I want to assign a short alias to a private registry host in the
+global config so that application authors never have to embed raw registry URLs in their
+manifests.
+
+**Why this priority**: This is the foundational capability — without aliases in config,
+the `reg:` prefix syntax has nothing to resolve against. All other stories depend on it.
+
+**Independent Test**: Configure a `shrine.yml` with one registry entry that includes an
+`alias` field and verify that the config loads without error and the alias is accessible
+to the planning pipeline.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `shrine.yml` with a registry entry `host: 192.168.1.1:3000, alias: myregistry`, **When** the config is loaded, **Then** the alias `myregistry` is associated with host `192.168.1.1:3000` and available throughout the system.
+2. **Given** two registry entries with the same alias value, **When** the config is loaded, **Then** the system reports a validation error indicating the duplicate alias.
+3. **Given** a registry entry with no `alias` field, **When** the config is loaded, **Then** the entry behaves exactly as before (host-only, no alias resolution).
+
+---
+
+### User Story 2 — Use `reg:<alias>` Prefix in Application Image (Priority: P1)
+
+As an application author, I want to write `image: reg:myregistry/myimage:latest` in my
+application manifest so that I can reference a private registry by a memorable alias
+without knowing its IP or port.
+
+**Why this priority**: This is the primary user-facing change; it directly addresses the
+privacy/leakage concern and is the core value of the feature.
+
+**Independent Test**: Write an application manifest with `image: reg:myregistry/myimage:latest`,
+run a dry-run plan with a config that defines `alias: myregistry`, and verify that no
+alias-not-found error is reported and the image appears as `reg:myregistry/myimage:latest`
+in the plan output. Then run a live deployment and verify the container engine pulls from
+the actual resolved host.
+
+**Acceptance Scenarios**:
+
+1. **Given** an app manifest with `image: reg:myregistry/myimage:latest` and a config alias `myregistry → 192.168.1.1:3000`, **When** a dry-run plan is executed, **Then** the plan output shows `reg:myregistry/myimage:latest` (alias preserved) and no error is reported. **When** live deployment is executed, **Then** the container engine receives `192.168.1.1:3000/myimage:latest`.
+2. **Given** an app manifest with `image: reg:unknown/myimage:latest` where `unknown` is not a defined alias, **When** planning is executed, **Then** the system reports an error naming the unresolvable alias.
+3. **Given** an app manifest with `image: myimage:latest` (no `reg:` prefix), **When** planning is executed, **Then** the image string is left unchanged — no alias expansion is attempted.
+
+---
+
+### User Story 3 — Use `reg:<alias>` Prefix in Resource Image (Priority: P2)
+
+As an application author, I want to use the same `reg:<alias>` syntax in resource
+manifests (e.g., a self-hosted database container) for the same privacy benefit.
+
+**Why this priority**: Resources share the same `image` field; consistency across both
+kinds is expected, but it is a lower priority than the app path since resources are less
+frequently authored than applications.
+
+**Independent Test**: Write a resource manifest with `image: reg:myregistry/postgres:15`,
+run a dry-run plan, and verify that the alias is shown as-is with no error. Then run a
+live deployment and verify the container engine receives the actual host.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource manifest with `image: reg:myregistry/postgres:15` and a defined alias, **When** a dry-run plan is executed, **Then** the plan output shows `reg:myregistry/postgres:15` with no error. **When** live deployment is executed, **Then** the container engine receives `192.168.1.1:3000/postgres:15`.
+2. **Given** a resource manifest with `image: reg:missing/postgres:15` where `missing` is not defined, **When** planning is executed, **Then** the system reports a clear error for the resource.
+
+---
+
+### Edge Cases
+
+- What happens when the `reg:` prefix is present but the alias portion is empty (e.g., `image: reg:/myimage:latest`)?  → System reports a validation error: alias name is required.
+- What happens when an alias contains characters that are invalid in a DNS label or registry path segment? → System reports a validation error on config load, before any manifest is processed.
+- What happens when two registry entries have the same host but different aliases? → Both aliases are valid and independently resolvable; this is a supported multi-alias scenario.
+- What happens when a config file defines no registries at all and a manifest uses `reg:`? → System reports an error: no registries configured, alias cannot be resolved.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `RegistryConfig` type MUST support an optional `alias` field containing a short, human-readable name for the registry host.
+- **FR-002**: On config load, the system MUST validate that all alias values across all registry entries are unique (case-sensitive comparison). Duplicate aliases MUST produce a load-time error.
+- **FR-003**: An alias MUST consist only of alphanumeric characters, hyphens, and underscores, and MUST NOT be empty when provided. Violations MUST produce a load-time error.
+- **FR-004**: During planning and dry-run validation, the system MUST detect any `image` field value starting with the prefix `reg:` and verify that the named alias exists in the loaded config. A missing alias MUST produce an error at this stage, before any execution begins.
+- **FR-005**: During live execution (container engine path), the system MUST replace a `reg:<alias>` prefix with the corresponding registry host from the config, producing a fully-qualified image reference passed to the container engine.
+- **FR-006**: When a `reg:<alias>` prefix references an alias that does not exist in the config, the system MUST return an error at plan/validation time that clearly identifies the manifest, the image field value, and the unresolvable alias name.
+- **FR-007**: Image strings that do not start with `reg:` MUST be passed through unmodified at all stages; alias resolution MUST NOT affect plain image references.
+- **FR-008**: The alias expansion MUST occur before the container engine receives the image value. Dry-run output intentionally preserves the `reg:<alias>` form, as it operates through the same planner path without invoking the container engine.
+
+### Key Entities
+
+- **RegistryConfig**: Extended with an optional `alias` string field alongside the existing `host`, `username`, and `password` fields.
+- **Config**: Gains a validation method that enforces alias uniqueness and format rules across its `Registries` slice.
+- **ImageRef**: The fully-qualified image string passed to the container engine after alias expansion at live execution time. In dry-run and plan output the `reg:<alias>` form is preserved.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can add an `alias` to any registry entry and immediately use `reg:<alias>` in manifests without any other configuration change.
+- **SC-002**: A manifest referencing a non-existent alias produces an error message that names the alias, allowing the author to correct it without ambiguity.
+- **SC-003**: All existing manifests that use plain image references (no `reg:` prefix) continue to plan and deploy without change — zero regressions.
+- **SC-004**: Duplicate or malformed aliases in config are caught at load time, before any manifest is processed, so errors surface immediately on startup.
+- **SC-005**: The raw registry host URL is never visible in application or resource manifest files when aliases are used — operators' internal network topology remains private to the config layer.
+
+## Assumptions
+
+- Alias matching is case-sensitive; `myregistry` and `MyRegistry` are treated as distinct aliases.
+- An alias is purely a config-layer indirection; it does not affect authentication — existing `username`/`password` fields on the same `RegistryConfig` entry continue to apply to the resolved host.
+- The `reg:` prefix is a reserved prefix within Shrine image strings; no existing manifest uses it today, so there are no backwards-compatibility concerns.
+- Alias expansion is applied only to the `image` field of Application and Resource manifests; other string fields are not scanned for `reg:` prefixes.
+- Out of scope: runtime image-pull-secret injection, alias namespacing per team, or wildcard aliases.

--- a/specs/014-registry-alias/tasks.md
+++ b/specs/014-registry-alias/tasks.md
@@ -1,0 +1,215 @@
+# Tasks: Registry Aliases
+
+**Input**: Design documents from `specs/014-registry-alias/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no shared state)
+- **[Story]**: User story label — US1, US2, US3
+- Exact file paths are listed in every task description
+
+---
+
+## Phase 2: Foundational — Config Struct Extension
+
+**Purpose**: Add the `Alias` field to `RegistryConfig`. This is a pure structural
+change (no behavior) that unblocks all three user stories. Must complete before any
+other phase.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T0\1 Add `Alias string \`yaml:"alias,omitempty"\`` field to `RegistryConfig` struct in `internal/config/config.go`
+
+**Checkpoint**: `RegistryConfig` has the new field; existing config files load without change.
+
+---
+
+## Phase 3: User Story 1 — Config Alias Validation (Priority: P1)
+
+**Goal**: Operators can add an `alias` to a registry entry in `config.yml`; duplicate
+or malformed aliases are caught at startup before any manifest is processed.
+
+**Independent Test**: Run `shrine deploy --dry-run --config-dir <dir>` where `<dir>/config.yml`
+contains a duplicate alias → the command must exit non-zero with a message naming the duplicate.
+
+### TDD: Integration Test Fixtures & Tests for User Story 1
+
+> **Write these BEFORE T006–T009 and verify they FAIL before implementation.**
+
+- [x] T0\1 [P] [US1] Create `tests/testdata/deploy/registry-alias/config.yml` containing a registry entry with `alias: myregistry` (valid case)
+- [x] T0\1 [P] [US1] Create `tests/testdata/deploy/registry-alias-dup/config.yml` containing two registry entries sharing the same alias (duplicate case)
+- [x] T0\1 [P] [US1] Create `tests/testdata/deploy/registry-alias-badformat/config.yml` containing a registry alias with a dot in the name (invalid format case)
+- [x] T0\1 [US1] Write integration tests for US1 scenarios in `tests/integration/registry_alias_test.go`:
+  - valid alias loads without error (dry-run succeeds)
+  - duplicate alias produces error naming the alias
+  - alias with invalid characters produces a format error
+
+### Implementation for User Story 1
+
+- [x] T0\1 [P] [US1] Add `ValidateRegistries() error` to `*Config` in `internal/config/config.go` — validates alias uniqueness (case-sensitive) and format (`^[a-zA-Z0-9_-]+$`)
+- [x] T0\1 [P] [US1] Add unit tests for `ValidateRegistries` covering: valid aliases, duplicate alias, invalid characters, missing alias (no-op) in `internal/config/config_test.go`
+- [x] T0\1 [US1] Call `cfg.ValidateRegistries()` in `DryRun` after `config.Load` in `internal/handler/deploy.go`; return error on failure
+- [x] T0\1 [US1] Call `cfg.ValidateRegistries()` in `Deploy` (live path) after config load in `internal/handler/deploy.go`; return error on failure
+- [x] T0\1 [US1] Call `cfg.ValidateRegistries()` in `ApplySingle` after config load in `internal/handler/apply.go`; return error on failure
+
+**Checkpoint**: `shrine deploy --dry-run --config-dir <dup-dir>` exits non-zero with a
+"duplicate alias" message. US1 integration tests pass.
+
+---
+
+## Phase 4: User Story 2 — App Image `reg:` Prefix (Priority: P1)
+
+**Goal**: Application manifests use `image: reg:<alias>/image:tag`; the planner validates
+the alias exists at plan/dry-run time; the docker backend expands the alias at live
+execution time; dry-run output preserves the `reg:` form.
+
+**Independent Test**: Create an app manifest with `image: reg:myregistry/whoami:latest`, a
+config with `alias: myregistry`, run `shrine deploy --dry-run --config-dir <dir>` and
+verify the output shows `reg:myregistry/whoami:latest` (alias preserved). Then verify that
+using an unknown alias produces an error naming the alias.
+
+### TDD: Integration Test Fixture & Tests for User Story 2
+
+> **Write these BEFORE T016–T023 and verify they FAIL before implementation.**
+
+- [x] T0\1 [P] [US2] Create `tests/testdata/deploy/registry-alias/app.yml` — application manifest with `image: reg:myregistry/traefik/whoami:latest`
+- [x] T0\1 [P] [US2] Create `tests/testdata/deploy/registry-alias-unknown/` fixture — app manifest referencing `reg:unknown/whoami:latest` with a config that has no matching alias
+- [x] T0\1 [US2] Write integration tests for US2 in `tests/integration/registry_alias_test.go`:
+  - dry-run output shows `reg:myregistry/traefik/whoami:latest` (alias preserved, not expanded)
+  - unknown alias produces error: `alias "unknown" is not defined in config registries`
+  - plain image (`image: traefik/whoami`) is unaffected (regression guard)
+
+### Implementation for User Story 2
+
+- [x] T0\1 [P] [US2] Add `validateRegistryImages(set *ManifestSet, registries []config.RegistryConfig) []error` to `internal/planner/resolve.go`:
+  - iterate `set.Applications`; for each `app.Spec.Image` starting with `reg:`, extract alias and verify it exists in the alias map
+  - return descriptive error: `app "<name>": image "<ref>": alias "<a>" is not defined in config registries`
+  - empty alias after `reg:` (`reg:/image`) is also an error
+- [x] T0\1 [US2] Extend `Resolve(set, store)` signature to `Resolve(set, store, registries)` in `internal/planner/resolve.go`; call `validateRegistryImages` as step 5 in the existing validation sequence
+- [x] T0\1 [US2] Update `Plan` in `internal/planner/plan.go` to accept `registries []config.RegistryConfig` and pass them to `Resolve`
+- [x] T0\1 [US2] Update `PlanSingle` in `internal/planner/plan.go` to accept `registries []config.RegistryConfig` and pass them to `Resolve`
+- [x] T0\1 [US2] Update `DryRun` call in `internal/handler/deploy.go` to pass `cfg.Registries` to `planner.Plan`
+- [x] T0\1 [US2] Update `Deploy` call in `internal/handler/deploy.go` to pass `cfg.Registries` to `planner.Plan`
+- [x] T0\1 [US2] Update `ApplySingle` call in `internal/handler/apply.go` to pass `cfg.Registries` to `planner.PlanSingle`
+- [x] T0\1 [P] [US2] Add `hasRegistryAliasPrefix(ref string) bool`, `buildAliasMap(registries []config.RegistryConfig) map[string]string`, and `expandRegistryAlias(ref string, registries []config.RegistryConfig) (string, error)` to `internal/engine/local/dockercontainer/registry_auth.go`
+- [x] T0\1 [US2] Call `expandRegistryAlias` at the top of `ensureImage` in `internal/engine/local/dockercontainer/docker_image.go`; propagate error
+- [x] T0\1 [US2] Call `expandRegistryAlias` at the top of `resolveImage` in `internal/engine/local/dockercontainer/docker_image.go`; propagate error
+- [x] T0\1 [P] [US2] Add unit tests for `hasRegistryAliasPrefix`, `buildAliasMap`, and `expandRegistryAlias` in `internal/engine/local/dockercontainer/registry_auth_test.go` (create file)
+- [x] T0\1 [P] [US2] Add unit tests for `validateRegistryImages` (valid alias, missing alias, empty alias, plain image passthrough) in `internal/planner/resolve_test.go`
+
+**Checkpoint**: US2 integration tests pass. `shrine deploy --dry-run` shows alias as-is;
+unknown alias fails at dry-run time with a clear error.
+
+---
+
+## Phase 5: User Story 3 — Resource Image `reg:` Prefix (Priority: P2)
+
+**Goal**: Resource manifests support the same `reg:<alias>` syntax as applications.
+
+**Independent Test**: Create a resource manifest with `image: reg:myregistry/postgres:15`,
+run dry-run, verify alias is shown as-is with no error. Verify unknown alias fails.
+
+### TDD: Integration Test Fixture & Tests for User Story 3
+
+> **Write these BEFORE T027 and verify they FAIL (if resources not yet covered).**
+
+- [x] T0\1 [P] [US3] Create `tests/testdata/deploy/registry-alias-resource/` fixture — resource manifest with `image: reg:myregistry/postgres:15` and matching config
+- [x] T0\1 [US3] Write integration tests for US3 in `tests/integration/registry_alias_test.go`:
+  - dry-run shows `reg:myregistry/postgres:15` for a resource (alias preserved)
+  - unknown alias on a resource produces error naming the resource and alias
+
+### Implementation for User Story 3
+
+- [x] T0\1 [US3] Extend `validateRegistryImages` in `internal/planner/resolve.go` to also iterate `set.Resources`; for each `res.Spec.Image` starting with `reg:`, apply the same alias check with error: `resource "<name>": image "<ref>": alias "<a>" is not defined in config registries`
+
+**Checkpoint**: US3 integration tests pass. Resources behave identically to applications
+for `reg:` images.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T0\1 [P] Verify error messages in `internal/config/config.go`, `internal/planner/resolve.go`, and `internal/engine/local/dockercontainer/registry_auth.go` match the contracts defined in `specs/014-registry-alias/contracts/registry-config.md`
+- [x] T0\1 Run `go test ./...` to confirm zero regressions across all unit tests
+- [x] T0\1 Run `make test-integration` (or `go test -tags integration ./tests/integration/...`) as the final gate; all integration tests must pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 2 (Foundational)**: No dependencies — start immediately
+- **Phase 3 (US1)**: Depends on Phase 2 (T001)
+- **Phase 4 (US2)**: Depends on Phase 3 completion (T001–T010)
+- **Phase 5 (US3)**: Depends on Phase 4 completion — specifically T014/T015 which implement `validateRegistryImages`
+- **Phase 6 (Polish)**: Depends on all story phases complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after T001 — no dependency on US2/US3
+- **US2 (P1)**: Depends on US1 completion (ValidateRegistries wired, Alias field available)
+- **US3 (P2)**: Depends on US2 completion (validateRegistryImages already exists, just extend it)
+
+### Within Each Phase
+
+- TDD fixtures [P] (T002–T004, T011–T012, T026) can be created in parallel
+- Integration test file tasks (T005, T013, T027) must follow their respective fixtures
+- Implementation tasks must follow their integration test tasks (tests fail first)
+- `expandRegistryAlias` (T021) can be written in parallel with planner changes (T014–T017)
+- Unit test tasks marked [P] can be written in parallel with their implementation counterparts
+
+---
+
+## Parallel Example: Phase 4 (User Story 2)
+
+```text
+# Fixtures can be created in parallel:
+Task T011: Create registry-alias/app.yml
+Task T012: Create registry-alias-unknown/ fixture
+
+# After fixtures: write integration tests (T013) [FAIL first]
+
+# After tests: implementation can parallelize across layers:
+Task T014: validateRegistryImages in internal/planner/resolve.go
+Task T021: expandRegistryAlias in internal/engine/local/dockercontainer/registry_auth.go
+
+# After T014: planner signature + handler wiring (sequential per dependency):
+Task T015 → T016 → T017 → T018 → T019 → T020
+
+# After T021: engine call sites (T022, T023)
+
+# Unit tests can be written in parallel with implementation:
+Task T024: registry_auth_test.go
+Task T025: resolve_test.go
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + 2)
+
+1. Complete Phase 2: Foundational (T001) — config field
+2. Complete Phase 3: US1 (T002–T010) — config validation
+3. Complete Phase 4: US2 (T011–T025) — app image expansion
+4. **STOP and VALIDATE**: `shrine deploy --dry-run` works with `reg:` aliases
+5. Deliver MVP
+
+### Incremental Delivery
+
+1. T001 → US1 (T002–T010) → Foundation: aliases defined in config ✓
+2. T011–T025 (US2) → App `reg:` images work end-to-end ✓ (MVP)
+3. T026–T028 (US3) → Resource `reg:` images work ✓
+4. T029–T031 (Polish) → Verified clean ✓
+
+---
+
+## Notes
+
+- [P] = different files with no overlapping state — safe to run in parallel
+- TDD order is mandatory per Constitution Principle V: integration tests must exist and FAIL before implementation
+- `ValidateRegistries()` is called in handlers (not in `config.Load`) to preserve `Load`'s pure unmarshal contract
+- Dry-run preserves the `reg:` alias form because `DryRunContainerBackend` never calls `expandRegistryAlias` — expansion lives only in `DockerBackend`
+- The `Resolve` signature change (adding `registries`) will require updating all existing call sites in `plan.go` — unit tests in `resolve_test.go` and callers in `handler/` must be updated together

--- a/tests/integration/registry_alias_test.go
+++ b/tests/integration/registry_alias_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/CarlosHPlata/shrine/tests/integration/testutils"
+)
+
+func registryAliasFixturesPath(parts ...string) string {
+	_, f, _, _ := runtime.Caller(0)
+	base := filepath.Join(filepath.Dir(f), "..", "..", "tests", "testdata", "deploy")
+	return filepath.Join(append([]string{base}, parts...)...)
+}
+
+
+func TestRegistryAliasConfig(t *testing.T) {
+	s := NewSuite(t)
+
+	s.Test("valid alias loads without error on dry-run", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias")
+
+		tc.Run("apply", "teams",
+			"--path", registryAliasFixturesPath("team"),
+			"--state-dir", stateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertSuccess()
+	})
+
+	s.Test("duplicate alias causes config validation error", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias-dup")
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertFailure().
+			AssertStderrContains("myregistry")
+	})
+
+	s.Test("alias with invalid characters causes config validation error", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias-badformat")
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertFailure().
+			AssertStderrContains("my.registry")
+	})
+}
+
+func TestRegistryAliasAppImage(t *testing.T) {
+	s := NewSuite(t)
+
+	s.Test("dry-run preserves reg: alias in output for application", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias")
+
+		tc.Run("apply", "teams",
+			"--path", registryAliasFixturesPath("team"),
+			"--state-dir", stateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertSuccess().
+			AssertOutputContains("reg:myregistry/")
+	})
+
+	s.Test("unknown alias in application image fails at dry-run time", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias")
+
+		tc.Run("apply", "teams",
+			"--path", registryAliasFixturesPath("team"),
+			"--state-dir", stateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias-unknown"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertFailure().
+			AssertStderrContains("unknown")
+	})
+
+	s.Test("plain image reference is unaffected by alias feature", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias")
+
+		tc.Run("apply", "teams",
+			"--path", registryAliasFixturesPath("team"),
+			"--state-dir", stateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("basic"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertSuccess()
+	})
+}
+
+func TestRegistryAliasResourceImage(t *testing.T) {
+	s := NewSuite(t)
+
+	s.Test("dry-run preserves reg: alias in output for resource", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias")
+
+		tc.Run("apply", "teams",
+			"--path", registryAliasFixturesPath("team"),
+			"--state-dir", stateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias-resource"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertSuccess().
+			AssertOutputContains("reg:myregistry/")
+	})
+
+	s.Test("unknown alias in resource image fails at dry-run time", func(tc *TestCase) {
+		stateDir := tc.TempDir()
+		cfgDir := registryAliasFixturesPath("registry-alias")
+
+		tc.Run("apply", "teams",
+			"--path", registryAliasFixturesPath("team"),
+			"--state-dir", stateDir,
+		).AssertSuccess()
+
+		tc.Run("deploy", "--dry-run",
+			"--path", registryAliasFixturesPath("registry-alias-resource-unknown"),
+			"--state-dir", stateDir,
+			"--config-dir", cfgDir,
+		).AssertFailure().
+			AssertStderrContains("unknown")
+	})
+}

--- a/tests/testdata/deploy/registry-alias-badformat/config.yml
+++ b/tests/testdata/deploy/registry-alias-badformat/config.yml
@@ -1,0 +1,3 @@
+registries:
+  - host: docker.io
+    alias: my.registry

--- a/tests/testdata/deploy/registry-alias-dup/config.yml
+++ b/tests/testdata/deploy/registry-alias-dup/config.yml
@@ -1,0 +1,5 @@
+registries:
+  - host: docker.io
+    alias: myregistry
+  - host: ghcr.io
+    alias: myregistry

--- a/tests/testdata/deploy/registry-alias-resource-unknown/config.yml
+++ b/tests/testdata/deploy/registry-alias-resource-unknown/config.yml
@@ -1,0 +1,3 @@
+registries:
+  - host: docker.io
+    alias: myregistry

--- a/tests/testdata/deploy/registry-alias-resource-unknown/resource.yml
+++ b/tests/testdata/deploy/registry-alias-resource-unknown/resource.yml
@@ -5,6 +5,7 @@ metadata:
   owner: shrine-deploy-test
 spec:
   type: postgres
+  version: "15"
   image: reg:unknown/postgres:15
   port: 5432
   outputs:

--- a/tests/testdata/deploy/registry-alias-resource-unknown/resource.yml
+++ b/tests/testdata/deploy/registry-alias-resource-unknown/resource.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: unknown-alias-db
+  owner: shrine-deploy-test
+spec:
+  type: postgres
+  image: reg:unknown/postgres:15
+  port: 5432
+  outputs:
+    - name: host
+    - name: port

--- a/tests/testdata/deploy/registry-alias-resource/config.yml
+++ b/tests/testdata/deploy/registry-alias-resource/config.yml
@@ -1,0 +1,3 @@
+registries:
+  - host: docker.io
+    alias: myregistry

--- a/tests/testdata/deploy/registry-alias-resource/resource.yml
+++ b/tests/testdata/deploy/registry-alias-resource/resource.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: alias-db
+  owner: shrine-deploy-test
+spec:
+  type: postgres
+  image: reg:myregistry/postgres:15
+  port: 5432
+  outputs:
+    - name: host
+    - name: port

--- a/tests/testdata/deploy/registry-alias-resource/resource.yml
+++ b/tests/testdata/deploy/registry-alias-resource/resource.yml
@@ -5,6 +5,7 @@ metadata:
   owner: shrine-deploy-test
 spec:
   type: postgres
+  version: "15"
   image: reg:myregistry/postgres:15
   port: 5432
   outputs:

--- a/tests/testdata/deploy/registry-alias-unknown/app.yml
+++ b/tests/testdata/deploy/registry-alias-unknown/app.yml
@@ -1,0 +1,10 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: unknown-alias-app
+  owner: shrine-deploy-test
+spec:
+  image: reg:unknown/traefik/whoami:latest
+  port: 80
+  networking:
+    exposeToPlatform: false

--- a/tests/testdata/deploy/registry-alias-unknown/config.yml
+++ b/tests/testdata/deploy/registry-alias-unknown/config.yml
@@ -1,0 +1,3 @@
+registries:
+  - host: docker.io
+    alias: myregistry

--- a/tests/testdata/deploy/registry-alias/app.yml
+++ b/tests/testdata/deploy/registry-alias/app.yml
@@ -1,0 +1,10 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: alias-app
+  owner: shrine-deploy-test
+spec:
+  image: reg:myregistry/traefik/whoami:latest
+  port: 80
+  networking:
+    exposeToPlatform: false

--- a/tests/testdata/deploy/registry-alias/config.yml
+++ b/tests/testdata/deploy/registry-alias/config.yml
@@ -1,0 +1,3 @@
+registries:
+  - host: docker.io
+    alias: myregistry


### PR DESCRIPTION
## What

Adds a short-name alias system for private registries. Operators define \`alias: myregistry\` on any registry entry in \`config.yml\`, and application/resource manifests can then reference it as \`image: reg:myregistry/image:tag\` instead of embedding the raw hostname.

## Why

Operators running private registries (self-hosted IP:port registries) were forced to put the raw internal hostname directly in application manifests. This leaked internal network topology to every team author. Registry aliases keep hostnames in the operator-controlled config layer and let manifests use readable names.

## How to test

\`\`\`bash
go test ./...
\`\`\`

**Dry-run with a valid alias** — \`config.yml\`:
\`\`\`yaml
registries:
  - host: docker.io
    alias: myregistry
\`\`\`
App manifest with \`image: reg:myregistry/traefik/whoami:latest\`, then:
\`\`\`bash
shrine deploy --dry-run --path <dir> --config-dir <config-dir>
\`\`\`
Expected: succeeds, output shows \`image=reg:myregistry/traefik/whoami:latest\` (alias preserved).

**Duplicate alias** → exits non-zero with \`alias "myregistry" is defined more than once\`.

**Unknown alias** → exits non-zero with \`alias "unknown" is not defined in config registries\`.

**Integration suite:**
\`\`\`bash
make test-integration
\`\`\`

## Checklist

- [x] Tests added or updated
- [x] \`go test ./...\` passes locally
- [x] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)