### PR TITLE
fix: compare versions by SemVer precedence in updater.IsNewer

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -42,11 +43,116 @@ func LatestVersion() (string, error) {
 	return release.TagName, nil
 }
 
-// IsNewer reports whether latest is a newer version than current.
-// Both are expected to be semver strings optionally prefixed with "v".
+// IsNewer reports whether latest is a strictly newer version than current,
+// using SemVer 2.0.0 precedence rules. Both are expected to be semver
+// strings optionally prefixed with "v". A "dev" current version, an empty
+// latest, or unparseable inputs all yield false.
 func IsNewer(current, latest string) bool {
-	return strings.TrimPrefix(latest, "v") != strings.TrimPrefix(current, "v") &&
-		latest != "" && current != "dev"
+	if current == "dev" || latest == "" {
+		return false
+	}
+	return compareSemver(latest, current) > 0
+}
+
+// compareSemver returns >0 if a > b, <0 if a < b, 0 if equal or either
+// side fails to parse.
+func compareSemver(a, b string) int {
+	aMain, aPre, aOK := parseSemver(a)
+	bMain, bPre, bOK := parseSemver(b)
+	if !aOK || !bOK {
+		return 0
+	}
+	for i := 0; i < 3; i++ {
+		if aMain[i] != bMain[i] {
+			if aMain[i] > bMain[i] {
+				return 1
+			}
+			return -1
+		}
+	}
+	// A version with a pre-release has lower precedence than one without.
+	switch {
+	case aPre == "" && bPre == "":
+		return 0
+	case aPre == "":
+		return 1
+	case bPre == "":
+		return -1
+	}
+	return comparePrerelease(aPre, bPre)
+}
+
+// parseSemver splits a semver string into its three numeric components and
+// pre-release tail. Build metadata (after '+') is discarded per SemVer.
+func parseSemver(s string) ([3]int, string, bool) {
+	s = strings.TrimPrefix(s, "v")
+	if j := strings.IndexByte(s, '+'); j >= 0 {
+		s = s[:j]
+	}
+	var pre string
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		pre = s[i+1:]
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return [3]int{}, "", false
+	}
+	var nums [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return [3]int{}, "", false
+		}
+		nums[i] = n
+	}
+	return nums, pre, true
+}
+
+// comparePrerelease applies SemVer 2.0.0 pre-release precedence:
+// numeric identifiers compare numerically and rank below alphanumeric ones;
+// alphanumeric identifiers compare in ASCII order; a longer set of
+// identifiers wins when all preceding identifiers are equal.
+func comparePrerelease(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	n := len(aParts)
+	if len(bParts) < n {
+		n = len(bParts)
+	}
+	for i := 0; i < n; i++ {
+		aN, aErr := strconv.Atoi(aParts[i])
+		bN, bErr := strconv.Atoi(bParts[i])
+		aIsNum := aErr == nil
+		bIsNum := bErr == nil
+		switch {
+		case aIsNum && bIsNum:
+			if aN != bN {
+				if aN > bN {
+					return 1
+				}
+				return -1
+			}
+		case aIsNum:
+			return -1
+		case bIsNum:
+			return 1
+		default:
+			if aParts[i] != bParts[i] {
+				if aParts[i] > bParts[i] {
+					return 1
+				}
+				return -1
+			}
+		}
+	}
+	if len(aParts) == len(bParts) {
+		return 0
+	}
+	if len(aParts) > len(bParts) {
+		return 1
+	}
+	return -1
 }
 
 // Update downloads the latest release and replaces the running binary.

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,49 @@
+package updater
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		// Baseline: stable vs stable.
+		{"stable patch bump is newer", "v0.0.1", "v0.0.2", true},
+		{"stable patch downgrade is not newer", "v0.0.2", "v0.0.1", false},
+		{"identical stable is not newer", "v0.0.1", "v0.0.1", false},
+		{"minor bump beats large patch", "v0.0.99", "v0.1.0", true},
+		{"major bump beats large minor", "v0.9.9", "v1.0.0", true},
+
+		// The reported bug: a pre-release of a higher patch must not be
+		// treated as older than a lower stable.
+		{"prerelease ahead of stable patch", "v0.0.2-beta.1.5", "v0.0.1", false},
+		{"stable lower than current prerelease", "v0.0.2-beta.1.5", "v0.0.2", true},
+		{"newer prerelease of same patch", "v0.0.2-beta.1", "v0.0.2-beta.2", true},
+		{"older prerelease of same patch", "v0.0.2-beta.2", "v0.0.2-beta.1", false},
+		{"alpha < beta on same patch", "v0.0.2-alpha.1", "v0.0.2-beta.1", true},
+		{"beta is older than final on same patch", "v0.0.2-beta.1", "v0.0.2", true},
+		{"final is not older than its own beta", "v0.0.2", "v0.0.2-beta.1", false},
+		{"longer prerelease chain wins when prefix equal", "v0.0.2-beta.1", "v0.0.2-beta.1.5", true},
+
+		// Special cases preserved from the original contract.
+		{"dev current is never updated", "dev", "v0.0.2", false},
+		{"empty latest yields no update", "v0.0.1", "", false},
+
+		// Unparseable inputs must not falsely trigger an update.
+		{"garbage latest yields no update", "v0.0.1", "not-a-version", false},
+		{"garbage current yields no update", "not-a-version", "v0.0.1", false},
+
+		// Build metadata is ignored per SemVer 2.0.0.
+		{"build metadata does not affect equality", "v0.0.1+abc", "v0.0.1+def", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNewer(tc.current, tc.latest); got != tc.want {
+				t.Errorf("IsNewer(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`shrine update` (and the deploy-time update banner) no longer treats unrelated tags as upgrades. Pre-release versions like `v0.0.2-beta.1.5` are now correctly recognised as newer than older stables like `v0.0.1`.

## Why

`updater.IsNewer` did a plain string-inequality check, so any tag that differed from the running version was reported as a newer release. The stable-to-stable case only happened to behave correctly because GitHub's `releases/latest` is, in fact, newer — the function itself never compared versions. Running a pre-release (e.g. `v0.0.2-beta.1.5`) exposed the bug: the older stable `v0.0.1` was flagged as an available update.

## How to test

- `go test ./internal/updater/ -v` — new table-driven coverage in `updater_test.go` exercises the reported regression plus alpha/beta/final ordering, longer pre-release chains, build metadata, and unparseable inputs.
- `go test ./...` — full unit suite stays green.
- Manual: build with `-ldflags "-X github.com/CarlosHPlata/shrine/cmd.Version=v0.0.2-beta.1.5"` and run `shrine update --check`; it should report up-to-date when the latest GitHub release is `v0.0.1`.

## Checklist

- [x] Tests added or updated
- [x] `go test ./...` passes locally
- [ ] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)