### PR TITLE
feat: infer same-team valueFrom edges in planner with fail-fast on cross-team

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/019-deploy-team-subcommand"
+  "feature_directory": "specs/020-infer-valuefrom-deps"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,10 @@ shrine/
 │   │   ├── loader.go           # LoadDir → ManifestSet (duplicate detection, recursive scan)
 │   │   ├── resolve.go          # validateDependencies, access checks, quota enforcement
 │   │   ├── templates.go        # Plan-time template ref validation (unknown refs rejected)
+│   │   ├── enrich.go           # Enricher chain + helpers — infers same-team valueFrom edges; fail-fast on cross-team. See specs/020-infer-valuefrom-deps/spec.md
+│   │   ├── enrich_valuefrom.go # Production rules for valueFrom: resource.*/application.* refs (see specs/020-infer-valuefrom-deps/quickstart.md)
 │   │   ├── order.go            # Topo sort over Resource+Application graph → []PlannedStep
-│   │   └── plan.go             # Plan(), PlanSingle() entry points: load → resolve → order/single-step
+│   │   └── plan.go             # Plan(), PlanSingle() entry points: load → resolve → enrich → order/single-step
 │   ├── resolver/               # Materializes outputs and env at deploy time
 │   │   ├── resolver.go         # LiveResolver: secrets, templates, valueFrom lookup
 │   │   └── dry_run_resolver.go # DryRunResolver: same API, placeholder values
@@ -216,6 +218,7 @@ shrine deploy
      │
      ├── manifest.LoadDir()          → ManifestSet (all Applications + Resources, recursive)
      ├── planner.Resolve()           → validates deps, access, quotas, template refs
+     ├── planner.ChainEnrich()       → infers deploy-order edges from same-team valueFrom refs; fail-fast on cross-team or absent target unless an explicit spec.dependencies entry covers it
      ├── planner.Order()             → topo-sorted []PlannedStep (Kahn's algorithm)
      ├── resolver.ResolveResource()  → materializes each Resource's outputs (literals, secrets, templates)
      ├── engine.ExecuteDeploy()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/019-deploy-team-subcommand/plan.md
+at specs/020-infer-valuefrom-deps/plan.md
 <!-- SPECKIT END -->
 
 ## graphify

--- a/internal/handler/deploy.go
+++ b/internal/handler/deploy.go
@@ -49,6 +49,8 @@ func DryRun(out, errOut io.Writer, manifestDir string, store *state.Store, cfg *
 		return nil
 	}
 
+	fmt.Fprint(out, formatDeployPlan(result.Steps, result.ManifestSet, result.InferredEdges))
+
 	engineInst := dryrun.NewDryRunEngine(out)
 	if err := engineInst.ExecuteDeploy(result.Steps, result.ManifestSet); err != nil {
 		return err

--- a/internal/handler/deploy_plan_format.go
+++ b/internal/handler/deploy_plan_format.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+	"github.com/CarlosHPlata/shrine/internal/planner"
+)
+
+// formatDeployPlan renders the dry-run plan summary. Inferred dependencies
+// (matched against edges via (Consumer.Name, Target.Kind, Target.Name)) are
+// tagged with ` (inferred from env <NAME>)`. Explicit deps carry no tag.
+func formatDeployPlan(steps []planner.PlannedStep, set *planner.ManifestSet, edges []planner.InferredEdge) string {
+	if len(steps) == 0 {
+		return ""
+	}
+
+	envIndex := make(map[string]string, len(edges))
+	for _, e := range edges {
+		envIndex[edgeKey(e.Consumer.Name, e.Target.Kind, e.Target.Name)] = e.EnvVar
+	}
+
+	var b strings.Builder
+	b.WriteString("Deploy order:\n")
+	for i, step := range steps {
+		fmt.Fprintf(&b, "  %d. %s:%s\n", i+1, step.Kind, step.Name)
+		deps := stepDependencies(set, step)
+		if len(deps) == 0 {
+			continue
+		}
+		b.WriteString("       depends on:\n")
+		for _, d := range deps {
+			line := fmt.Sprintf("         - %s:%s", d.Kind, d.Name)
+			if env, ok := envIndex[edgeKey(step.Name, d.Kind, d.Name)]; ok {
+				line += fmt.Sprintf(" (inferred from env %s)", env)
+			}
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func edgeKey(consumer, kind, name string) string {
+	return consumer + "|" + kind + "|" + name
+}
+
+func stepDependencies(set *planner.ManifestSet, step planner.PlannedStep) []manifest.Dependency {
+	if step.Kind != manifest.ApplicationKind {
+		return nil
+	}
+	app, ok := set.Applications[step.Name]
+	if !ok {
+		return nil
+	}
+	return app.Spec.Dependencies
+}

--- a/internal/handler/deploy_plan_format_test.go
+++ b/internal/handler/deploy_plan_format_test.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+	"github.com/CarlosHPlata/shrine/internal/planner"
+)
+
+func TestFormatDeployPlan_RendersHeaderAndOrdinals(t *testing.T) {
+	set := planner.NewManifestSet()
+	set.Resources["db"] = &manifest.ResourceManifest{
+		Metadata: manifest.Metadata{Name: "db", Owner: "team-a"},
+	}
+	set.Applications["api"] = &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "api", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Dependencies: []manifest.Dependency{
+				{Kind: manifest.ResourceKind, Name: "db", Owner: "team-a"},
+			},
+		},
+	}
+
+	steps := []planner.PlannedStep{
+		{Kind: manifest.ResourceKind, Name: "db"},
+		{Kind: manifest.ApplicationKind, Name: "api"},
+	}
+	edges := []planner.InferredEdge{{
+		Consumer: planner.ManifestRef{Kind: manifest.ApplicationKind, Name: "api", Owner: "team-a"},
+		Target:   planner.ManifestRef{Kind: manifest.ResourceKind, Name: "db", Owner: "team-a"},
+		EnvVar:   "DB_URL",
+	}}
+
+	out := formatDeployPlan(steps, set, edges)
+	if !strings.HasPrefix(out, "Deploy order:\n") {
+		t.Errorf("missing header. got:\n%s", out)
+	}
+	if !strings.Contains(out, "  1. Resource:db\n") {
+		t.Errorf("missing step 1. got:\n%s", out)
+	}
+	if !strings.Contains(out, "  2. Application:api\n") {
+		t.Errorf("missing step 2. got:\n%s", out)
+	}
+	if !strings.Contains(out, "       depends on:\n         - Resource:db (inferred from env DB_URL)\n") {
+		t.Errorf("missing inferred dep tag. got:\n%s", out)
+	}
+}
+
+func TestFormatDeployPlan_ExplicitDepHasNoTag(t *testing.T) {
+	set := planner.NewManifestSet()
+	set.Applications["api"] = &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "api", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Dependencies: []manifest.Dependency{
+				{Kind: manifest.ResourceKind, Name: "db", Owner: "team-a"},
+			},
+		},
+	}
+	steps := []planner.PlannedStep{
+		{Kind: manifest.ApplicationKind, Name: "api"},
+	}
+	out := formatDeployPlan(steps, set, nil)
+	if !strings.Contains(out, "         - Resource:db\n") {
+		t.Errorf("expected untagged explicit dep. got:\n%s", out)
+	}
+	if strings.Contains(out, "inferred from env") {
+		t.Errorf("explicit dep must not be tagged. got:\n%s", out)
+	}
+}
+
+func TestFormatDeployPlan_NoDepsNoDependsOnBlock(t *testing.T) {
+	set := planner.NewManifestSet()
+	set.Resources["db"] = &manifest.ResourceManifest{
+		Metadata: manifest.Metadata{Name: "db"},
+	}
+	steps := []planner.PlannedStep{{Kind: manifest.ResourceKind, Name: "db"}}
+	out := formatDeployPlan(steps, set, nil)
+	if strings.Contains(out, "depends on:") {
+		t.Errorf("steps with no deps must omit block. got:\n%s", out)
+	}
+}

--- a/internal/planner/enrich.go
+++ b/internal/planner/enrich.go
@@ -1,0 +1,156 @@
+package planner
+
+import (
+	"fmt"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+)
+
+// Enricher transforms a ManifestSet into an enriched copy by adding inferred
+// deploy-order dependencies. Implementations must not mutate the input set.
+//
+// Enrich returns a non-nil error when a valueFrom reference cannot be resolved
+// to a same-team manifest and is not already covered by an explicit
+// Spec.Dependencies entry on the consumer; the chain stops at the first such
+// error.
+type Enricher interface {
+	Enrich(set *ManifestSet) (*ManifestSet, error)
+}
+
+// edgeAwareEnricher is the package-internal richer contract that production
+// rules implement so ChainEnrich can aggregate the rule's inferred-edge
+// provenance. External Enricher implementations (e.g., tests passing
+// arbitrary rules) simply contribute no edges.
+type edgeAwareEnricher interface {
+	Enricher
+	enrichWithEdges(set *ManifestSet) (*ManifestSet, []InferredEdge, error)
+}
+
+// ManifestRef identifies a target manifest in the current set.
+type ManifestRef struct {
+	Kind  string
+	Name  string
+	Owner string
+}
+
+// InferredEdge records one inferred dependency edge for dry-run provenance.
+type InferredEdge struct {
+	Consumer ManifestRef
+	Target   ManifestRef
+	EnvVar   string
+}
+
+// EnrichmentErrorKind is a stable identifier for the failure category.
+type EnrichmentErrorKind string
+
+const ErrCrossTeamOrUnresolvedValueFrom EnrichmentErrorKind = "cross-team-or-unresolved-valuefrom"
+
+// EnrichmentError is the typed error returned when a valueFrom reference cannot
+// be enriched and is not covered by an explicit Spec.Dependencies entry.
+type EnrichmentError struct {
+	Kind          EnrichmentErrorKind
+	ConsumerKind  string
+	ConsumerName  string
+	ConsumerOwner string
+	EnvName       string
+	TargetKind    string // "resource" | "application"
+	TargetName    string
+	TargetOutput  string
+}
+
+func (e *EnrichmentError) Error() string {
+	return fmt.Sprintf(
+		`enrichment: app %q env %q references %s %q which is not owned by team %q; add an explicit spec.dependencies entry (kind: %s, name: %s) to declare this dependency`,
+		e.ConsumerName,
+		e.EnvName,
+		e.TargetKind,
+		e.TargetName+"."+e.TargetOutput,
+		e.ConsumerOwner,
+		titleKind(e.TargetKind),
+		e.TargetName,
+	)
+}
+
+func titleKind(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[0] >= 'a' && s[0] <= 'z' {
+		return string(s[0]-32) + s[1:]
+	}
+	return s
+}
+
+// ChainEnrich applies the given Enrichers in order to a shallow copy of set,
+// returning the enriched copy along with the inferred-edge provenance. The
+// input set is observably unmodified after this call. Rules operate on the
+// previous rule's output. On any non-nil error, returns (nil, nil, err).
+func ChainEnrich(set *ManifestSet, rules ...Enricher) (*ManifestSet, []InferredEdge, error) {
+	current := copyManifestSetShallow(set)
+	var all []InferredEdge
+
+	for _, rule := range rules {
+		if ea, ok := rule.(edgeAwareEnricher); ok {
+			out, edges, err := ea.enrichWithEdges(current)
+			if err != nil {
+				return nil, nil, err
+			}
+			current = out
+			all = append(all, edges...)
+			continue
+		}
+		out, err := rule.Enrich(current)
+		if err != nil {
+			return nil, nil, err
+		}
+		current = out
+	}
+	return current, all, nil
+}
+
+// DefaultEnrichers returns the production rule chain in deterministic order.
+func DefaultEnrichers() []Enricher {
+	return []Enricher{
+		enrichValueFromResource{},
+		enrichValueFromApplication{},
+	}
+}
+
+// copyManifestSetShallow allocates a new *ManifestSet whose maps are fresh
+// (different headers) but whose values are pointer-shared with the input.
+func copyManifestSetShallow(set *ManifestSet) *ManifestSet {
+	out := NewManifestSet()
+	for name, app := range set.Applications {
+		out.Applications[name] = app
+	}
+	for name, res := range set.Resources {
+		out.Resources[name] = res
+	}
+	return out
+}
+
+// cloneApplicationWithDeps returns a new ApplicationManifest whose
+// Spec.Dependencies is the original slice plus extra appended. If extra is
+// empty, returns app unchanged.
+func cloneApplicationWithDeps(app *manifest.ApplicationManifest, extra []manifest.Dependency) *manifest.ApplicationManifest {
+	if len(extra) == 0 {
+		return app
+	}
+	clone := *app
+	deps := make([]manifest.Dependency, 0, len(app.Spec.Dependencies)+len(extra))
+	deps = append(deps, app.Spec.Dependencies...)
+	deps = append(deps, extra...)
+	clone.Spec.Dependencies = deps
+	return &clone
+}
+
+// hasExplicitDependency returns true if any entry in deps matches (kind, name).
+// Owner is intentionally ignored.
+func hasExplicitDependency(deps []manifest.Dependency, kind, name string) bool {
+	for _, d := range deps {
+		if d.Kind == kind && d.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/planner/enrich_test.go
+++ b/internal/planner/enrich_test.go
@@ -1,0 +1,405 @@
+package planner
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+)
+
+// helpers tests (T003)
+
+func TestCopyManifestSetShallow_AllocsFreshMapsAndPointerSharesValues(t *testing.T) {
+	set := NewManifestSet()
+	app := &manifest.ApplicationManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ApplicationKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "a", Owner: "team-a"},
+	}
+	set.Applications["a"] = app
+	res := &manifest.ResourceManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ResourceKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "r", Owner: "team-a"},
+	}
+	set.Resources["r"] = res
+
+	copied := copyManifestSetShallow(set)
+
+	if copied == set {
+		t.Fatal("expected fresh *ManifestSet pointer")
+	}
+	if reflect.ValueOf(copied.Applications).Pointer() == reflect.ValueOf(set.Applications).Pointer() {
+		t.Error("Applications map header should be fresh")
+	}
+	if reflect.ValueOf(copied.Resources).Pointer() == reflect.ValueOf(set.Resources).Pointer() {
+		t.Error("Resources map header should be fresh")
+	}
+	if copied.Applications["a"] != app {
+		t.Error("expected pointer-shared Application value")
+	}
+	if copied.Resources["r"] != res {
+		t.Error("expected pointer-shared Resource value")
+	}
+}
+
+func TestCloneApplicationWithDeps_NoExtraReturnsSamePointer(t *testing.T) {
+	app := &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "a"},
+		Spec: manifest.ApplicationSpec{
+			Dependencies: []manifest.Dependency{{Kind: manifest.ResourceKind, Name: "x"}},
+		},
+	}
+	out := cloneApplicationWithDeps(app, nil)
+	if out != app {
+		t.Error("expected same pointer when extra is empty")
+	}
+}
+
+func TestCloneApplicationWithDeps_AppendsAndPreservesOriginalSlice(t *testing.T) {
+	app := &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "a"},
+		Spec: manifest.ApplicationSpec{
+			Dependencies: []manifest.Dependency{{Kind: manifest.ResourceKind, Name: "old"}},
+		},
+	}
+	extra := []manifest.Dependency{{Kind: manifest.ResourceKind, Name: "new"}}
+	out := cloneApplicationWithDeps(app, extra)
+
+	if out == app {
+		t.Fatal("expected fresh *ApplicationManifest pointer")
+	}
+	if len(out.Spec.Dependencies) != 2 {
+		t.Fatalf("expected 2 deps, got %d", len(out.Spec.Dependencies))
+	}
+	if out.Spec.Dependencies[0].Name != "old" || out.Spec.Dependencies[1].Name != "new" {
+		t.Errorf("unexpected deps order: %+v", out.Spec.Dependencies)
+	}
+	// Original slice unchanged.
+	if len(app.Spec.Dependencies) != 1 {
+		t.Errorf("original slice mutated: len=%d", len(app.Spec.Dependencies))
+	}
+}
+
+func TestHasExplicitDependency_MatchesKindAndName_IgnoresOwner(t *testing.T) {
+	deps := []manifest.Dependency{
+		{Kind: manifest.ResourceKind, Name: "db", Owner: "team-x"},
+	}
+	if !hasExplicitDependency(deps, manifest.ResourceKind, "db") {
+		t.Error("expected match ignoring owner")
+	}
+	if hasExplicitDependency(deps, manifest.ApplicationKind, "db") {
+		t.Error("kind must matter")
+	}
+	if hasExplicitDependency(deps, manifest.ResourceKind, "other") {
+		t.Error("name must matter")
+	}
+}
+
+// ChainEnrich tests (T004)
+
+type noopEnricher struct{}
+
+func (noopEnricher) Enrich(set *ManifestSet) (*ManifestSet, error) { return set, nil }
+
+// edgeAdder is a test Enricher that appends a hard-coded edge to a target app.
+type edgeAdder struct {
+	app    string
+	dep    manifest.Dependency
+	envVar string
+}
+
+func (e edgeAdder) Enrich(set *ManifestSet) (*ManifestSet, error) {
+	out := copyManifestSetShallow(set)
+	app, ok := out.Applications[e.app]
+	if !ok {
+		return out, nil
+	}
+	out.Applications[e.app] = cloneApplicationWithDeps(app, []manifest.Dependency{e.dep})
+	return out, nil
+}
+
+type failEnricher struct {
+	calls *int
+}
+
+func (f failEnricher) Enrich(set *ManifestSet) (*ManifestSet, error) {
+	*f.calls++
+	return nil, &EnrichmentError{Kind: ErrCrossTeamOrUnresolvedValueFrom, ConsumerName: "x"}
+}
+
+type countingEnricher struct {
+	calls *int
+}
+
+func (c countingEnricher) Enrich(set *ManifestSet) (*ManifestSet, error) {
+	*c.calls++
+	return set, nil
+}
+
+func TestChainEnrich_EmptyRules_ReturnsShallowCopy(t *testing.T) {
+	set := NewManifestSet()
+	set.Applications["a"] = &manifest.ApplicationManifest{Metadata: manifest.Metadata{Name: "a"}}
+	out, edges, err := ChainEnrich(set)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected no edges, got %d", len(edges))
+	}
+	if out == set {
+		t.Error("expected fresh *ManifestSet")
+	}
+	if out.Applications["a"] != set.Applications["a"] {
+		t.Error("expected pointer-shared values inside shallow copy")
+	}
+}
+
+func TestChainEnrich_TwoRules_SecondObservesFirst(t *testing.T) {
+	set := NewManifestSet()
+	set.Applications["a"] = &manifest.ApplicationManifest{Metadata: manifest.Metadata{Name: "a"}}
+
+	r1 := edgeAdder{app: "a", dep: manifest.Dependency{Kind: manifest.ResourceKind, Name: "x"}}
+	r2 := edgeAdder{app: "a", dep: manifest.Dependency{Kind: manifest.ResourceKind, Name: "y"}}
+
+	out, _, err := ChainEnrich(set, r1, r2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	deps := out.Applications["a"].Spec.Dependencies
+	if len(deps) != 2 || deps[0].Name != "x" || deps[1].Name != "y" {
+		t.Errorf("expected r1 then r2 edges, got %+v", deps)
+	}
+}
+
+func TestChainEnrich_FirstErrorShortCircuits(t *testing.T) {
+	calls := 0
+	failCalls := 0
+	rules := []Enricher{
+		failEnricher{calls: &failCalls},
+		countingEnricher{calls: &calls},
+	}
+	set := NewManifestSet()
+	_, _, err := ChainEnrich(set, rules...)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if failCalls != 1 {
+		t.Errorf("fail enricher should run once, got %d", failCalls)
+	}
+	if calls != 0 {
+		t.Errorf("subsequent rule must not run, got %d calls", calls)
+	}
+}
+
+func TestChainEnrich_SuccessIdempotent(t *testing.T) {
+	set := NewManifestSet()
+	set.Applications["a"] = &manifest.ApplicationManifest{Metadata: manifest.Metadata{Name: "a"}}
+
+	rule := edgeAdder{app: "a", dep: manifest.Dependency{Kind: manifest.ResourceKind, Name: "x"}}
+	out1, _, err := ChainEnrich(set, rule)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	// Running rule on its own output: it would dedup in production code, but here
+	// edgeAdder always appends. The idempotence guarantee in the contract is on
+	// the chain WHEN the rules themselves dedup (which they do via
+	// hasExplicitDependency in applyEnrichmentRule). Use a real-style dedup rule.
+	dedupRule := dedupEdgeAdder{app: "a", dep: manifest.Dependency{Kind: manifest.ResourceKind, Name: "x"}}
+	out2, _, err := ChainEnrich(set, dedupRule)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+	out3, _, err := ChainEnrich(out2, dedupRule)
+	if err != nil {
+		t.Fatalf("third call error: %v", err)
+	}
+	if !reflect.DeepEqual(out2.Applications["a"].Spec.Dependencies, out3.Applications["a"].Spec.Dependencies) {
+		t.Errorf("idempotence broken: out2=%+v out3=%+v",
+			out2.Applications["a"].Spec.Dependencies,
+			out3.Applications["a"].Spec.Dependencies)
+	}
+	_ = out1
+}
+
+func TestChainEnrich_FailureDeterministic(t *testing.T) {
+	calls1 := 0
+	calls2 := 0
+	set := NewManifestSet()
+
+	_, _, err1 := ChainEnrich(set, failEnricher{calls: &calls1})
+	_, _, err2 := ChainEnrich(set, failEnricher{calls: &calls2})
+
+	var ee1, ee2 *EnrichmentError
+	if !errors.As(err1, &ee1) || !errors.As(err2, &ee2) {
+		t.Fatalf("expected *EnrichmentError both runs, got %T %T", err1, err2)
+	}
+	if ee1.Kind != ee2.Kind || ee1.ConsumerName != ee2.ConsumerName {
+		t.Errorf("non-deterministic failure: %+v vs %+v", ee1, ee2)
+	}
+}
+
+// dedupEdgeAdder appends the dep only if not already present.
+type dedupEdgeAdder struct {
+	app string
+	dep manifest.Dependency
+}
+
+func (e dedupEdgeAdder) Enrich(set *ManifestSet) (*ManifestSet, error) {
+	out := copyManifestSetShallow(set)
+	app, ok := out.Applications[e.app]
+	if !ok {
+		return out, nil
+	}
+	if hasExplicitDependency(app.Spec.Dependencies, e.dep.Kind, e.dep.Name) {
+		return out, nil
+	}
+	out.Applications[e.app] = cloneApplicationWithDeps(app, []manifest.Dependency{e.dep})
+	return out, nil
+}
+
+// applyEnrichmentRule failure-path tests (T005)
+
+func TestApplyEnrichmentRule_CrossTeam_Fails(t *testing.T) {
+	set := NewManifestSet()
+	set.Applications["alpha"] = &manifest.ApplicationManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ApplicationKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "alpha", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Env: []manifest.EnvVar{{Name: "X", ValueFrom: "resource.shared.HOST"}},
+		},
+	}
+	set.Resources["shared"] = &manifest.ResourceManifest{
+		Metadata: manifest.Metadata{Name: "shared", Owner: "team-b"},
+	}
+
+	out, edges, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err == nil {
+		t.Fatal("expected error for cross-team ref")
+	}
+	if out != nil {
+		t.Errorf("expected nil set on error, got %+v", out)
+	}
+	if edges != nil {
+		t.Errorf("expected nil edges on error, got %+v", edges)
+	}
+	var ee *EnrichmentError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *EnrichmentError, got %T", err)
+	}
+	if ee.Kind != ErrCrossTeamOrUnresolvedValueFrom {
+		t.Errorf("unexpected kind: %q", ee.Kind)
+	}
+	if ee.ConsumerName != "alpha" || ee.EnvName != "X" || ee.TargetName != "shared" {
+		t.Errorf("unexpected fields: %+v", ee)
+	}
+}
+
+func TestApplyEnrichmentRule_AbsentTarget_Fails(t *testing.T) {
+	set := NewManifestSet()
+	set.Applications["alpha"] = &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "alpha", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Env: []manifest.EnvVar{{Name: "X", ValueFrom: "resource.absent.HOST"}},
+		},
+	}
+	_, _, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err == nil {
+		t.Fatal("expected error for absent target")
+	}
+	var ee *EnrichmentError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *EnrichmentError, got %T", err)
+	}
+	if ee.TargetName != "absent" {
+		t.Errorf("unexpected target: %q", ee.TargetName)
+	}
+}
+
+func TestApplyEnrichmentRule_CrossTeamWithExplicitDep_Succeeds(t *testing.T) {
+	set := NewManifestSet()
+	set.Applications["alpha"] = &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "alpha", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Env: []manifest.EnvVar{{Name: "X", ValueFrom: "resource.shared.HOST"}},
+			Dependencies: []manifest.Dependency{
+				{Kind: manifest.ResourceKind, Name: "shared", Owner: "team-b"},
+			},
+		},
+	}
+	set.Resources["shared"] = &manifest.ResourceManifest{
+		Metadata: manifest.Metadata{Name: "shared", Owner: "team-b"},
+	}
+
+	_, edges, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err != nil {
+		t.Fatalf("explicit dep must satisfy gate, got %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("explicit dep must short-circuit (no inferred edge), got %+v", edges)
+	}
+}
+
+func TestApplyEnrichmentRule_DeterministicFirstError(t *testing.T) {
+	set := NewManifestSet()
+	// Two consumers each with two bad refs.
+	set.Applications["beta"] = &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "beta", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Env: []manifest.EnvVar{
+				{Name: "B1", ValueFrom: "resource.missing-b1.X"},
+				{Name: "B2", ValueFrom: "resource.missing-b2.X"},
+			},
+		},
+	}
+	set.Applications["alpha"] = &manifest.ApplicationManifest{
+		Metadata: manifest.Metadata{Name: "alpha", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Env: []manifest.EnvVar{
+				{Name: "A1", ValueFrom: "resource.missing-a1.X"},
+				{Name: "A2", ValueFrom: "resource.missing-a2.X"},
+			},
+		},
+	}
+
+	var first *EnrichmentError
+	for i := 0; i < 3; i++ {
+		_, _, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+		var ee *EnrichmentError
+		if !errors.As(err, &ee) {
+			t.Fatalf("run %d: expected *EnrichmentError", i)
+		}
+		if first == nil {
+			first = ee
+			continue
+		}
+		if ee.ConsumerName != first.ConsumerName || ee.EnvName != first.EnvName || ee.TargetName != first.TargetName {
+			t.Errorf("run %d non-deterministic: got %+v vs %+v", i, ee, first)
+		}
+	}
+	// Sort-order says alpha < beta, and within alpha the first env var (declaration order) wins.
+	if first.ConsumerName != "alpha" || first.EnvName != "A1" {
+		t.Errorf("expected first error on alpha/A1, got %+v", first)
+	}
+}
+
+func TestEnrichmentError_FormatsContractMessage(t *testing.T) {
+	ee := &EnrichmentError{
+		Kind:          ErrCrossTeamOrUnresolvedValueFrom,
+		ConsumerKind:  manifest.ApplicationKind,
+		ConsumerName:  "ops-bot",
+		ConsumerOwner: "ops_bot",
+		EnvName:       "CACHE_HOST",
+		TargetKind:    "resource",
+		TargetName:    "shared-cache",
+		TargetOutput:  "HOST",
+	}
+	msg := ee.Error()
+	want := `enrichment: app "ops-bot" env "CACHE_HOST" references resource "shared-cache.HOST" which is not owned by team "ops_bot"; add an explicit spec.dependencies entry (kind: Resource, name: shared-cache) to declare this dependency`
+	if msg != want {
+		t.Errorf("wrong format\n got: %s\nwant: %s", msg, want)
+	}
+	if !strings.Contains(msg, "ops-bot") {
+		t.Error("must mention consumer")
+	}
+}

--- a/internal/planner/enrich_valuefrom.go
+++ b/internal/planner/enrich_valuefrom.go
@@ -1,0 +1,178 @@
+package planner
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+)
+
+// valueFromRef is the parsed shape of `<kind>.<name>.<output>` env references.
+type valueFromRef struct {
+	Kind   string // "resource" | "application"
+	Name   string
+	Output string
+}
+
+// parseValueFromRef recognizes the `resource.<name>.<output>` and
+// `application.<name>.<output>` grammars. Returns (_, false) for vault refs,
+// literal values, malformed strings, or any string that does not split into
+// exactly three dot-separated non-empty parts with a known kind prefix.
+func parseValueFromRef(s string) (valueFromRef, bool) {
+	if s == "" {
+		return valueFromRef{}, false
+	}
+	if strings.HasPrefix(s, "vault:") {
+		return valueFromRef{}, false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return valueFromRef{}, false
+	}
+	if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return valueFromRef{}, false
+	}
+	if parts[0] != "resource" && parts[0] != "application" {
+		return valueFromRef{}, false
+	}
+	return valueFromRef{Kind: parts[0], Name: parts[1], Output: parts[2]}, true
+}
+
+// applyEnrichmentRule is the shared loop both production rules use. It
+// iterates Applications in sorted-by-name order; for each Application it scans
+// Spec.Env in declaration order, parses the valueFrom via parseFor, dedups
+// against the consumer's existing Spec.Dependencies on (Kind, Name), and
+// either fails fast on a cross-team / absent target or appends an inferred
+// edge plus the dependency to a cloned manifest.
+func applyEnrichmentRule(
+	set *ManifestSet,
+	targetKind string,
+	lookupOwner func(name string) (string, bool),
+	parseFor func(string) (valueFromRef, bool),
+) (*ManifestSet, []InferredEdge, error) {
+	out := copyManifestSetShallow(set)
+
+	names := make([]string, 0, len(out.Applications))
+	for name := range out.Applications {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var edges []InferredEdge
+	for _, name := range names {
+		app := out.Applications[name]
+		var extra []manifest.Dependency
+		seenInThisRule := make(map[string]struct{})
+		for _, env := range app.Spec.Env {
+			if env.ValueFrom == "" {
+				continue
+			}
+			ref, ok := parseFor(env.ValueFrom)
+			if !ok {
+				continue
+			}
+			// Explicit dep covers this reference — skip both inference and
+			// the fail-fast check.
+			if hasExplicitDependency(app.Spec.Dependencies, targetKind, ref.Name) {
+				continue
+			}
+			// Resolve same-team gate.
+			owner, exists := lookupOwner(ref.Name)
+			if !exists || owner != app.Metadata.Owner {
+				return nil, nil, &EnrichmentError{
+					Kind:          ErrCrossTeamOrUnresolvedValueFrom,
+					ConsumerKind:  manifest.ApplicationKind,
+					ConsumerName:  app.Metadata.Name,
+					ConsumerOwner: app.Metadata.Owner,
+					EnvName:       env.Name,
+					TargetKind:    ref.Kind,
+					TargetName:    ref.Name,
+					TargetOutput:  ref.Output,
+				}
+			}
+			// Dedup within this rule (multiple env vars referencing same target).
+			if _, dup := seenInThisRule[ref.Name]; dup {
+				continue
+			}
+			seenInThisRule[ref.Name] = struct{}{}
+			extra = append(extra, manifest.Dependency{
+				Kind:  targetKind,
+				Name:  ref.Name,
+				Owner: owner,
+			})
+			edges = append(edges, InferredEdge{
+				Consumer: ManifestRef{Kind: manifest.ApplicationKind, Name: app.Metadata.Name, Owner: app.Metadata.Owner},
+				Target:   ManifestRef{Kind: targetKind, Name: ref.Name, Owner: owner},
+				EnvVar:   env.Name,
+			})
+		}
+		if len(extra) > 0 {
+			out.Applications[name] = cloneApplicationWithDeps(app, extra)
+		}
+	}
+	return out, edges, nil
+}
+
+// lookupResourceOwner returns a closure resolving resource name → owner.
+func lookupResourceOwner(set *ManifestSet) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		res, ok := set.Resources[name]
+		if !ok {
+			return "", false
+		}
+		return res.Metadata.Owner, true
+	}
+}
+
+// lookupApplicationOwner returns a closure resolving app name → owner.
+func lookupApplicationOwner(set *ManifestSet) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		app, ok := set.Applications[name]
+		if !ok {
+			return "", false
+		}
+		return app.Metadata.Owner, true
+	}
+}
+
+// parseResourceRef filters to refs whose Kind is "resource".
+func parseResourceRef(s string) (valueFromRef, bool) {
+	ref, ok := parseValueFromRef(s)
+	if !ok || ref.Kind != "resource" {
+		return valueFromRef{}, false
+	}
+	return ref, true
+}
+
+// parseApplicationRef filters to refs whose Kind is "application".
+func parseApplicationRef(s string) (valueFromRef, bool) {
+	ref, ok := parseValueFromRef(s)
+	if !ok || ref.Kind != "application" {
+		return valueFromRef{}, false
+	}
+	return ref, true
+}
+
+// --- production rules ---
+
+type enrichValueFromResource struct{}
+
+func (enrichValueFromResource) Enrich(set *ManifestSet) (*ManifestSet, error) {
+	out, _, err := enrichValueFromResource{}.enrichWithEdges(set)
+	return out, err
+}
+
+func (enrichValueFromResource) enrichWithEdges(set *ManifestSet) (*ManifestSet, []InferredEdge, error) {
+	return applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+}
+
+type enrichValueFromApplication struct{}
+
+func (enrichValueFromApplication) Enrich(set *ManifestSet) (*ManifestSet, error) {
+	out, _, err := enrichValueFromApplication{}.enrichWithEdges(set)
+	return out, err
+}
+
+func (enrichValueFromApplication) enrichWithEdges(set *ManifestSet) (*ManifestSet, []InferredEdge, error) {
+	return applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)
+}

--- a/internal/planner/enrich_valuefrom_test.go
+++ b/internal/planner/enrich_valuefrom_test.go
@@ -1,0 +1,291 @@
+package planner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CarlosHPlata/shrine/internal/manifest"
+)
+
+func TestParseValueFromRef_ResourcePrefix(t *testing.T) {
+	ref, ok := parseValueFromRef("resource.db.HOST")
+	if !ok {
+		t.Fatal("expected ok=true for resource.db.HOST")
+	}
+	if ref.Kind != "resource" || ref.Name != "db" || ref.Output != "HOST" {
+		t.Errorf("unexpected parse: %+v", ref)
+	}
+}
+
+func TestParseValueFromRef_ApplicationPrefix(t *testing.T) {
+	ref, ok := parseValueFromRef("application.api.host")
+	if !ok {
+		t.Fatal("expected ok=true for application.api.host")
+	}
+	if ref.Kind != "application" || ref.Name != "api" || ref.Output != "host" {
+		t.Errorf("unexpected parse: %+v", ref)
+	}
+}
+
+func TestParseValueFromRef_RejectsVault(t *testing.T) {
+	if _, ok := parseValueFromRef("vault:proj/env/key"); ok {
+		t.Error("vault refs must return false")
+	}
+}
+
+func TestParseValueFromRef_RejectsEmpty(t *testing.T) {
+	if _, ok := parseValueFromRef(""); ok {
+		t.Error("empty string must return false")
+	}
+}
+
+func TestParseValueFromRef_RejectsTwoParts(t *testing.T) {
+	if _, ok := parseValueFromRef("resource.foo"); ok {
+		t.Error("two-part refs must return false")
+	}
+}
+
+func TestParseValueFromRef_RejectsEmptyMiddle(t *testing.T) {
+	if _, ok := parseValueFromRef("resource..output"); ok {
+		t.Error("empty middle must return false")
+	}
+}
+
+func TestParseValueFromRef_RejectsUnknownPrefix(t *testing.T) {
+	if _, ok := parseValueFromRef("secret.x.y"); ok {
+		t.Error("unknown prefix must return false")
+	}
+}
+
+// US1 unit tests for enrichValueFromResource.
+
+func ownerAppSet(t *testing.T) *ManifestSet {
+	t.Helper()
+	set := NewManifestSet()
+	set.Resources["db"] = &manifest.ResourceManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ResourceKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "db", Owner: "team-a"},
+		Spec: manifest.ResourceSpec{
+			Type:    "postgres",
+			Version: "16",
+			Outputs: []manifest.Output{{Name: "URL", Value: "v"}},
+		},
+	}
+	set.Applications["alpha"] = &manifest.ApplicationManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ApplicationKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "alpha", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Image: "nginx",
+			Env: []manifest.EnvVar{
+				{Name: "DB_URL", ValueFrom: "resource.db.URL"},
+			},
+		},
+	}
+	return set
+}
+
+func TestEnrichValueFromResource_AddsInferredEdge(t *testing.T) {
+	set := ownerAppSet(t)
+	out, edges, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 inferred edge, got %d", len(edges))
+	}
+	if edges[0].Consumer.Name != "alpha" || edges[0].Target.Name != "db" || edges[0].EnvVar != "DB_URL" {
+		t.Errorf("unexpected edge: %+v", edges[0])
+	}
+	app := out.Applications["alpha"]
+	if len(app.Spec.Dependencies) != 1 {
+		t.Fatalf("expected 1 dep, got %d", len(app.Spec.Dependencies))
+	}
+	if app.Spec.Dependencies[0].Kind != manifest.ResourceKind || app.Spec.Dependencies[0].Name != "db" {
+		t.Errorf("unexpected dep: %+v", app.Spec.Dependencies[0])
+	}
+	// Input set untouched.
+	if len(set.Applications["alpha"].Spec.Dependencies) != 0 {
+		t.Error("input set was mutated")
+	}
+}
+
+func TestEnrichValueFromResource_CrossTeamWithoutExplicitDep_Fails(t *testing.T) {
+	set := ownerAppSet(t)
+	set.Resources["db"].Metadata.Owner = "team-b"
+
+	_, _, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err == nil {
+		t.Fatal("expected error for cross-team ref")
+	}
+	var ee *EnrichmentError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *EnrichmentError, got %T: %v", err, err)
+	}
+	if ee.Kind != ErrCrossTeamOrUnresolvedValueFrom {
+		t.Errorf("unexpected kind: %q", ee.Kind)
+	}
+	if ee.ConsumerName != "alpha" || ee.EnvName != "DB_URL" || ee.TargetName != "db" {
+		t.Errorf("unexpected error fields: %+v", ee)
+	}
+}
+
+func TestEnrichValueFromResource_AbsentTargetWithoutExplicitDep_Fails(t *testing.T) {
+	set := ownerAppSet(t)
+	delete(set.Resources, "db")
+
+	_, _, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err == nil {
+		t.Fatal("expected error for absent target ref")
+	}
+	var ee *EnrichmentError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *EnrichmentError, got %T", err)
+	}
+}
+
+func TestEnrichValueFromResource_ExplicitDepShortCircuitsFailureAndDedups(t *testing.T) {
+	set := ownerAppSet(t)
+	set.Resources["db"].Metadata.Owner = "team-b" // would otherwise fail
+	set.Applications["alpha"].Spec.Dependencies = []manifest.Dependency{
+		{Kind: manifest.ResourceKind, Name: "db", Owner: "team-b"},
+	}
+
+	out, edges, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err != nil {
+		t.Fatalf("expected no error when explicit dep covers ref, got %v", err)
+	}
+	if len(edges) != 0 {
+		t.Fatalf("explicit dep must dedup — expected 0 inferred edges, got %d", len(edges))
+	}
+	// Original explicit entry preserved.
+	app := out.Applications["alpha"]
+	if len(app.Spec.Dependencies) != 1 || app.Spec.Dependencies[0].Owner != "team-b" {
+		t.Errorf("explicit owner field must be preserved verbatim: %+v", app.Spec.Dependencies)
+	}
+}
+
+func TestEnrichValueFromResource_IgnoresApplicationPrefix(t *testing.T) {
+	set := ownerAppSet(t)
+	set.Applications["alpha"].Spec.Env = []manifest.EnvVar{
+		{Name: "HOST", ValueFrom: "application.alpha.host"},
+	}
+	_, edges, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("resource rule must ignore application.* refs, got edges: %+v", edges)
+	}
+}
+
+func TestEnrichValueFromResource_SkipsVaultAndLiteral(t *testing.T) {
+	set := ownerAppSet(t)
+	set.Applications["alpha"].Spec.Env = []manifest.EnvVar{
+		{Name: "S", ValueFrom: "vault:proj/env/key"},
+		{Name: "L", Value: "literal"},
+	}
+	_, edges, err := applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("vault/literal env vars must be skipped: %+v", edges)
+	}
+}
+
+// US2 unit tests for enrichValueFromApplication.
+
+func appAppSet(t *testing.T) *ManifestSet {
+	t.Helper()
+	set := NewManifestSet()
+	set.Applications["producer"] = &manifest.ApplicationManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ApplicationKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "producer", Owner: "team-a"},
+		Spec:     manifest.ApplicationSpec{Image: "nginx"},
+	}
+	set.Applications["consumer"] = &manifest.ApplicationManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ApplicationKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "consumer", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Image: "nginx",
+			Env: []manifest.EnvVar{
+				{Name: "PROD_HOST", ValueFrom: "application.producer.host"},
+			},
+		},
+	}
+	return set
+}
+
+func TestEnrichValueFromApplication_AddsInferredEdge(t *testing.T) {
+	set := appAppSet(t)
+	out, edges, err := applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 inferred edge, got %d", len(edges))
+	}
+	if edges[0].Consumer.Name != "consumer" || edges[0].Target.Name != "producer" {
+		t.Errorf("unexpected edge: %+v", edges[0])
+	}
+	app := out.Applications["consumer"]
+	if len(app.Spec.Dependencies) != 1 || app.Spec.Dependencies[0].Kind != manifest.ApplicationKind {
+		t.Errorf("unexpected dep: %+v", app.Spec.Dependencies)
+	}
+}
+
+func TestEnrichValueFromApplication_CrossTeamWithoutExplicitDep_Fails(t *testing.T) {
+	set := appAppSet(t)
+	set.Applications["producer"].Metadata.Owner = "team-b"
+
+	_, _, err := applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)
+	if err == nil {
+		t.Fatal("expected error for cross-team ref")
+	}
+	var ee *EnrichmentError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *EnrichmentError, got %T", err)
+	}
+	if ee.TargetName != "producer" {
+		t.Errorf("unexpected target name: %q", ee.TargetName)
+	}
+}
+
+func TestEnrichValueFromApplication_AbsentTargetWithoutExplicitDep_Fails(t *testing.T) {
+	set := appAppSet(t)
+	delete(set.Applications, "producer")
+
+	_, _, err := applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)
+	if err == nil {
+		t.Fatal("expected error for absent app target")
+	}
+}
+
+func TestEnrichValueFromApplication_ExplicitDepShortCircuits(t *testing.T) {
+	set := appAppSet(t)
+	set.Applications["producer"].Metadata.Owner = "team-b"
+	set.Applications["consumer"].Spec.Dependencies = []manifest.Dependency{
+		{Kind: manifest.ApplicationKind, Name: "producer", Owner: "team-b"},
+	}
+	_, edges, err := applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)
+	if err != nil {
+		t.Fatalf("explicit dep must short-circuit failure, got %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("dedup against explicit must skip inferred edge: %+v", edges)
+	}
+}
+
+func TestEnrichValueFromApplication_IgnoresResourcePrefix(t *testing.T) {
+	set := appAppSet(t)
+	set.Applications["consumer"].Spec.Env = []manifest.EnvVar{
+		{Name: "X", ValueFrom: "resource.something.URL"},
+	}
+	_, edges, err := applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("application rule must ignore resource.* refs, got edges: %+v", edges)
+	}
+}

--- a/internal/planner/plan.go
+++ b/internal/planner/plan.go
@@ -13,6 +13,10 @@ type PlanResult struct {
 	ManifestSet   *ManifestSet
 	Error         error
 	ValidationErr []error
+	// InferredEdges carries per-rule provenance for inferred deploy-order
+	// edges added by enrichment. Populated on the success path only; nil on
+	// validation failure or enrichment failure.
+	InferredEdges []InferredEdge
 }
 
 type PlanTeardownResult struct {
@@ -34,6 +38,12 @@ func Plan(set *ManifestSet, store state.TeamStore, registries []config.RegistryC
 		return PlanResult{ValidationErr: errs}
 	}
 
+	enriched, edges, err := ChainEnrich(set, DefaultEnrichers()...)
+	if err != nil {
+		return PlanResult{Error: err}
+	}
+	set = enriched
+
 	switch filter.Kind {
 	case FilterNone, FilterTeam:
 		if err := DetectRoutingCollisions(set); err != nil {
@@ -46,18 +56,20 @@ func Plan(set *ManifestSet, store state.TeamStore, registries []config.RegistryC
 		if filter.Kind == FilterTeam {
 			steps = filterStepsByOwner(steps, set, filter.Name)
 		}
-		return PlanResult{Steps: steps, ManifestSet: set}
+		return PlanResult{Steps: steps, ManifestSet: set, InferredEdges: edges}
 
 	case FilterApp:
 		return PlanResult{
-			Steps:       []PlannedStep{{Kind: manifest.ApplicationKind, Name: filter.Name}},
-			ManifestSet: set,
+			Steps:         []PlannedStep{{Kind: manifest.ApplicationKind, Name: filter.Name}},
+			ManifestSet:   set,
+			InferredEdges: edges,
 		}
 
 	case FilterRes:
 		return PlanResult{
-			Steps:       []PlannedStep{{Kind: manifest.ResourceKind, Name: filter.Name}},
-			ManifestSet: set,
+			Steps:         []PlannedStep{{Kind: manifest.ResourceKind, Name: filter.Name}},
+			ManifestSet:   set,
+			InferredEdges: edges,
 		}
 	}
 

--- a/internal/planner/plan_test.go
+++ b/internal/planner/plan_test.go
@@ -1,6 +1,8 @@
 package planner
 
 import (
+	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -61,8 +63,11 @@ func TestPlan_NoFilter_EmitsAllSteps(t *testing.T) {
 	if len(result.Steps) != 4 {
 		t.Errorf("expected 4 steps (2 apps + 2 resources), got %d: %+v", len(result.Steps), result.Steps)
 	}
-	if result.ManifestSet != set {
-		t.Error("ManifestSet should be returned unchanged")
+	// Post-enrichment, ManifestSet is a shallow copy with pointer-shared
+	// values; assert content equivalence rather than pointer identity.
+	if len(result.ManifestSet.Applications) != len(set.Applications) ||
+		len(result.ManifestSet.Resources) != len(set.Resources) {
+		t.Error("ManifestSet content should match input set")
 	}
 }
 
@@ -141,6 +146,97 @@ func TestPlan_ByApp_Missing_ReturnsError(t *testing.T) {
 	if !strings.Contains(result.Error.Error(), "nope") {
 		t.Errorf("error should name missing app, got: %v", result.Error)
 	}
+}
+
+// inferenceSet returns a set where alpha has a same-team valueFrom that
+// will yield an inferred edge and a cross-team-ish setup for failure cases.
+func inferenceSet(t *testing.T) *ManifestSet {
+	t.Helper()
+	set := NewManifestSet()
+	set.Resources["db"] = &manifest.ResourceManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ResourceKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "db", Owner: "team-a"},
+		Spec: manifest.ResourceSpec{
+			Type: "postgres", Version: "16",
+			Outputs: []manifest.Output{{Name: "URL", Value: "v"}},
+		},
+	}
+	set.Applications["alpha"] = &manifest.ApplicationManifest{
+		TypeMeta: manifest.TypeMeta{Kind: manifest.ApplicationKind, APIVersion: "shrine/v1"},
+		Metadata: manifest.Metadata{Name: "alpha", Owner: "team-a"},
+		Spec: manifest.ApplicationSpec{
+			Image: "nginx",
+			Env:   []manifest.EnvVar{{Name: "DB_URL", ValueFrom: "resource.db.URL"}},
+		},
+	}
+	return set
+}
+
+// crossTeamFailureSet triggers an *EnrichmentError on Plan().
+func crossTeamFailureSet(t *testing.T) *ManifestSet {
+	t.Helper()
+	set := inferenceSet(t)
+	set.Resources["db"].Metadata.Owner = "team-b" // becomes cross-team
+	return set
+}
+
+func TestPlan_DoesNotWriteToDisk(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	before, err := os.Stat(cwd)
+	if err != nil {
+		t.Fatalf("stat cwd: %v", err)
+	}
+
+	// Success path.
+	_ = Plan(inferenceSet(t), stubTeamStore{}, nil, NoFilter())
+	// Failure path.
+	_ = Plan(crossTeamFailureSet(t), stubTeamStore{}, nil, NoFilter())
+
+	after, err := os.Stat(cwd)
+	if err != nil {
+		t.Fatalf("stat cwd: %v", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("Plan() must not modify the working directory; mtime changed: %v → %v",
+			before.ModTime(), after.ModTime())
+	}
+}
+
+func TestPlan_DoesNotMutateInputSet(t *testing.T) {
+	check := func(label string, set *ManifestSet, runPlan func()) {
+		snap := make(map[string][]manifest.Dependency, len(set.Applications))
+		for name, app := range set.Applications {
+			if app.Spec.Dependencies == nil {
+				snap[name] = nil
+				continue
+			}
+			cp := make([]manifest.Dependency, len(app.Spec.Dependencies))
+			copy(cp, app.Spec.Dependencies)
+			snap[name] = cp
+		}
+		runPlan()
+		for name, app := range set.Applications {
+			if !reflect.DeepEqual(snap[name], app.Spec.Dependencies) {
+				t.Errorf("%s: Plan mutated app %q Spec.Dependencies\nbefore: %+v\nafter:  %+v",
+					label, name, snap[name], app.Spec.Dependencies)
+			}
+		}
+	}
+
+	// Success path.
+	successSet := inferenceSet(t)
+	check("success", successSet, func() {
+		_ = Plan(successSet, stubTeamStore{}, nil, NoFilter())
+	})
+
+	// Failure path.
+	failSet := crossTeamFailureSet(t)
+	check("failure", failSet, func() {
+		_ = Plan(failSet, stubTeamStore{}, nil, NoFilter())
+	})
 }
 
 // TestPlan_ByTeam_CrossTeamDepResolution proves that even when a team-scoped

--- a/internal/planner/resolve.go
+++ b/internal/planner/resolve.go
@@ -274,8 +274,9 @@ func validateValueFrom(set *ManifestSet, app *manifest.ApplicationManifest) []er
 		case "resource":
 			res, exists := set.Resources[name]
 			if !exists {
-				errs = append(errs, fmt.Errorf("app %q: env %q references missing resource %q",
-					app.Metadata.Name, env.Name, name))
+				// Absent target is handled by the enrichment layer (FR-010, Q2):
+				// it raises the typed EnrichmentError unless an explicit
+				// spec.dependencies entry covers the reference. Skip here.
 				continue
 			}
 
@@ -294,8 +295,7 @@ func validateValueFrom(set *ManifestSet, app *manifest.ApplicationManifest) []er
 		case "application":
 			_, exists := set.Applications[name]
 			if !exists {
-				errs = append(errs, fmt.Errorf("app %q: env %q references missing application %q",
-					app.Metadata.Name, env.Name, name))
+				// Same reasoning as the resource branch above.
 				continue
 			}
 			if output != "host" && output != "port" {

--- a/internal/planner/resolve_test.go
+++ b/internal/planner/resolve_test.go
@@ -256,13 +256,14 @@ func TestResolve(t *testing.T) {
 
 		errs := Resolve(set, store, nil)
 
+		// Absent-target cases (MISSING_RES, MISSING_APP) are no longer reported
+		// by Resolve — enrichment owns those and emits *EnrichmentError instead
+		// (FR-010, Q2). Resolve still flags format errors and bad-output refs.
 		expectedErrors := []string{
 			"invalid valueFrom format \"resource.db1\"",
 			"invalid valueFrom format \"config.db1.url\"",
-			"references missing resource \"db2\"",
 			"references non-existent output \"host\" on resource \"db1\"",
 			"application \"worker\" has no built-in output \"url\" (only host and port are supported)",
-			"references missing application \"ghost\"",
 		}
 
 		for _, expected := range expectedErrors {

--- a/specs/020-infer-valuefrom-deps/checklists/requirements.md
+++ b/specs/020-infer-valuefrom-deps/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Infer Implicit Deploy-Order Dependencies from Same-Owner valueFrom References
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All quality items pass on first pass. The spec describes operator-visible behaviour and observable outcomes; the words "decorator", "chain", "in-memory struct", and similar implementation cues from the input were translated to user-facing rules (FR-007 talks about composable units of inference; FR-004/FR-005 talk about the absence of YAML mutation and immutability of inputs, not Go semantics).
+- Spec is ready for `/speckit-clarify` or `/speckit-plan`.

--- a/specs/020-infer-valuefrom-deps/contracts/enrichment-api.md
+++ b/specs/020-infer-valuefrom-deps/contracts/enrichment-api.md
@@ -1,0 +1,342 @@
+# Contract: Enrichment API & Operator-Visible Output
+
+**Feature**: `020-infer-valuefrom-deps` | **Phase**: 1 (Design)
+**Scope**: Internal Go API contract within `internal/planner` + the
+operator-visible output contract for dry-run and deploy.
+
+This project ships a single binary; the relevant "external" contracts
+are (a) the planner's package-public API consumed by `internal/handler`
+and (b) the operator-visible stdout/stderr produced by `shrine deploy`
+and `shrine deploy --dry-run`. There are no HTTP, RPC, or wire-format
+contracts to record.
+
+---
+
+## 1. Planner package API
+
+### `planner.ChainEnrich`
+
+```go
+// ChainEnrich applies the given Enrichers in order to a shallow copy
+// of set, returning the enriched copy along with the inferred-edge
+// provenance.
+//
+// The input set is observably unmodified after this call returns,
+// regardless of success or failure:
+//   - set.Applications and set.Resources map headers are the same
+//   - every *manifest.ApplicationManifest reachable through the input
+//     set has the same Spec.Dependencies length and contents as before.
+//
+// Rules in the chain operate on the previous rule's output, so an
+// Application enriched by rule R[i] is observed by rule R[i+1] with the
+// added edges already present in its Spec.Dependencies — this is how
+// cross-rule dedup is achieved.
+//
+// Error handling (fail-fast, FR-010):
+//   - If any rule returns a non-nil error (in practice an
+//     *EnrichmentError), ChainEnrich stops and returns
+//     (nil, nil, err). Subsequent rules are not invoked and
+//     subsequent offending references in the same run are not
+//     enumerated.
+//   - Determinism: for a given input set and rule chain, the same
+//     first error is produced on every run (sorted iteration order,
+//     Decision 8).
+//
+// On success, ChainEnrich is idempotent: ChainEnrich(out, rules...)
+// where out is the output of a previous ChainEnrich on the same rules
+// produces a set with identical dependency edges and an identical
+// (possibly empty) []InferredEdge.
+//
+// ChainEnrich never writes to disk and never invokes user-provided
+// callbacks; it is a pure function of set and rules.
+func ChainEnrich(
+    set *ManifestSet,
+    rules ...Enricher,
+) (enriched *ManifestSet, edges []InferredEdge, err error)
+```
+
+**Errors**: On success, `err == nil`. On failure, `err` is a
+`*EnrichmentError` with `Kind == ErrCrossTeamOrUnresolvedValueFrom`
+and structured fields naming the offending reference. Callers can
+extract the typed error via `errors.As(err, &target)` for structured
+inspection in tests; handlers can simply call `err.Error()` for the
+operator-facing message.
+
+### `planner.DefaultEnrichers`
+
+```go
+// DefaultEnrichers returns the production rule chain in deterministic
+// order. Callers (in particular planner.Plan) should pass the returned
+// slice verbatim into ChainEnrich.
+//
+// The chain is, in order:
+//   1. enrichValueFromResource — for valueFrom: resource.<name>.<output>
+//   2. enrichValueFromApplication — for valueFrom: application.<name>.<output>
+//
+// Tests MAY construct alternative chains for isolation.
+func DefaultEnrichers() []Enricher
+```
+
+### `planner.Plan` — extended contract
+
+The signature is unchanged:
+
+```go
+func Plan(set *ManifestSet, store state.TeamStore, registries []config.RegistryConfig, filter Filter) PlanResult
+```
+
+The contract is extended:
+
+- On success, `PlanResult.ManifestSet` holds the **enriched** set,
+  not the loaded one. Callers that need to inspect the enriched
+  dependency graph (e.g., for the dry-run summary) MUST use this field.
+  `PlanResult.InferredEdges` carries the provenance list for the
+  dry-run renderer.
+- On enrichment failure, `PlanResult.Error` is a `*EnrichmentError`,
+  `PlanResult.Steps == nil`, `PlanResult.ManifestSet == nil`, and
+  `PlanResult.InferredEdges == nil`. Handlers detect this with the
+  existing `if result.Error != nil` branch.
+- The input `*ManifestSet` value remains usable after `Plan()` returns
+  in both the success and failure paths.
+
+### `Enricher` (interface contract)
+
+```go
+// Enricher.Enrich(set) MUST:
+//   - return a *ManifestSet (possibly the input pointer if no changes)
+//     when err == nil
+//   - return (nil, err) where err is typically a *EnrichmentError on
+//     failure
+//   - never mutate the input set or any manifest reachable from it
+//   - process Applications in deterministic order (sorted by
+//     metadata.name) so that the first error reported on failure is
+//     stable across runs
+//
+// Enricher implementations MUST NOT perform I/O, call external
+// services, or read filesystem state. They are pure functions of the
+// input set.
+type Enricher interface {
+    Enrich(set *ManifestSet) (*ManifestSet, error)
+}
+```
+
+(`InferredEdge` provenance flows through a separate channel inside
+`ChainEnrich`; see the package-private `inferredEdges` accumulator.
+External implementers should not need to surface provenance directly —
+the rule helper exposes it.)
+
+### `planner.EnrichmentError`
+
+```go
+// EnrichmentError is the typed error returned by enrichment when a
+// valueFrom reference cannot be resolved to a same-team manifest in
+// the loaded set and the consumer has no explicit Spec.Dependencies
+// entry covering it.
+type EnrichmentError struct {
+    Kind          EnrichmentErrorKind
+    ConsumerKind  string
+    ConsumerName  string
+    ConsumerOwner string
+    EnvName       string
+    TargetKind    string
+    TargetName    string
+    TargetOutput  string
+}
+
+func (e *EnrichmentError) Error() string
+
+type EnrichmentErrorKind string
+const ErrCrossTeamOrUnresolvedValueFrom EnrichmentErrorKind = "cross-team-or-unresolved-valuefrom"
+```
+
+The `Error()` format is part of this contract (see §2.1 below).
+
+---
+
+## 2. Operator-visible output contract
+
+### 2.1 Cross-team / unresolved `valueFrom` failure (FR-010)
+
+**Where**: `ErrOut` of the calling command (stderr).
+
+**When**: For every `valueFrom: resource.<name>.<output>` or
+`valueFrom: application.<name>.<output>` reference where the target
+cannot be resolved to a same-team manifest in the current
+`ManifestSet` AND the consumer Application has no explicit
+`Spec.Dependencies` entry matching the reference under the
+`(Kind, Name)` dedup key. "Cannot be resolved to same-team" covers:
+- target manifest present but owned by a different team; OR
+- target manifest absent from the loaded set entirely.
+
+Fail-fast: the planner stops at the first such reference. The error
+is printed once; subsequent offending references in the same run are
+not enumerated.
+
+**Format** (single line, plus the standard handler exit on error):
+
+```
+enrichment: app "<consumer>" env "<NAME>" references <kind> "<target>.<output>" which is not owned by team "<consumer-owner>"; add an explicit spec.dependencies entry (kind: <Kind>, name: <target>) to declare this dependency
+```
+
+**Example**:
+
+```
+enrichment: app "ops-bot" env "CACHE_HOST" references resource "shared-cache.HOST" which is not owned by team "ops_bot"; add an explicit spec.dependencies entry (kind: Resource, name: shared-cache) to declare this dependency
+```
+
+**Exit code**: Non-zero (the existing planner-error path on the
+handler). No deploy steps run; no Docker calls are made.
+
+### 2.2 Dry-run plan-summary header
+
+**Where**: `Out` of the dry-run command (stdout).
+
+**When**: `handler.DryRun` invocations only, on the success path
+(enrichment did not fail). The non-dry-run `handler.Deploy` does not
+print the summary. If enrichment failed, the §2.1 error is printed to
+stderr and no summary is rendered.
+
+**Format**:
+
+```
+Deploy order:
+  1. <Kind>:<Name>
+  2. <Kind>:<Name>
+       depends on:
+         - <Kind>:<Name>
+         - <Kind>:<Name> (inferred from env <ENV_VAR_NAME>)
+```
+
+**Rules**:
+- The header line `Deploy order:` is fixed text.
+- Each step is `  <ordinal>. <Kind>:<Name>` (1-based ordinal, two-space
+  indent, padded ordinal not required because homelab plans are short).
+- Steps with no dependencies emit no `depends on:` block.
+- Within a step's `depends on:` block, dependencies are listed in the
+  order they appear in the Application's (enriched) `Spec.Dependencies`.
+- Explicit dependencies have no provenance tag.
+- Inferred dependencies are tagged `(inferred from env <NAME>)` where
+  `<NAME>` is the originating env var. When the same target is referenced
+  by multiple env vars, the first one in declaration order is used.
+
+**Example**:
+
+```
+Deploy order:
+  1. Resource:ops-bot-db
+  2. Application:ops-bot
+       depends on:
+         - Resource:ops-bot-db (inferred from env DB_CONNECTION_URL)
+```
+
+After the summary header, the existing `[DOCKER] …` lines from the
+dry-run engine continue as today, unchanged.
+
+### 2.3 Apply-single carve-out
+
+The `handler.ApplySingle` path (powering `shrine apply -f`) is **not**
+required to print the plan-summary header — it operates on one
+manifest at a time and its output is already minimal. However, the
+FR-010 failure rule applies uniformly across all planner entry points,
+so a cross-team or unresolved `valueFrom` on the single manifest still
+fails the apply with the §2.1 error.
+
+---
+
+## 3. Behavioral guarantees (contract assertions)
+
+These are the assertions that integration and unit tests pin in place.
+
+### 3.1 Ordering guarantee (SC-001, SC-008)
+
+For any input `*ManifestSet` containing:
+- an `Application` *A* with `metadata.owner == "team-x"` and an env var with
+  `valueFrom: resource.R.<output>`, no explicit deps;
+- a `Resource` *R* with `metadata.owner == "team-x"` and an output `<output>`,
+
+`planner.Plan(set, …, ByTeam("team-x"))` returns
+`PlanResult{Steps, Error: nil}` in which `Resource:R` appears strictly
+before `Application:A` in `Steps`.
+
+### 3.2 No-mutation guarantee (SC-006, SC-007)
+
+For the same input, after `planner.Plan(set, …, filter)` returns,
+`len(set.Applications[A.Name].Spec.Dependencies) == 0` (the input
+Application is untouched). The enriched edge is visible only on
+`result.ManifestSet.Applications[A.Name].Spec.Dependencies`. This
+holds in both the success and failure paths.
+
+### 3.3 No-disk-write guarantee (SC-006)
+
+Running `planner.Plan` against any in-memory `ManifestSet` does not
+open any file for write. (Validated via a unit test that wraps the
+test's working directory and asserts no `WRITE` syscalls; in practice,
+the assertion is "no test-side `os.WriteFile`/`os.Create` calls in the
+planner package", combined with a code-review check that no new file-
+writing import was added.)
+
+### 3.4 Cross-team / unresolved failure guarantee (SC-003, FR-010)
+
+For any `valueFrom: resource.<X>.<Y>` or `valueFrom:
+application.<X>.<Y>` reference on a consumer Application where:
+- no manifest of the matching kind named `<X>` with
+  `metadata.owner == consumer.Metadata.Owner` exists in the loaded set,
+  AND
+- the consumer's `Spec.Dependencies` contains no entry matching
+  `(targetKind, X)`,
+
+`planner.Plan(set, …, filter)` returns `PlanResult{Error:
+&EnrichmentError{Kind: ErrCrossTeamOrUnresolvedValueFrom, …}}` with
+`Steps == nil` and `ManifestSet == nil`. `handler.Deploy` /
+`handler.DryRun` print exactly one corresponding `enrichment: …` line
+to `ErrOut` and exit non-zero.
+
+### 3.5 Explicit-dep-satisfies-cross-team guarantee (FR-010 second clause, US3 acceptance scenario 2)
+
+For the same setup as 3.4 except the consumer's `Spec.Dependencies`
+contains an entry with `Kind == targetKind` and `Name == X`,
+`planner.Plan` does NOT raise an `*EnrichmentError` for that
+reference; the explicit entry satisfies the requirement and planning
+proceeds to ordering.
+
+### 3.6 Provenance-tagging guarantee (SC-004)
+
+For any inferred edge, the dry-run plan summary's line for that edge
+ends with ` (inferred from env <NAME>)`. For any explicit edge
+(including one that covers a cross-team reference per 3.5), the line
+does NOT end with such a tag. An automated test parses the summary and
+asserts the partition.
+
+### 3.7 Determinism in both paths (FR-013, SC-005)
+
+For a given input `*ManifestSet` and rule chain:
+- Success path: repeated calls produce identical `Steps` order,
+  identical `InferredEdges` slices (byte-for-byte).
+- Failure path: repeated calls produce an `*EnrichmentError` with the
+  same `Kind`, same `ConsumerName`, same `EnvName`, same `TargetName`,
+  same `TargetKind` — i.e., the same offending reference is reported
+  first.
+
+---
+
+## 4. What this contract does NOT promise
+
+- **Detection of unreachable inferred edges via cycles**: if a
+  same-team `valueFrom` references a target that participates in a
+  cycle via other edges, the existing topological sort raises a cycle
+  error (unchanged behavior). Enrichment does not pre-check or
+  rephrase cycle errors.
+- **Cross-team auto-inference**: never. Cross-team coupling is always
+  an operator decision and now requires an explicit
+  `spec.dependencies` entry on pain of planner failure.
+- **Persisted inferred edges**: inferred edges live only in memory.
+  They are never written to YAML, to the state store, or to the
+  deployment record (FR-004, Assumption 6 in the spec).
+- **Other env input shapes**: only `valueFrom: resource.<name>.<output>`
+  and `valueFrom: application.<name>.<output>` are recognized at
+  landing. Future shapes (vault refs, templates) would require new
+  rules in a follow-up. `valueFrom: vault:…` and literal `value:` are
+  silently skipped and do NOT trigger the §2.1 failure.
+- **Collected (multi-error) reporting**: enrichment is fail-fast; only
+  the first offending reference is reported per run. Operators fix
+  issues one at a time across successive planner invocations.

--- a/specs/020-infer-valuefrom-deps/data-model.md
+++ b/specs/020-infer-valuefrom-deps/data-model.md
@@ -1,0 +1,362 @@
+# Data Model: Enrichment Layer
+
+**Feature**: `020-infer-valuefrom-deps` | **Phase**: 1 (Design)
+**Date**: 2026-05-20
+
+This document specifies the internal types introduced by this feature
+and how they relate to existing planner types. No persistent data model
+changes (no YAML schema additions, no state-store keys).
+
+---
+
+## New types
+
+### `Enricher` (interface)
+
+```go
+// Enricher transforms a ManifestSet into an enriched copy by adding
+// inferred deploy-order dependencies according to its own rule.
+// Implementations MUST NOT mutate the input set or any manifest within it.
+//
+// Enrich returns a non-nil error when the rule encounters a valueFrom
+// reference that does not resolve to a same-team manifest in the loaded
+// set and is not already covered by an explicit Spec.Dependencies entry
+// on the consumer. The chain stops at the first such error (fail-fast).
+type Enricher interface {
+    Enrich(set *ManifestSet) (*ManifestSet, error)
+}
+```
+
+- One method, pure function shape.
+- Defined in `internal/planner/enrich.go`.
+- Implementations live in sibling files (e.g., `enrich_valuefrom.go`)
+  so a new rule never requires editing an existing rule's file (FR-007).
+
+### `EnrichmentError`
+
+```go
+// EnrichmentError is the typed error returned by an Enricher when a
+// valueFrom reference cannot be enriched and is not covered by an
+// explicit Spec.Dependencies entry. It implements the error interface.
+//
+// EnrichmentError carries the structured fields needed for tests to
+// assert on the offending reference without parsing the rendered
+// message, and for handlers to render a clear stderr line.
+type EnrichmentError struct {
+    Kind          EnrichmentErrorKind
+    ConsumerKind  string // manifest.ApplicationKind
+    ConsumerName  string // consumer Application's metadata.name
+    ConsumerOwner string // consumer Application's metadata.owner
+    EnvName       string // env var on the consumer that triggered the failure
+    TargetKind    string // "resource" | "application" (from the valueFrom prefix)
+    TargetName    string // <name> from valueFrom: <kind>.<name>.<output>
+    TargetOutput  string // <output> from valueFrom: <kind>.<name>.<output>
+}
+
+func (e *EnrichmentError) Error() string
+
+type EnrichmentErrorKind string
+const ErrCrossTeamOrUnresolvedValueFrom EnrichmentErrorKind = "cross-team-or-unresolved-valuefrom"
+```
+
+- `Kind` is a stable identifier tests can assert on via
+  `errors.As(err, &target)`.
+- `Error()` renders a single-line message of the form:
+  `enrichment: app "<consumer>" env "<NAME>" references <kind> "<target>.<output>" which is not owned by team "<consumer-owner>"; add an explicit spec.dependencies entry (kind: <Kind>, name: <target>) to declare this dependency`
+- Only one kind exists at landing; `EnrichmentErrorKind` is defined as
+  a string type so future kinds can be added without breaking existing
+  matchers.
+
+### `InferredEdge`
+
+```go
+// InferredEdge records one inferred dependency edge for dry-run provenance.
+// The planner emits these; the dry-run handler renders them with the
+// "(inferred from env <NAME>)" tag.
+type InferredEdge struct {
+    Consumer ManifestRef // the Application that gained the edge
+    Target   ManifestRef // the Resource or Application it now depends on
+    EnvVar   string      // originating env var name on Consumer
+}
+```
+
+- When multiple env vars on the same Application reference the same
+  target, only one `InferredEdge` is emitted; `EnvVar` is the first one
+  in declaration order (stable across runs — FR-013).
+- Only emitted in the success path; on enrichment failure, the
+  planner returns `Steps == nil` and `InferredEdges == nil`.
+
+### `ManifestRef`
+
+```go
+// ManifestRef identifies a target manifest in the current set.
+type ManifestRef struct {
+    Kind  string // manifest.ApplicationKind or manifest.ResourceKind
+    Name  string
+    Owner string
+}
+```
+
+- Defined in `internal/planner/enrich.go`.
+- Mirrors the existing `manifest.Dependency` shape but lives in the
+  planner package because it is internal to enrichment bookkeeping;
+  the on-disk schema uses `manifest.Dependency`.
+
+---
+
+## Modified types
+
+### `PlanResult` (`internal/planner/plan.go`)
+
+```go
+type PlanResult struct {
+    Steps         []PlannedStep
+    ManifestSet   *ManifestSet    // already present — now holds the ENRICHED set on success
+    Error         error           // already present — now also carries *EnrichmentError on enrichment failure
+    ValidationErr []error
+    InferredEdges []InferredEdge  // NEW — populated by enrichment in the success path
+}
+```
+
+- The existing `ManifestSet` field's contract changes subtly: callers
+  receive the **post-enrichment** set on success. Existing callers
+  (`handler.Deploy`, `handler.DryRun`, `handler.ApplySingle`) all
+  pass `result.ManifestSet` straight into the engine; they never
+  compare it against the original. The enrichment is intentionally
+  invisible to them aside from the new edges on Application manifests
+  they did not write — which is exactly the desired effect.
+- On enrichment failure: `Steps == nil`, `ManifestSet == nil`,
+  `InferredEdges == nil`, and `Error` is a `*EnrichmentError`. Handlers
+  detect this with the same `if result.Error != nil` branch they
+  already use for validation errors.
+- No `Notices` field is introduced — the previous "nudge" channel has
+  been removed in favour of fail-fast errors.
+
+---
+
+## Helper functions
+
+All defined in `internal/planner/enrich.go` unless noted.
+
+### `ChainEnrich`
+
+```go
+func ChainEnrich(set *ManifestSet, rules ...Enricher) (*ManifestSet, []InferredEdge, error)
+```
+
+- Threads the set through each rule. After each rule, the set returned
+  by that rule becomes the input to the next.
+- Stops at the first error from any rule and returns
+  `(nil, nil, err)` unchanged. Subsequent rules are not invoked.
+- Aggregates `[]InferredEdge` across rules in deterministic order
+  (the order each rule produces them, which is itself deterministic
+  per Decision 8).
+- Idempotent on the success path: `ChainEnrich(set, R)` followed by
+  `ChainEnrich(setOut, R)` yields a set whose dependency edges are
+  identical to `setOut`'s (SC-005). On the failure path, a re-run on
+  the same input produces the same first `*EnrichmentError` (SC-005,
+  FR-013).
+
+### `DefaultEnrichers`
+
+```go
+func DefaultEnrichers() []Enricher
+```
+
+- Returns the production rule chain in deterministic order:
+  1. `enrichValueFromResource{}`
+  2. `enrichValueFromApplication{}`
+- Tests may supply their own chains. Plan() always uses `DefaultEnrichers()`.
+
+### `copyManifestSetShallow`
+
+```go
+func copyManifestSetShallow(set *ManifestSet) *ManifestSet
+```
+
+- Allocates a new `*ManifestSet` and copies the `Applications` and
+  `Resources` maps' entries by reference. Each map header is fresh; the
+  pointer values inside are shared with the input.
+- Called once by `ChainEnrich` before the first rule runs. Rules
+  receive the shallow copy and replace map entries by pointer when
+  they need to enrich an Application.
+
+### `cloneApplicationWithDeps`
+
+```go
+func cloneApplicationWithDeps(
+    app *manifest.ApplicationManifest,
+    extra []manifest.Dependency,
+) *manifest.ApplicationManifest
+```
+
+- Returns a new Application whose `Spec.Dependencies` is
+  `append(copyOf(app.Spec.Dependencies), extra...)`. All other fields
+  share their values with the input — slice headers in `Spec.Env`,
+  `Spec.Volumes`, etc. are pointer-shared (they are immutable from the
+  planner's view).
+- Used by rule helpers when they have decided to enrich an Application.
+- If `len(extra) == 0`, returns `app` unchanged (no-op — preserves
+  pointer equality for the common case).
+
+### `hasExplicitDependency`
+
+```go
+func hasExplicitDependency(deps []manifest.Dependency, kind, name string) bool
+```
+
+- Returns true if any entry in `deps` matches `(kind, name)`. Used by
+  rule code to both dedup inferred edges against existing explicit ones
+  AND to skip the FR-010 failure when an explicit entry already covers
+  a cross-team reference.
+
+---
+
+## Rule-internal types (in `enrich_valuefrom.go`)
+
+### `valueFromRef` (private)
+
+```go
+type valueFromRef struct {
+    Kind   string // "resource" | "application"
+    Name   string
+    Output string
+}
+
+func parseValueFromRef(s string) (valueFromRef, bool)
+```
+
+- Returns `(_, false)` for `vault:…` strings, literal values, malformed
+  strings, and any string that does not split into exactly three dot-
+  separated non-empty parts with a known kind prefix. Rules that
+  recognize only one prefix (resource OR application) further filter
+  by `Kind`.
+- A `false` return is the rule's signal to skip the env var silently
+  (per FR-011) — vault and literal values never trigger the FR-010
+  failure.
+- Used by both `enrichValueFromResource` and `enrichValueFromApplication`.
+
+### `applyEnrichmentRule` (private helper)
+
+```go
+func applyEnrichmentRule(
+    set *ManifestSet,
+    targetKind string,                              // "Resource" or "Application"
+    lookupOwner func(name string) (owner string, exists bool),
+    parseFor   func(string) (valueFromRef, bool),
+) (*ManifestSet, []InferredEdge, error)
+```
+
+- Encapsulates the shared loop:
+  1. Iterate Applications in sorted name order (Decision 8).
+  2. For each Application, scan `Spec.Env` in declaration order.
+  3. Call `parseFor(env.ValueFrom)`. If `false`, skip the env var.
+  4. Filter parsed refs whose `Kind` does not match this rule
+     (e.g., the resource rule skips `application.*` parses); skip silently.
+  5. If `hasExplicitDependency(app.Spec.Dependencies, targetKind,
+     ref.Name)` is true, skip the env var entirely (explicit wins;
+     no inferred edge, no failure check).
+  6. Call `lookupOwner(ref.Name)`. If the target does not exist OR
+     its owner differs from `app.Metadata.Owner`, return
+     `(nil, nil, &EnrichmentError{...})` — fail-fast.
+  7. Otherwise append the inferred edge to the rule's accumulator
+     and replace the Application in the working set via
+     `cloneApplicationWithDeps`.
+- Returns the enriched set, the inferred-edge provenance list, and
+  the first error encountered (or `nil`).
+- The two concrete rules are tiny wrappers around this helper:
+  - `enrichValueFromResource.Enrich(set)` passes
+    `targetKind = manifest.ResourceKind`, `lookupOwner` reading from
+    `set.Resources`, and `parseFor` returning only refs where
+    `Kind == "resource"`.
+  - `enrichValueFromApplication.Enrich(set)` passes
+    `targetKind = manifest.ApplicationKind`, lookups in
+    `set.Applications`, refs where `Kind == "application"`.
+
+This single shared helper is the DRY answer to Principle VII — the only
+code touched per new rule is the wrapper that supplies the constants.
+
+---
+
+## Relationship diagram
+
+```text
+                ┌──────────────────────────────────────────┐
+                │           planner.Plan(set, …)            │
+                │                                            │
+                │   filter.Validate(set)                     │
+                │   Resolve(set, store, registries)          │
+                │   ───────────────────────────────────────  │
+                │   set, edges, err := ChainEnrich(set,      │
+                │       enrichValueFromResource{},           │
+                │       enrichValueFromApplication{},        │
+                │   )                                        │
+                │   if err != nil { return PlanResult{       │
+                │       Error: err,  // *EnrichmentError     │
+                │   } }                                      │
+                │   ───────────────────────────────────────  │
+                │   DetectRoutingCollisions(set)             │
+                │   steps, _ := Order(set)                   │
+                │   return PlanResult{                       │
+                │       Steps:         steps,                │
+                │       ManifestSet:   set,  // enriched     │
+                │       InferredEdges: edges,                │
+                │   }                                        │
+                └──────────────────────────────────────────┘
+                                  │
+                                  ▼ (success path)
+                ┌──────────────────────────────────────────┐
+                │   handler.DryRun                          │
+                │     - if result.Error != nil:             │
+                │         print Error to ErrOut; exit non-0 │
+                │     - print formatDeployPlan(             │
+                │         result.Steps,                     │
+                │         result.ManifestSet,               │
+                │         result.InferredEdges,             │
+                │       ) to Out                            │
+                │     - engine.ExecuteDeploy(steps, set)    │
+                └──────────────────────────────────────────┘
+```
+
+The pre-enrichment set is only visible to code that lives inside
+`Plan()` between `Resolve` and `ChainEnrich`. Outside callers see the
+enriched set on `PlanResult.ManifestSet` (success) or no set at all
+(failure).
+
+---
+
+## Invariants (verified by unit tests)
+
+1. **Input immutability** — for every Application `app` in the original
+   set, `len(app.Spec.Dependencies)` and the contents of that slice are
+   identical before and after `Plan()` returns, in both the success and
+   failure paths (FR-005, SC-007). Verified by snapshotting the input
+   set's deps before calling Plan and comparing afterwards.
+2. **No file I/O** — running enrichment does not open any file for
+   write under the manifests directory (SC-006). Verified by running
+   enrichment against an in-memory `ManifestSet` and asserting the
+   working directory's mtime is unchanged.
+3. **Idempotence on success** — `ChainEnrich(ChainEnrich(set))` produces
+   edges identical to `ChainEnrich(set)` (SC-005, success path).
+4. **Idempotence on failure** — re-running `ChainEnrich` on the same
+   input that previously failed produces a `*EnrichmentError` with the
+   same `Kind` and identical structured fields (SC-005, failure path).
+5. **Determinism** — repeated `Plan()` calls on the same input produce
+   identical `InferredEdges` slices (success) or identical first
+   `*EnrichmentError` (failure), byte for byte (FR-013).
+6. **Same-owner gate** — for any inferred edge `(consumer, target)`,
+   `consumer.Metadata.Owner == target.Metadata.Owner` (FR-002).
+7. **Dedup correctness** — for every inferred edge added, there is no
+   pre-existing explicit `Dependency` in the consumer's deps with the
+   same `(Kind, Name)` (FR-006).
+8. **Cross-team / unresolved failure** — for every `valueFrom`
+   reference whose target is not same-team AND not covered by an
+   explicit `Spec.Dependencies` entry, `Plan()` returns
+   `PlanResult{Error: &EnrichmentError{Kind:
+   ErrCrossTeamOrUnresolvedValueFrom, …}}` and `Steps == nil` (FR-010,
+   SC-003).
+9. **Explicit dep satisfies cross-team** — when the consumer's
+   `Spec.Dependencies` contains an entry matching a cross-team or
+   absent `valueFrom` reference under the `(Kind, Name)` dedup key,
+   `Plan()` succeeds and no `*EnrichmentError` is raised for that
+   reference (FR-010 second clause; US3 acceptance scenario 2).

--- a/specs/020-infer-valuefrom-deps/plan.md
+++ b/specs/020-infer-valuefrom-deps/plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Infer Implicit Deploy-Order Dependencies from Same-Owner valueFrom References
+
+**Branch**: `020-infer-valuefrom-deps` | **Date**: 2026-05-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/020-infer-valuefrom-deps/spec.md`
+
+## Summary
+
+Add an in-memory enrichment step between manifest validation and topological
+ordering inside `internal/planner.Plan()` that derives implicit deploy-order
+dependencies for an `Application` from its env vars whose `valueFrom`
+references another manifest in the current `ManifestSet`.
+
+Behaviour boundary (post-clarification, 2026-05-20):
+
+- **Same-team reference** → inferred edge added; dedup against existing
+  explicit `spec.dependencies` by `(Kind, Name)`.
+- **Cross-team reference** (target manifest present but owned by a different
+  team than the consumer) → enrichment fails the planner with a
+  fail-fast error unless the consumer's explicit `spec.dependencies` already
+  covers the reference.
+- **Reference whose target is absent from the loaded `ManifestSet`** (typo,
+  or target in a team that was not loaded) → same fail-fast error as
+  cross-team. Because `shrine deploy team <T>` loads all manifests owned
+  by `<T>`, absence implies the reference is not same-team.
+- **Vault references and literal `value:`** → silently skipped.
+
+Technical approach: implement the enrichment step as a chain of `Enricher`
+units (`Enricher.Enrich(set) (*ManifestSet, error)`) composed by a
+`ChainEnrich` helper, with copy-on-write at the `Spec.Dependencies` slice
+level so the input set is observably unmodified. Two rules ship at
+landing — `enrichValueFromResource` and `enrichValueFromApplication` —
+sharing a single `applyEnrichmentRule` helper. The dry-run handler renders
+a plan-summary header that tags inferred edges with their originating
+env var name.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+
+**Primary Dependencies**: existing `internal/manifest`, `internal/planner`,
+`internal/handler` packages; no new third-party dependencies.
+**Storage**: N/A — enrichment is purely in-memory and never touches disk
+(FR-004, SC-006).
+**Testing**: `go test ./...` for unit gates (`internal/planner/...`,
+`internal/handler/...`); `go test -tags integration ./tests/integration/...`
+for the Principle V gate using `NewDockerSuite` against the real shrine
+binary.
+**Target Platform**: Linux server (homelab Docker host); same as the
+shrine binary today.
+**Project Type**: Single-binary Go CLI (`cmd/shrine`).
+**Performance Goals**: enrichment is O(applications × env vars) with map
+lookups for target resolution. Typical team size (~10–50 manifests, ~10
+env vars each) puts enrichment under 10 ms on commodity hardware — well
+inside the existing `Plan()` budget.
+**Constraints**:
+- No file I/O during enrichment (FR-004).
+- Input `ManifestSet` is observably unmodified after `Plan()` returns
+  (FR-005, SC-007).
+- Determinism across runs, including the choice of "first offending
+  reference" reported by the fail-fast error (FR-013).
+- Enrichment runs strictly between `Resolve()` and the existing ordering
+  step (FR-008).
+**Scale/Scope**: tens of manifests per team, low single-digit teams
+per homelab. The enrichment cost is dominated by validation and Docker
+operations elsewhere; this feature does not introduce a hot path.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Question | Status |
+|-----------|---------------|--------|
+| I. Declarative Manifest-First | Does this feature expose new capabilities via manifest fields (not CLI flags)? | [x] Pass — uses the existing `env[].valueFrom` field; no schema change (FR-012). |
+| II. Kubectl-Style CLI | Do new commands follow verb-first convention and include `--dry-run`? | [x] N/A — no new CLI subcommands; behaviour is layered behind existing `shrine deploy`/`shrine deploy --dry-run`. |
+| III. Pluggable Backend | Is new infrastructure logic behind a backend interface (not engine core)? | [x] N/A — enrichment lives in `internal/planner`; no backend interface is touched. |
+| IV. Simplicity & YAGNI | Is every abstraction justified by ≥3 concrete usages? | [x] Pass (with note) — the `Enricher` interface has 2 concrete implementations at landing, but FR-007 explicitly mandates a composable chain so a future rule can be added without modifying existing rules, and a shared `applyEnrichmentRule` helper provides immediate DRY benefit across both rules. Documented in Complexity Tracking. |
+| V. Integration-Test Gate | Does this phase map to an integration test phase using `NewDockerSuite` against a real binary? | [x] Pass — new `tests/integration/deploy_team_infer_test.go` covers US1, US2, US3 (failure case), and the no-disk-write invariant. |
+| VI. Docker-Authoritative State | Does state update happen *after* Docker operations complete? | [x] N/A — enrichment runs entirely before any backend call; no state-record changes. |
+| VII. Clean Code & Readability | Is repeated logic extracted into named helpers? Are names self-documenting (no WHAT comments)? | [x] Pass — both rules share `applyEnrichmentRule`; helpers named `parseValueFromRef`, `cloneApplicationWithDeps`, `hasExplicitDependency`. Boolean names use `has`/`is`/`should` per Principle VII. |
+
+> Violations MUST be documented in the Complexity Tracking table below.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-infer-valuefrom-deps/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md        # Phase 1 output (/speckit-plan command)
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── contracts/           # Phase 1 output (/speckit-plan command)
+│   └── enrichment-api.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── planner/
+│   ├── enrich.go                 # NEW — Enricher interface, ChainEnrich, DefaultEnrichers, helpers
+│   ├── enrich_valuefrom.go       # NEW — enrichValueFromResource, enrichValueFromApplication, applyEnrichmentRule, parseValueFromRef
+│   ├── enrich_test.go            # NEW — unit tests for ChainEnrich + helpers
+│   ├── enrich_valuefrom_test.go  # NEW — unit tests for the two production rules
+│   └── plan.go                   # MODIFIED — calls ChainEnrich between Resolve and the filter switch; propagates enrichment errors as PlanResult.Error
+├── handler/
+│   ├── deploy.go                 # MODIFIED — propagate planner errors (including enrichment failures) to stderr + non-zero exit
+│   ├── dryrun.go                 # MODIFIED — same error propagation; on success, render plan-summary header
+│   ├── apply_single.go           # MODIFIED — same error propagation
+│   └── deploy_plan_format.go     # NEW — formatDeployPlan(steps, set, edges) renders the dry-run summary with provenance tags
+└── manifest/                     # NOT MODIFIED — no schema change (FR-012)
+
+tests/
+└── integration/
+    └── deploy_team_infer_test.go # NEW — covers US1, US2, US3 (failure), no-disk-write invariant, dedup vs explicit
+```
+
+**Structure Decision**: Single-binary Go CLI; new code lives under
+`internal/planner` and `internal/handler`. No new top-level package and no
+new module. The split between `enrich.go` (mechanism: interface + chain
++ shared helpers) and `enrich_valuefrom.go` (policy: the two production
+rules) means a future rule can be added as a third file
+(`enrich_<something>.go`) plus one line in `DefaultEnrichers()` —
+satisfying FR-007 ("composable units, no edits to existing rules").
+
+## Complexity Tracking
+
+> The constitution's Principle IV asks for ≥3 concrete usages before
+> introducing an abstraction. This plan introduces one abstraction with
+> 2 concrete usages at landing; the table below records the justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| `Enricher` interface + `ChainEnrich` composer with 2 concrete rules at landing (vs. constitution's "≥3 usages" rule). | FR-007 explicitly mandates composable inference units so a future rule (e.g., a vault-aware rule, or a future `valueFrom` prefix) can be added without modifying existing rules. The shared `applyEnrichmentRule` helper also delivers immediate DRY benefit across the two production rules (Principle VII). | Inlining both rules' loops in `Plan()` would duplicate the iterate-apps × sort × per-env-scan boilerplate verbatim and force any future rule to either modify `Plan()` (violating FR-007) or duplicate the loop again. The cost of the interface (one method, one file) is small relative to the maintenance friction of in-line duplication. |

--- a/specs/020-infer-valuefrom-deps/quickstart.md
+++ b/specs/020-infer-valuefrom-deps/quickstart.md
@@ -1,0 +1,283 @@
+# Quickstart: valueFrom-Inferred Deploy Order
+
+**Feature**: `020-infer-valuefrom-deps`
+**Audience**: Operators verifying the feature works end-to-end, and
+contributors adding a new enrichment rule.
+
+---
+
+## Part A — Operator walkthrough (verify the bug is fixed)
+
+### Setup
+
+Create a fresh specs directory with two manifests under the same team
+`ops_bot`.
+
+`specs/ops-bot-db.yaml`:
+
+```yaml
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: ops-bot-db
+  owner: ops_bot
+spec:
+  type: postgres
+  version: "16"
+  outputs:
+    - name: DB_CONNECTION_URL
+      template: "postgres://{{.user}}:{{.password}}@{{.host}}:{{.port}}/{{.db}}"
+```
+
+`specs/ops-bot.yaml`:
+
+```yaml
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: ops-bot
+  owner: ops_bot
+spec:
+  image: registry.example/ops-bot:1.0
+  env:
+    - name: DB_CONNECTION_URL
+      valueFrom: resource.ops-bot-db.DB_CONNECTION_URL
+```
+
+Note: the `Application` has **no** `spec.dependencies` block.
+
+### Verify ordering (dry-run)
+
+```bash
+shrine deploy team ops_bot --dry-run
+```
+
+Expected output on stdout begins with:
+
+```
+Deploy order:
+  1. Resource:ops-bot-db
+  2. Application:ops-bot
+       depends on:
+         - Resource:ops-bot-db (inferred from env DB_CONNECTION_URL)
+```
+
+Followed by the usual `[DOCKER] …` lines.
+
+Key assertions to eyeball:
+- `Resource:ops-bot-db` is step 1, `Application:ops-bot` is step 2.
+- The dependency line carries `(inferred from env DB_CONNECTION_URL)`.
+
+### Verify ordering (real deploy)
+
+```bash
+shrine deploy team ops_bot
+```
+
+The summary header does NOT print (real deploys are silent on the
+summary), but the Docker operations for `ops-bot-db` complete before
+`ops-bot` is created. If `ops-bot-db` fails to come up, `ops-bot` is
+never created — same gate as if the operator had declared the
+dependency explicitly.
+
+### Verify on-disk state is untouched
+
+After running either command above:
+
+```bash
+git status specs/
+# expected: nothing to commit, working tree clean
+```
+
+The planner never writes back to YAML (FR-004, SC-006).
+
+### Verify the cross-team failure
+
+Add a second team's resource that the first team can read:
+
+`specs/team-b/shared.yaml`:
+
+```yaml
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: shared-cache
+  owner: team_b
+  access: [ops_bot]
+spec:
+  type: redis
+  version: "7"
+  networking:
+    exposeToPlatform: true
+  outputs:
+    - name: HOST
+      template: "{{.host}}"
+```
+
+Add an env var on `ops-bot` referencing it:
+
+```yaml
+    - name: CACHE_HOST
+      valueFrom: resource.shared-cache.HOST
+```
+
+Run:
+
+```bash
+shrine deploy team ops_bot --dry-run
+```
+
+The planner now **fails** before any deploy step runs. You will see
+on stderr:
+
+```
+enrichment: app "ops-bot" env "CACHE_HOST" references resource "shared-cache.HOST" which is not owned by team "ops_bot"; add an explicit spec.dependencies entry (kind: Resource, name: shared-cache) to declare this dependency
+```
+
+The exit code is non-zero. No plan summary is printed and no Docker
+operations are attempted.
+
+To make the deploy succeed, declare the cross-team coupling explicitly:
+
+```yaml
+spec:
+  dependencies:
+    - kind: Resource
+      name: shared-cache
+      owner: team_b
+```
+
+Now `shrine deploy team ops_bot --dry-run` succeeds. The dry-run
+summary shows `Resource:shared-cache` as an explicit dep (no
+`(inferred from …)` tag), and the deploy proceeds normally.
+
+> **Why a failure and not a warning?** Cross-team coupling means
+> another team owns the lifecycle of `shared-cache`. Inferring the
+> ordering silently would hide the coupling; emitting only a warning
+> would let an under-specified deploy proceed. Requiring an explicit
+> `spec.dependencies` entry forces the coupling to be visible in code
+> review.
+
+### Verify the absent-target failure
+
+The same error fires if you reference a manifest that simply does not
+exist in the loaded set — typo or otherwise:
+
+```yaml
+    - name: BAD_REF
+      valueFrom: resource.does-not-exist.HOST
+```
+
+`shrine deploy team ops_bot --dry-run` produces:
+
+```
+enrichment: app "ops-bot" env "BAD_REF" references resource "does-not-exist.HOST" which is not owned by team "ops_bot"; add an explicit spec.dependencies entry (kind: Resource, name: does-not-exist) to declare this dependency
+```
+
+Because `shrine deploy team ops_bot` loads all manifests owned by
+`ops_bot`, an absent target is by construction not same-team. The
+remediation is to fix the typo (or remove the env var, or declare an
+explicit dep if the target lives in another team).
+
+### Multiple bad references — fail-fast
+
+If multiple env vars on the same Application — or across multiple
+Applications in the team — would each individually trigger the
+failure, only the **first** one (in sorted Application name +
+declaration order on each Application's env list) is reported per run.
+Fix that one and re-run to surface the next.
+
+---
+
+## Part B — Contributor walkthrough (add a new enrichment rule)
+
+This walkthrough shows how to add a hypothetical "implicit ordering
+from `valueFrom: vault:…` references that resolve to a manifest-owned
+secret" rule. The exact rule is illustrative; the steps generalize.
+
+### Step 1 — create the rule file
+
+`internal/planner/enrich_vault.go`:
+
+```go
+package planner
+
+import "github.com/CarlosHPlata/shrine/internal/manifest"
+
+type enrichValueFromVault struct{}
+
+func (enrichValueFromVault) Enrich(set *ManifestSet) (*ManifestSet, error) {
+    // Use applyEnrichmentRule with your own parseFor and lookupOwner.
+    // Return new set + error (use *EnrichmentError for FR-010-style
+    // failures). NEVER mutate `set`.
+    return set, nil // (skeleton — implement parse + gate + dedup here)
+}
+```
+
+### Step 2 — register it in the default chain
+
+`internal/planner/enrich.go`:
+
+```go
+func DefaultEnrichers() []Enricher {
+    return []Enricher{
+        enrichValueFromResource{},
+        enrichValueFromApplication{},
+        enrichValueFromVault{},  // ← new rule, appended
+    }
+}
+```
+
+That is the **only** edit to an existing file. The previous two rule
+files are untouched (FR-007).
+
+### Step 3 — add unit tests
+
+`internal/planner/enrich_vault_test.go`:
+
+```go
+func TestEnrichValueFromVault_AddsEdgeForSameOwnerSecret(t *testing.T) { … }
+func TestEnrichValueFromVault_FailsOnCrossTeamWithoutExplicitDep(t *testing.T) { … }
+func TestEnrichValueFromVault_SucceedsOnCrossTeamWithExplicitDep(t *testing.T) { … }
+func TestEnrichValueFromVault_FailsOnAbsentTargetWithoutExplicitDep(t *testing.T) { … }
+func TestEnrichValueFromVault_DedupsAgainstExplicit(t *testing.T) { … }
+func TestEnrichValueFromVault_DoesNotMutateInputOnSuccessOrFailure(t *testing.T) { … }
+```
+
+Use the test fixtures already in `enrich_valuefrom_test.go` as a model
+— same shape, different `valueFrom` strings.
+
+### Step 4 — extend the integration test if the rule changes
+operator-visible output
+
+If the new rule produces a new dry-run provenance tag (e.g., `(inferred
+from vault env <NAME>)`), update `tests/integration/deploy_team_infer_test.go`
+to assert the new tag for the new scenario.
+
+### Step 5 — run the gates
+
+```bash
+go test ./internal/planner/...                              # unit gate
+go test -tags integration ./tests/integration/...           # integration gate (Principle V)
+make docs-gen-cli && git diff --exit-code docs/content/cli/ # docs freshness
+```
+
+The constitution requires the integration gate before the phase is
+declared complete. For this feature, the gating test is
+`tests/integration/deploy_team_infer_test.go`.
+
+---
+
+## Part C — Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `enrichment: app "<X>" env "<Y>" references … which is not owned by team …` | The `valueFrom` references a manifest owned by another team, or a manifest that is not in the loaded set. Either fix the typo, or declare an explicit `spec.dependencies` entry for the cross-team target (US3 acceptance scenario 2). |
+| Planner fails on what looks like a same-team reference | Confirm the target manifest is actually loaded — `shrine deploy team <T>` only loads manifests with `metadata.owner == <T>`. Confirm both consumer and target have the same `metadata.owner` value (typos in the owner field count as cross-team). |
+| Inferred dep is missing in dry-run | The env var uses literal `value:` (not `valueFrom:`), or its `valueFrom` uses `vault:…` (not currently inferred). Note: a `valueFrom: resource.<X>.<Y>` whose target is absent from the loaded set no longer silently skips — it FAILS the planner (see first row). |
+| Duplicate edge in dry-run summary | This is a bug — file an issue. Dedup is keyed on `(Kind, Name)` and should suppress duplicates. |
+| Multiple cross-team failures reported in one run | Enrichment is fail-fast — only the first offending reference is reported per run. Fix it and re-run to surface the next one. |
+| YAML on disk shows changes after running `shrine deploy` | This is a bug — file an issue. Enrichment must never write to disk (FR-004, SC-006). |
+
+For deeper debugging, run with `--dry-run` first; the plan summary makes
+provenance explicit and removes a layer of guesswork.

--- a/specs/020-infer-valuefrom-deps/research.md
+++ b/specs/020-infer-valuefrom-deps/research.md
@@ -1,0 +1,399 @@
+# Research: Implicit Dependency Inference
+
+**Feature**: `020-infer-valuefrom-deps` | **Phase**: 0 (Research)
+**Date**: 2026-05-20
+
+This document records the design decisions made before Phase 1 (data model
+and contracts). All `NEEDS CLARIFICATION` markers from `plan.md` are
+resolved here.
+
+---
+
+## Decision 1 — Where the enrichment step sits in the planner pipeline
+
+**Decision**: Insert enrichment between `Resolve()` and the filter switch
+inside `internal/planner.Plan()`. The order becomes
+`Validate → Resolve → Enrich → (collision-detect) → Order`.
+
+**Rationale**:
+- FR-008 mandates the step run *after* validation and *before* `Order`.
+- All current callers (`handler.Deploy`, `handler.DryRun`,
+  `handler.ApplySingle`) enter the planner through `Plan()`, so a single
+  insertion point covers every call site uniformly. No caller can bypass
+  enrichment by accident.
+- `Resolve()` is what guarantees the references the inference layer
+  parses are well-formed (`validateValueFrom` rejects malformed strings,
+  missing targets, and bad outputs). Running enrichment after `Resolve()`
+  means inference rules never have to re-validate — they can assume any
+  `resource.<name>.<output>` they see resolves to a real `Resource` in
+  the set or has been ruled out by validation already.
+
+**Alternatives considered**:
+- *Move enrichment into `LoadDir`*: would couple file I/O to inference
+  semantics and forces every test that constructs a `ManifestSet`
+  manually (planner unit tests, integration test fixtures) to also opt
+  into enrichment. Rejected.
+- *Move enrichment into a new top-level handler step before `Plan()`*:
+  would duplicate the call across `handler.Deploy`, `handler.DryRun`,
+  `handler.ApplySingle`. Rejected — Plan() is already the funnel point.
+- *Run enrichment inside `Order()`*: would couple the topological-sort
+  algorithm to env-var semantics and break the separation between graph
+  construction and graph traversal. Rejected on Principle III/VII grounds.
+
+---
+
+## Decision 2 — Decorator/chain pattern shape
+
+**Decision**: Define an `Enricher` interface with a single method
+`Enrich(*ManifestSet) (*ManifestSet, error)`. A composer
+`ChainEnrich(set, rules ...Enricher) (*ManifestSet, []InferredEdge, error)`
+threads the result through each rule in order and aggregates the
+inferred-edge provenance. Any rule may return an error; the chain stops
+at the first error and propagates it unchanged.
+`DefaultEnrichers()` returns the rules registered for production use
+(`enrichValueFromResource`, `enrichValueFromApplication`). Tests can
+construct ad-hoc chains.
+
+**Rationale**:
+- FR-007: composable units of inference, additive at the call site, no
+  edits to existing rules when adding a new one.
+- A single-method interface is the minimum abstraction that satisfies
+  the rule.
+- Threading `(*ManifestSet, error)` through the chain mirrors how Go
+  middleware decorators are typically written: each unit takes a value,
+  returns a value plus error, no shared mutable state.
+- The error return on `Enrich` is what enables FR-010's fail-fast
+  behaviour without inventing a separate validation channel. Rules that
+  do not validate (in the future) can simply return `nil` always.
+
+**Alternatives considered**:
+- *Each rule mutates the input set in place*: rejected explicitly by the
+  user ("new set returned, but can contain same specs structs enriched")
+  and by FR-005.
+- *A registry that rules self-register into via `init()`*: rejected
+  because it hides the rule set from the call site and makes testing
+  with an alternative chain awkward. Explicit composition wins.
+- *Variadic `func(*ManifestSet) (*ManifestSet, error)` instead of
+  an interface*: equivalent in capability but less greppable when a
+  contributor wants to find "all current enrichers". Interface + factory
+  function (`DefaultEnrichers()`) is the explicit-registry version of
+  the same idea.
+- *Two-channel return (`(*ManifestSet, []Notice)` plus a separate
+  validator step)*: rejected — splitting validation across two passes
+  would force every caller and every test to remember to run both, and
+  the validation rule is intrinsic to the enrichment rule (same parse,
+  same lookup, same gate).
+
+---
+
+## Decision 3 — Immutability strategy (copy-on-write)
+
+**Decision**:
+- `ChainEnrich` first calls `copyManifestSetShallow(set)` to allocate a
+  fresh `*ManifestSet` with fresh `map` headers. Map values (manifest
+  pointers) are copied by reference.
+- Each rule iterates the (already-shallow-copied) maps. When a rule
+  decides to add edges to a given Application `app`, it constructs a
+  **new** `*manifest.ApplicationManifest` value (`*app` copied),
+  allocates a new `Dependencies` slice (`append(append([]Dependency{},
+  app.Spec.Dependencies...), inferred...)`), and replaces the entry in
+  the working map with the new pointer. Applications that gained no
+  edges remain pointer-shared with the input set.
+- `manifest.Metadata`, `Env`, `Routing`, `Networking`, `Volumes` etc.
+  are not deep-copied — they are immutable from the planner's
+  perspective and are read-only after `Resolve`. Only the
+  `Spec.Dependencies` slice is grown.
+
+**Rationale**:
+- FR-005 requires that callers observing the input set after enrichment
+  see no changes to `Spec.Dependencies` lengths or contents.
+- Edge Case 8 in the spec: callers can reuse the pre-enrichment set for
+  diagnostics or to display the raw manifests as authored.
+- Deep-copying the entire manifest tree would be wasteful for the common
+  case where only one or two slices need to grow. Copy-on-write at the
+  slice level is the minimum work that preserves immutability.
+
+**Alternatives considered**:
+- *Deep-clone every manifest before passing into the chain*: rejected
+  on cost grounds and as gratuitous (no other field is mutated).
+- *Persistent/immutable data structure for `[]Dependency`*: overkill;
+  Go's slice copy-on-append idiom is sufficient.
+
+---
+
+## Decision 4 — Dedup against explicit dependencies
+
+**Decision**: Before scanning env vars for inference targets, each rule
+builds a local `explicit` set keyed on `(Kind, Name)` from the
+Application's existing `Spec.Dependencies`. When the rule discovers an
+inference candidate, if `(Kind, Name)` is already in `explicit`, the
+candidate is dropped silently. The explicit entry is preserved verbatim
+in the cloned manifest, including its `Owner` field (even when that
+field disagrees with the live `metadata.owner` on the target — FR-006
+preserves the operator's authored value; `Resolve()` already raised the
+mismatch as an error if it was reachable).
+
+**Rationale**:
+- FR-006 (explicit wins on dedup; operator's text never overwritten).
+- The dedup key intentionally ignores `Owner` so that a typo in
+  `dep.Owner` does not produce a duplicate edge. The explicit entry is
+  the one that survives in either case.
+- Cross-rule dedup is handled by virtue of each rule running over the
+  already-enriched set produced by the previous rule: by the time
+  `enrichValueFromApplication` runs, any `Resource:X` edge added by
+  `enrichValueFromResource` is in `app.Spec.Dependencies` and will be
+  treated as an "explicit" entry for dedup purposes inside the next
+  rule. Idempotence (SC-005) falls out for free.
+
+**Alternatives considered**:
+- *Dedup on `(Kind, Name, Owner)`*: rejected because the same logical
+  edge would be doubly recorded whenever the operator's `Owner` typo
+  differs from the live owner.
+- *Always replace explicit entries with inferred ones (richer
+  metadata)*: rejected — operator-authored text is sacrosanct (FR-006).
+
+---
+
+## Decision 5 — Cross-team `valueFrom` handling (fail-fast)
+
+**Decision**: When a rule sees a `valueFrom` reference whose target
+cannot be resolved to a same-team manifest in the current
+`ManifestSet`, the rule:
+
+1. Checks the consumer Application's explicit `Spec.Dependencies` for
+   an entry matching the reference under the `(Kind, Name)` dedup key.
+   If one is present, the explicit entry satisfies the requirement —
+   the rule skips the reference and continues.
+2. Otherwise the rule returns an `*EnrichmentError` whose
+   `Kind == ErrCrossTeamOrUnresolvedValueFrom`. The chain stops at the
+   first error; subsequent references in the same run are not
+   enumerated. The planner returns the error in `PlanResult.Error`
+   and `Steps` is `nil`.
+
+"Cannot be resolved to a same-team manifest" covers two cases that are
+treated identically (per Clarifications Q2):
+- The target manifest is present in the set but its `metadata.owner`
+  differs from the consumer's owner (true cross-team).
+- The target manifest is absent from the set entirely (typo, or target
+  lives in a team that was not loaded). Because `shrine deploy team <T>`
+  loads all manifests owned by `<T>`, absence implies the reference is
+  not same-team.
+
+The error message format (printed to `ErrOut` by the handler and used
+as `Error()`):
+
+```
+enrichment: app "<consumer>" env "<NAME>" references <kind> "<target>.<output>" which is not owned by team "<consumer-owner>"; add an explicit spec.dependencies entry (kind: <Kind>, name: <target>) to declare this dependency
+```
+
+**Rationale**:
+- FR-010 (post-clarification) requires the planner to fail rather than
+  emit an informational nudge. Operators editing manifests benefit from
+  a hard failure that prevents an under-specified deploy from running.
+- Routing the failure through the rule's error return uses the same
+  channel as any other planner error; handlers already propagate
+  `PlanResult.Error` to stderr with a non-zero exit. No new wiring
+  needed in `handler.Deploy`/`handler.DryRun`/`handler.ApplySingle`
+  besides the error propagation already in place.
+- The same-team gate is computed by lookup against the set's
+  `Applications` and `Resources` maps; absence and cross-ownership are
+  both expressible as "no matching same-owner entry in the maps", so
+  the rule implementation has one code path for both.
+
+**Alternatives considered**:
+- *Print an informational nudge and continue (original design)*:
+  rejected by the user during clarification. Letting a cross-team
+  reference proceed without an explicit dep leaves the deploy in an
+  under-specified state.
+- *Collect all offending references in one run and report them
+  together*: rejected during clarification — operator chose fail-fast
+  (Q3). Simpler implementation; deterministic first-error reporting is
+  guaranteed by Decision 8's sort order.
+- *Raise the failure inside `Resolve()` rather than during enrichment*:
+  rejected — `Resolve()` is about value substitution (templates,
+  secrets) and access validation, not ordering semantics. Putting the
+  same-team-or-explicit gate next to the inference rule keeps the two
+  concerns in one place.
+
+---
+
+## Decision 6 — Dry-run plan summary header (FR-009)
+
+**Decision**: The dry-run engine itself is **unchanged**. Instead,
+`handler.DryRun` renders a plan-summary header to stdout *before*
+invoking `engine.ExecuteDeploy`. The summary is only rendered when
+enrichment succeeded; if enrichment failed (Decision 5), the handler
+prints the error to stderr with a non-zero exit and no Docker
+operations are attempted. The header is produced by a new helper
+`formatDeployPlan(steps, set, provenance)` in
+`internal/handler/deploy_plan_format.go`. The output looks like:
+
+```
+Deploy order:
+  1. Resource:ops-bot-db
+  2. Application:ops-bot
+       depends on:
+         - Resource:ops-bot-db (inferred from env DB_CONNECTION_URL)
+```
+
+Explicit deps appear with no provenance tag:
+```
+       depends on:
+         - Resource:shared-db
+```
+
+The `provenance` argument is a new field on `PlanResult` —
+`InferredEdges map[appName][]InferredEdge` — populated by the
+enrichment rules. Each `InferredEdge` carries the target's
+`(Kind, Name)` and the originating env var name (one of them, if
+multiple env vars referenced the same target).
+
+**Rationale**:
+- FR-009 requires inferred edges to be visibly tagged in dry-run output.
+- Today's dry-run output (Docker ops only) gives no per-step dep view,
+  so we must add one. The spec's Assumption #7 explicitly anticipated this.
+- Keeping the renderer in the handler (not the dryrun engine) maintains
+  Principle III: the engine's backends print Docker ops; a planner
+  *summary* belongs to the planner's output surface.
+- The non-dry-run `handler.Deploy` does NOT print the summary by default
+  (operator already chose to deploy; the dry-run is where the preview
+  matters). Notices still print in both paths.
+
+**Alternatives considered**:
+- *Pass the provenance through the steps themselves*: rejected — `PlannedStep`
+  is a stable, tiny value type used by every backend; bloating it with
+  provenance just for the renderer would leak planner semantics into
+  the engine.
+- *Render the summary inside the dryrun engine*: rejected per Principle III.
+
+---
+
+## Decision 7 — Vault and non-manifest `valueFrom` handling
+
+**Decision**:
+- `valueFrom: vault:...` references are skipped silently by every rule.
+  They are tokens, not manifest references, and therefore are outside
+  the same-team-gate scope of FR-010.
+- Literal `value:` env vars (no `valueFrom`) are not parsed at all.
+- `valueFrom: resource.<X>.<Y>` and `valueFrom: application.<X>.<Y>`
+  references are NOT silently skipped when `<X>` is absent from the
+  current `ManifestSet`. Per Clarifications Q2 and the revised FR-010,
+  absence is treated identically to cross-team: the rule returns the
+  fail-fast `EnrichmentError` unless the consumer has an explicit
+  `Spec.Dependencies` entry covering the reference.
+
+**Rationale**:
+- FR-011 (post-clarification) narrows "ignored" to vault and literal
+  cases — the categories that, by syntax, are clearly not manifest
+  references. Anything that uses the `resource.` / `application.`
+  manifest-reference grammar must resolve to a same-team manifest in
+  the loaded set or be covered by an explicit dep, otherwise FR-010
+  fires.
+- This unifies the absent-from-set case with the cross-team case under
+  a single error path (Decision 5), which is the smallest possible rule
+  surface: one parse, one lookup, one branch.
+- The previous "warn would be noisy" concern (which justified silent
+  skipping for absent targets) no longer applies — operators must now
+  declare an explicit dep when they intentionally reference a target
+  outside their team's loaded set. The friction is intentional and is
+  the point of FR-010.
+
+**Alternatives considered**:
+- *Keep silent-skip for absent targets and fail only for in-set cross-
+  team references*: rejected during clarification (Q2). The operator
+  cannot tell from the spec output whether an absent reference was
+  intentional or a typo; failure is preferable to silent under-
+  specification.
+- *Distinguish "absent" from "cross-team" with different error kinds*:
+  rejected as low-value. The remediation is identical in both cases
+  (declare an explicit `spec.dependencies` entry, or fix the typo); a
+  single error kind with a clear message keeps the rule simpler.
+
+---
+
+## Decision 8 — Determinism across map iteration (including fail-fast ordering)
+
+**Decision**: Inside each rule, the iteration over `set.Applications`
+collects names into a slice, sorts the slice (stdlib `sort.Strings`),
+and then processes Applications in sorted order. Within a single
+Application, env vars are scanned in declaration order (slice order
+preserved by the parser). Target-manifest lookups go through the
+already-sorted maps via map access (deterministic for single lookups).
+
+For the fail-fast path (Decision 5), the first offending reference
+encountered under this sorted traversal is the one returned in the
+error — this guarantees FR-013's determinism requirement extends to
+the failure case: the same input always produces the same first error.
+
+**Rationale**:
+- Go map iteration order is randomized; without an explicit sort, the
+  choice of "first offending reference" reported by FR-010 would
+  differ across runs and SC-005's failure-path idempotence would not hold.
+- Sorting by Application `metadata.name` is stable, cheap (n log n
+  for small n), and uses no allocator-of-doom.
+- The choice of "originating env var" when multiple env vars on the
+  same Application reference the same target (Edge Case 5) picks the
+  first in declaration order — Go slices preserve order, so this is
+  already deterministic without extra sorting.
+
+**Alternatives considered**:
+- *Stable sort using slice insertion order from the parser*: the
+  parser/loader doesn't preserve cross-file ordering; sort by name is
+  the simpler, stable input.
+- *Sort env vars too*: rejected — declaration order is the operator's
+  authored order and the only natural choice for the source-tag in
+  dry-run output.
+
+---
+
+## Decision 9 — Error type and handler propagation
+
+**Decision**: Define a typed `*EnrichmentError` in
+`internal/planner/enrich.go` with the fields needed to render the
+FR-010 message (consumer kind/name/owner, env var name, target
+kind/name/output) and a stable `Kind` value
+(`ErrCrossTeamOrUnresolvedValueFrom`). The error implements `error`
+via a `String()/Error()` method that produces the human-readable
+message in Decision 5.
+
+`ChainEnrich` returns `(*ManifestSet, []InferredEdge, error)`.
+`Plan()` sets `PlanResult.Error = err` and leaves `Steps == nil` on
+enrichment failure. The existing handler error path then prints the
+error to `ErrOut` and exits non-zero. No new wiring is required in
+`handler.Deploy`/`handler.DryRun`/`handler.ApplySingle` beyond the
+existing `if result.Error != nil` branch.
+
+**Rationale**:
+- A typed error lets tests assert on `Kind` and on the structured
+  fields without parsing the formatted message.
+- Reusing the existing `PlanResult.Error` channel means the handler-
+  side code path for an enrichment failure is identical to the path
+  for a validation failure today, minimizing surface area.
+- The error wraps no underlying error (it is the root cause); tests can
+  use `errors.As(err, &target)` to extract the typed shape.
+
+**Alternatives considered**:
+- *Sentinel error value (`ErrCrossTeamValueFrom = errors.New(...)`)*:
+  rejected — the rendered message needs to name the specific reference,
+  so a sentinel forces wrapping with `fmt.Errorf` everywhere and loses
+  the structured fields for testing.
+- *Reuse `internal/manifest.ValidationError`*: rejected — that type
+  belongs to manifest validation and would conflate enrichment failures
+  with parse/schema failures in the handler's error reporting.
+
+---
+
+## Open questions resolved
+
+| Question | Resolved by |
+|---|---|
+| Where does enrichment run? | Decision 1 — `Plan()` between `Resolve` and the filter switch. |
+| What's the rule contract? | Decision 2 — `Enricher` interface, `(*ManifestSet) → (*ManifestSet, error)`. |
+| How are inputs kept immutable? | Decision 3 — shallow-copy maps + copy-on-write for `Spec.Dependencies`. |
+| Same-team vs cross-team behaviour? | Decisions 4–5 — dedup for same-team + fail-fast for cross-team/absent. |
+| What about absent-from-set targets? | Decision 7 — treated identically to cross-team (Clarifications Q2). |
+| How does the dry-run show provenance? | Decision 6 — handler-rendered summary header. |
+| Determinism (including failure path)? | Decision 8 — sort iteration by Application name; first-error is deterministic. |
+| Error type and handler wiring? | Decision 9 — typed `*EnrichmentError`, routed through existing `PlanResult.Error`. |
+
+No `NEEDS CLARIFICATION` markers remain.

--- a/specs/020-infer-valuefrom-deps/spec.md
+++ b/specs/020-infer-valuefrom-deps/spec.md
@@ -1,0 +1,123 @@
+# Feature Specification: Infer Implicit Deploy-Order Dependencies from Same-Owner valueFrom References
+
+**Feature Branch**: `020-infer-valuefrom-deps`
+**Created**: 2026-05-20
+**Status**: Draft
+**Input**: User description: "Infer implicit deploy-order dependencies from same-owner valueFrom references. When an Application's env declares `valueFrom: resource.<name>.<output>` or `valueFrom: application.<name>.<output>` and the referenced manifest belongs to the same owner, the planner should treat the reference as a deploy-order dependency. Today only `spec.dependencies` feeds the topological sort, so an app reading from a same-team resource via `valueFrom` can be ordered before that resource, causing deploy failures."
+
+## Clarifications
+
+### Session 2026-05-20
+
+- Q: When a cross-team `valueFrom` reference on a consumer Application has no matching explicit `spec.dependencies` entry, should the planner emit an informational nudge (original US3 behavior) or fail the deploy? → A: Fail. Cross-team `valueFrom` references require an explicit `spec.dependencies` entry; only same-team references are enriched implicitly. When the explicit entry is missing, the planner must fail with a clear error and not proceed to deploy.
+- Q: What should the enrichment layer do when a `valueFrom: resource.<X>.<output>` or `valueFrom: application.<X>.<...>` reference's target manifest is not present in the current `ManifestSet` at all (e.g., absent because it lives in another team or because of a typo)? → A: Fail under the same FR-010 rule. Because `shrine deploy team <T>` loads all manifests owned by team `<T>`, a missing target implies the reference is not same-team; it is treated identically to a cross-team reference and requires an explicit `spec.dependencies` entry to proceed.
+- Q: When multiple `valueFrom` references would each trigger an FR-010 failure in a single planner run, should the planner collect them all into one error or fail fast on the first one? → A: Fail fast. The enrichment layer raises an FR-010 error on the first offending reference encountered and stops; subsequent references are not enumerated in that run. The operator fixes one issue at a time across successive planner invocations.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Application is sequenced after its same-team resource (Priority: P1)
+
+An operator on team `ops_bot` writes an Application manifest that declares an env var pulling its value from a Resource manifest owned by the same team — for example, `DB_CONNECTION_URL` sourced via `valueFrom: resource.ops-bot-db.DB_CONNECTION_URL`. The operator does not add an explicit `spec.dependencies` block on the Application; they expect the platform to understand that the Application reads from the Resource and to deploy the Resource first.
+
+**Why this priority**: This is the original bug. Without this story, `shrine deploy team ops_bot` can deploy the Application before the Resource and the Application starts against a missing or unready data source. P1 because it is the failure mode the user reproduced and the reason the feature exists.
+
+**Independent Test**: Place a same-owner Application + Resource pair in a fresh specs directory where the Application's env uses `valueFrom: resource.<resource-name>.<output>` and the Application has no `spec.dependencies` block. Run `shrine deploy team <owner>`. The plan emits the Resource step before the Application step. With only this story shipped, the original bug is resolved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a same-owner Application and Resource where the Application's env contains `valueFrom: resource.<X>.<output>` and the Application has no `spec.dependencies`, **When** the operator runs `shrine deploy team <owner>`, **Then** the planned order lists `Resource:<X>` strictly before `Application:<app-name>`.
+2. **Given** the same setup but invoked with `shrine deploy --dry-run`, **When** the operator inspects the dry-run output, **Then** the Application step shows its dependency on `Resource:<X>` tagged as inferred from the env var (for example `Resource:<X> (inferred from env DB_CONNECTION_URL)`).
+3. **Given** the Application also has an explicit `spec.dependencies` entry naming the same Resource, **When** the planner runs, **Then** no duplicate edge is created, the explicit entry is preserved as written (including its `owner` field), and ordering is identical to the inference-only case.
+
+---
+
+### User Story 2 - Application-to-application inference within a team (Priority: P2)
+
+An operator on team `ops_bot` deploys two Applications where one reads a built-in value from the other through `valueFrom: application.<other-app>.<built-in>` (for example, the other application's hostname). Both Applications are owned by the same team. The operator wants the consumer to be deployed after the producer without having to list it explicitly.
+
+**Why this priority**: Same-team coupling between two Applications is less common than App-to-Resource, but it is part of the supported `valueFrom` grammar and the inference rule generalizes cleanly. Shipping this together with US1 closes the loop on "any same-team `valueFrom` implies ordering." P2 because the bug report focused on the Resource case; this is the symmetry guarantee.
+
+**Independent Test**: Set up two same-owner Applications A and B where A's env contains `valueFrom: application.B.<built-in>` and A has no `spec.dependencies`. Run `shrine deploy team <owner>`. The plan lists `Application:B` strictly before `Application:A`.
+
+**Acceptance Scenarios**:
+
+1. **Given** two same-owner Applications A and B where A's env contains `valueFrom: application.B.<built-in>` and A has no `spec.dependencies`, **When** the operator runs `shrine deploy team <owner>`, **Then** the planned order lists `Application:B` strictly before `Application:A`.
+2. **Given** the dry-run output for the same setup, **When** the operator inspects A's dependencies, **Then** `Application:B` appears tagged as inferred from the relevant env var.
+
+---
+
+### User Story 3 - Cross-team valueFrom without explicit dependency fails the deploy (Priority: P3)
+
+An operator on team `team-a` writes an Application that reads from a Resource owned by `team-b` (with access granted via the Resource's `metadata.access` list). The operator expects the platform to refuse to plan the deploy unless they have declared an explicit `spec.dependencies` entry for the cross-team target, so that cross-team coupling is never silently inferred and is always made visible in code review.
+
+**Why this priority**: Cross-team ordering is intentionally an operator decision and must remain visible in code review. Silently inferring a cross-team edge would hide coupling that the other team owns; merely warning about it lets the deploy proceed in an under-specified state. Failing the planner forces the operator to acknowledge the cross-team coupling explicitly. P3 because cross-team `valueFrom` is rare and the primary inference path (US1, US2) handles the common case.
+
+**Independent Test**: Set up a Resource owned by `team-b` with `metadata.access` granting `team-a`, and an Application owned by `team-a` whose env contains `valueFrom: resource.<team-b-resource>.<output>` and no matching explicit `spec.dependencies` entry. Run `shrine deploy team team-a` (or any plan that includes the Application). The planner must fail with an error that names the cross-team reference and recommends declaring an explicit `spec.dependencies` entry. Adding the explicit entry makes the same input plan successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cross-team `valueFrom` reference with access granted and no explicit `spec.dependencies` entry naming the same target, **When** the operator runs the planner, **Then** the planner fails with an error naming the reference (kind, name, output) and recommending an explicit `spec.dependencies` entry. No inferred edge is added and no deploy steps are executed.
+2. **Given** the operator adds an explicit `spec.dependencies` entry for the cross-team target, **When** the planner runs, **Then** the explicit edge is honoured exactly as it is today, no error is raised for that reference, and no duplicate edge is created.
+
+---
+
+### Edge Cases
+
+- An env var uses `valueFrom: vault:<project>/<env>/<key>` — the inference layer ignores it because it does not name a manifest in the set.
+- An env var uses `value:` only (literal) — no `valueFrom` to interpret, so the inference layer ignores it.
+- An env var uses `valueFrom: resource.<X>.<output>` where `<X>` is not present in the current `ManifestSet` (typo, target owned by another team that did not provide the manifest, or otherwise absent). Because `shrine deploy team <T>` loads all manifests owned by team `<T>`, a missing target implies the reference is not same-team. The enrichment layer treats this case identically to a cross-team reference under FR-010: the planner fails unless the consumer's explicit `spec.dependencies` already covers the reference under the `(Kind, Name)` dedup key.
+- An operator declares an explicit dependency with a different `owner` value than the referenced manifest's actual owner (typo or stale value). The explicit entry is preserved verbatim; the inferred entry is dropped because the `(Kind, Name)` dedup key matches. The operator's text is never overwritten.
+- The same Resource is referenced by multiple env vars on the same Application. Only one inferred edge is added (dedup is per `(Kind, Name)`). The dry-run source tag names one of the originating env vars; multiple sources are coalesced.
+- An Application references a Resource the operator did declare explicitly but with extra fields (e.g., a hypothetical future field). Dedup still treats them as the same edge by `(Kind, Name)`. The explicit entry wins; inferred metadata is discarded.
+- Two same-owner Applications form a cycle via `valueFrom: application.…` references (A depends on B and B depends on A). The existing topological sort detects the cycle and emits its current cycle error. The inference layer does not need to detect or special-case cycles.
+- The `ManifestSet` passed into the inference layer is reused by callers after enrichment runs (e.g., for diagnostics or display of the raw manifests as authored). Those callers must observe the original `Spec.Dependencies` lengths and contents, unchanged by enrichment.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST derive implicit deploy-order dependencies for an Application from its env vars whose `valueFrom` references a manifest in the current `ManifestSet`.
+- **FR-002**: The system MUST apply implicit inference only when the referenced manifest's `metadata.owner` equals the consumer Application's `metadata.owner` (the same-owner gate).
+- **FR-003**: The system MUST support inference from both `valueFrom: resource.<name>.<output>` (producing a `Resource` dependency edge) and `valueFrom: application.<name>.<output>` (producing an `Application` dependency edge).
+- **FR-004**: The system MUST NOT modify any YAML file on disk during inference. Enrichment is performed entirely in memory against the already-parsed manifest objects.
+- **FR-005**: The system MUST return a new `ManifestSet` value from enrichment rather than mutating the input. Manifests that gained no inferred edges MAY be shared by reference with the input; manifests that gained inferred edges MUST be returned as new manifest values whose `spec.dependencies` was constructed by copying the original slice and appending the inferred entries.
+- **FR-006**: The system MUST dedupe inferred entries against existing explicit `spec.dependencies` entries using the `(Kind, Name)` pair as the key. When an explicit entry already names a target, the inferred entry MUST be dropped and the explicit entry preserved verbatim, including its `owner` field.
+- **FR-007**: The system MUST organize inference rules as a chain of independently composable units (one per inference rule), so that a future rule can be added without modifying existing rules and without changes to the topological-sort step.
+- **FR-008**: The system MUST place the inference step strictly between manifest validation and the existing ordering step (`Validate → Enrich → Order`). The inference step MUST NOT alter the existing manifest validation rules and MUST NOT change the topological-sort algorithm. Enrichment MAY introduce additional same-team validation checks as defined in FR-010, raised as planner errors that prevent the Order step from running.
+- **FR-009**: The dry-run/plan output MUST distinguish inferred dependencies from explicit ones. Each inferred edge MUST be shown with a source tag identifying the originating env var name on the consumer manifest (for example, `Resource:ops-bot-db (inferred from env DB_CONNECTION_URL)`).
+- **FR-010**: When a consumer Application's env contains a `valueFrom: resource.<name>.<output>` or `valueFrom: application.<name>.<output>` reference and no manifest with the matching kind and name owned by the consumer's `metadata.owner` is present in the current `ManifestSet`, the enrichment layer MUST fail the planner with an error that names the reference (kind, name, output, and the env var on the consumer) and recommends declaring an explicit `spec.dependencies` entry. This rule MUST be skipped when the consumer's explicit `spec.dependencies` already contains an entry matching the reference under the `(Kind, Name)` dedup key — in that case the explicit entry satisfies the requirement and the planner proceeds. The same failure MUST apply whether the target manifest is absent from the loaded set or is present but owned by a different team. The failure MUST occur before any deploy step executes. The enrichment layer MUST fail fast: on the first offending reference, it stops and returns the error without enumerating subsequent offending references in the same run.
+- **FR-011**: The system MUST silently ignore `valueFrom` strings that are not manifest references in the `resource.<name>.<output>` / `application.<name>.<built-in>` grammar — specifically vault references (`valueFrom: vault:…`) and literal `value:` env vars. These categories MUST NOT trigger the FR-010 failure and MUST NOT emit warnings.
+- **FR-012**: The system MUST NOT introduce changes to the manifest YAML schema. Authors MAY continue to declare explicit `spec.dependencies` entries; inference is purely additive and optional.
+- **FR-013**: Inference MUST be deterministic: the resulting set of dependency edges (post-dedup) MUST be a function of the input `ManifestSet` alone and MUST not depend on map iteration order or processing order across runs. When enrichment fails under FR-010, the offending reference reported by the fail-fast error MUST also be deterministic for a given input — re-running the planner on the same `ManifestSet` MUST report the same first-offending reference.
+
+### Key Entities *(include if feature involves data)*
+
+- **ManifestSet**: The collection of Application, Resource, and Team manifests currently in scope for a single planner invocation. Used as both the input and the output type of the enrichment layer.
+- **Application Manifest**: Declares an application's image, runtime env vars (some of which may use `valueFrom`), and an optional explicit `spec.dependencies` list.
+- **Resource Manifest**: Declares a backing service (database, queue, etc.) and its named outputs. May be the target of an `valueFrom: resource.<name>.<output>` reference.
+- **Dependency Edge**: An ordered pair `(consumer, target)` where the consumer must be deployed after the target. Each edge has a provenance: explicit (operator-declared) or inferred (with a source env var name).
+- **Enrichment Rule**: A single inference rule that transforms a `ManifestSet` into a new `ManifestSet` by adding edges according to its specific rule (e.g., `valueFrom: resource.…` or `valueFrom: application.…`). Composes via a chain so additional rules can be added later without touching existing rules.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For any same-owner Application/Resource pair where the Application's env uses `valueFrom: resource.<X>.<output>` and the Application has no explicit `spec.dependencies`, the planned deploy order places the Resource step strictly before the Application step in 100% of runs.
+- **SC-002**: For any same-owner Application-to-Application reference via `valueFrom: application.<X>.<built-in>` with no explicit `spec.dependencies`, the planned deploy order places the producer Application strictly before the consumer Application in 100% of runs.
+- **SC-003**: For every cross-team `valueFrom` reference encountered during planning without a matching explicit `spec.dependencies` entry, the planner fails with an error that names the reference and recommends declaring an explicit `spec.dependencies` entry; no deploy step executes for that plan. When a matching explicit entry exists, the planner does not fail on that reference and no duplicate edge is added.
+- **SC-004**: For any plan run with `--dry-run`, every inferred dependency edge is annotated with the consumer env var that originated it, and explicit edges carry no such annotation. An operator reading the dry-run output can distinguish the two without consulting code.
+- **SC-005**: Re-running enrichment on the same `ManifestSet` zero times, one time, or N times produces the same outcome: either the same final dependency edge set (post-dedup) when enrichment succeeds, or the same FR-010 error citing the same first-offending reference when enrichment fails. Enrichment is idempotent and order-independent across rules in both the success and failure paths.
+- **SC-006**: After enrichment, no file under the operator's specs directory has been written, modified, renamed, or deleted by the planner; the on-disk state is identical before and after the planning step.
+- **SC-007**: A reader of the pre-enrichment `ManifestSet` after the enrichment step has run observes the same `spec.dependencies` length and entries on every manifest as before enrichment (immutability of inputs).
+- **SC-008**: The original reproduction case in the bug report — a same-team Application `ops-bot` with `valueFrom: resource.ops-bot-db.DB_CONNECTION_URL` and a Resource `ops-bot-db`, no explicit deps — produces a plan that orders `Resource:ops-bot-db` before `Application:ops-bot` under `shrine deploy team ops_bot`.
+
+## Assumptions
+
+- The current `valueFrom` grammar (`resource.<name>.<output>`, `application.<name>.<built-in>`, `vault:<project>/<env>/<key>`) is stable for the scope of this feature. The inference layer parses only these prefixes; new prefixes would warrant their own decorators in a follow-up.
+- Manifest validation runs before enrichment and rejects malformed `valueFrom` strings and references to manifests outside the operator's access scope. The enrichment layer is allowed to treat any reference that passes validation but is not present in the in-memory `ManifestSet` as out-of-scope (silently skipped, except for the same-owner cross-team nudge).
+- The `metadata.owner` field is authoritative for the same-owner gate. Operators do not impersonate other owners in their own manifests; that is enforced elsewhere.
+- The current planner pipeline (`LoadDir → Validate → Order → topo.Sort`) is the right place to insert enrichment between Validate and Order. Existing callers of the planner do not bypass Validate, so they will all observe the enrichment effect uniformly. Enrichment may now return errors (FR-010); callers must propagate them as planner failures.
+- When the planner is invoked via `shrine deploy team <T>`, the loaded `ManifestSet` contains all manifests owned by team `<T>`. The enrichment layer relies on this completeness assumption to treat absence-from-set as equivalent to not-same-team for the FR-010 failure rule.
+- Cross-team coupling that today depends on luck or hand-ordering is rare and acceptable to surface via the informational nudge; no migration of existing manifests is required by this feature.
+- Inferred dependencies do not need to be persisted to disk or surfaced anywhere outside the planner's in-memory data structures and the dry-run/plan output. There is no need to write them back into the YAML.
+- The dry-run output already enumerates per-step dependencies in some form; this feature extends that surface to include provenance tagging. If the current output is silent about dependencies, FR-009 implies adding the minimal dependency listing needed to make provenance visible.

--- a/specs/020-infer-valuefrom-deps/tasks.md
+++ b/specs/020-infer-valuefrom-deps/tasks.md
@@ -1,0 +1,245 @@
+---
+description: "Task list for feature 020-infer-valuefrom-deps"
+---
+
+# Tasks: Infer Implicit Deploy-Order Dependencies from Same-Owner valueFrom References
+
+**Input**: Design documents from `/specs/020-infer-valuefrom-deps/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/enrichment-api.md, quickstart.md
+
+**Tests**: Tests are REQUIRED for this feature — Principle V of the constitution mandates an integration-test gate and explicit TDD ("integration test files are created before the implementation code"). Unit tests follow TDD conventions where practical.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and tested independently. The shared enrichment machinery (interface, chain, error type, the `applyEnrichmentRule` helper that contains the fail-fast same-team check, the `Plan()` wiring, the dry-run formatter, the handler error propagation) sits in Phase 2 Foundational because all three user stories depend on it. Each user story then ships its concrete rule wrapper (US1, US2) or its end-to-end failure-mode scenarios (US3).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-project Go CLI. Source under `internal/planner/`, `internal/handler/`, `internal/manifest/`. Unit tests live next to their source files (`*_test.go`). Integration tests live under `tests/integration/` and run against the real shrine binary with `NewDockerSuite` (Principle V).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the empty source files so subsequent tasks have stable file paths to edit.
+
+- [X] T001 Create empty Go source files `internal/planner/enrich.go` and `internal/planner/enrich_valuefrom.go` with `package planner` declarations and import blocks for `github.com/CarlosHPlata/shrine/internal/manifest` and `sort`. Confirm the new files compile (`go build ./internal/planner/...`).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: All shared enrichment machinery — types, helpers, chain composer, planner wiring, dry-run formatter, handler error propagation. The fail-fast same-team check (FR-010) lives in the shared `applyEnrichmentRule` helper here so US1, US2, and US3 all inherit it.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+### Foundational tests (write FIRST per TDD — these MUST fail before T006–T016 land)
+
+- [X] T002 [P] Write failing unit tests for `parseValueFromRef` in `internal/planner/enrich_valuefrom_test.go` covering: `resource.<name>.<output>` → ok with `Kind=="resource"`; `application.<name>.<output>` → ok with `Kind=="application"`; `vault:proj/env/key` → `(_, false)`; empty string → `(_, false)`; `resource.foo` (two parts) → `(_, false)`; `resource..output` (empty middle) → `(_, false)`; unknown prefix `secret.x.y` → `(_, false)`.
+
+- [X] T003 Write failing unit tests for `copyManifestSetShallow`, `cloneApplicationWithDeps`, `hasExplicitDependency` in `internal/planner/enrich_test.go`. Cover: shallow copy yields a new `*ManifestSet` with fresh maps but pointer-shared values; `cloneApplicationWithDeps` with `len(extra)==0` returns the same pointer; with `extra` returns a new pointer whose `Spec.Dependencies` is the original slice plus appended entries, with the original slice unchanged; `hasExplicitDependency` returns true on `(Kind,Name)` match ignoring `Owner`.
+
+- [X] T004 Write failing unit tests for `ChainEnrich` in `internal/planner/enrich_test.go`. Cover: empty rule chain returns `(shallowCopy, nil, nil)`; two-rule chain threads the set so rule 2 observes rule 1's added edges (cross-rule dedup); first rule returning a non-nil error short-circuits — second rule is NOT invoked; success-path idempotence (running the chain twice on the input produces edges identical to running it once); failure-path idempotence (running on the same failing input twice produces an `*EnrichmentError` with identical structured fields).
+
+- [X] T005 Write failing unit tests for `applyEnrichmentRule` failure paths in `internal/planner/enrich_test.go` using minimal fake `lookupOwner` and `parseFor` callbacks. Cover (FR-010, US3 AS1): cross-team reference with no explicit dep → returns `*EnrichmentError{Kind: ErrCrossTeamOrUnresolvedValueFrom, ...}` with `Steps == nil`; absent-target reference with no explicit dep → same error (Q2 clarification); cross-team reference WITH a matching `(Kind, Name)` explicit dep → succeeds, no error, no inferred edge added (FR-010 second clause, US3 AS2); deterministic first-error across runs when multiple bad refs exist — assert the same offending consumer name + env var name is reported on repeated calls (FR-013 failure-path determinism, Q3 clarification).
+
+### Foundational implementation (TDD — only start once T002–T005 are written and failing)
+
+- [X] T006 Define types in `internal/planner/enrich.go`: the `Enricher` interface (`Enrich(*ManifestSet) (*ManifestSet, error)`); the `ManifestRef` struct (`Kind`, `Name`, `Owner string`); the `InferredEdge` struct (`Consumer`, `Target ManifestRef`, `EnvVar string`); the `EnrichmentError` struct with all fields from data-model.md §New types; the `EnrichmentErrorKind` string type and the `ErrCrossTeamOrUnresolvedValueFrom` constant; the `Error()` method on `*EnrichmentError` returning the exact format specified in contracts/enrichment-api.md §2.1.
+
+- [X] T007 Implement the helper functions in `internal/planner/enrich.go`: `copyManifestSetShallow(set *ManifestSet) *ManifestSet`; `cloneApplicationWithDeps(app *manifest.ApplicationManifest, extra []manifest.Dependency) *manifest.ApplicationManifest` (returns the input pointer if `len(extra) == 0`); `hasExplicitDependency(deps []manifest.Dependency, kind, name string) bool`. T003 unit tests must pass after this task.
+
+- [X] T008 [P] Implement `parseValueFromRef(s string) (valueFromRef, bool)` and the private `valueFromRef` struct in `internal/planner/enrich_valuefrom.go`. Recognize exactly the `resource.<name>.<output>` and `application.<name>.<output>` grammars; return `(_, false)` for vault, literal, malformed, or unknown-prefix inputs (FR-011). T002 unit tests must pass after this task.
+
+- [X] T009 Implement `applyEnrichmentRule(set *ManifestSet, targetKind string, lookupOwner func(string) (string, bool), parseFor func(string) (valueFromRef, bool)) (*ManifestSet, []InferredEdge, error)` in `internal/planner/enrich_valuefrom.go`. Iterate `set.Applications` in sorted-by-name order (Decision 8). For each Application, scan `Spec.Env` in declaration order. For each env var: call `parseFor`; if `(_, false)`, skip silently. If `hasExplicitDependency(app.Spec.Dependencies, targetKind, ref.Name)` is true, skip the env var (explicit wins; no edge, no failure check). Otherwise call `lookupOwner(ref.Name)`: if `!exists || owner != app.Metadata.Owner`, return `(nil, nil, &EnrichmentError{Kind: ErrCrossTeamOrUnresolvedValueFrom, ...})` immediately (fail-fast). On a successful same-owner match, append the inferred edge and replace the app in the working set via `cloneApplicationWithDeps`. T005 unit tests must pass after this task.
+
+- [X] T010 Implement `ChainEnrich(set *ManifestSet, rules ...Enricher) (*ManifestSet, []InferredEdge, error)` in `internal/planner/enrich.go`. Start by calling `copyManifestSetShallow(set)`. Loop over rules, threading the current set through each. If any rule returns a non-nil error, return `(nil, nil, err)` immediately. Aggregate `[]InferredEdge` across rules (each rule's edges appended to the running slice). T004 unit tests must pass after this task.
+
+- [X] T011 Add empty struct stubs `enrichValueFromResource{}` and `enrichValueFromApplication{}` with no-op `Enrich(set *ManifestSet) (*ManifestSet, error)` methods returning `(set, nil)` in `internal/planner/enrich_valuefrom.go`. Implement `DefaultEnrichers() []Enricher` in `internal/planner/enrich.go` returning `[]Enricher{enrichValueFromResource{}, enrichValueFromApplication{}}` in that fixed order. Rule bodies are filled in US1 (T019) and US2 (T024); the stubs let `Plan()` integrate now.
+
+- [X] T012 [P] Add the `InferredEdges []InferredEdge` field to the `PlanResult` struct in `internal/planner/plan.go`. Add a one-line doc comment per data-model.md.
+
+- [X] T013 Wire `ChainEnrich(set, DefaultEnrichers()...)` into `planner.Plan()` in `internal/planner/plan.go`, placed strictly between the existing `Resolve(...)` call and the existing filter switch (per FR-008 + Decision 1). On non-nil error from `ChainEnrich`, return `PlanResult{Error: err}` with `Steps`, `ManifestSet`, and `InferredEdges` all `nil`. On success, replace the working set with the enriched one and populate `PlanResult.InferredEdges`.
+
+- [X] T014 [P] Implement `formatDeployPlan(steps []PlannedStep, set *ManifestSet, edges []InferredEdge) string` in a new file `internal/handler/deploy_plan_format.go`. Render the exact format documented in contracts/enrichment-api.md §2.2: header `Deploy order:`, then per-step `  <ordinal>. <Kind>:<Name>`; for steps with non-empty `Spec.Dependencies`, emit a `       depends on:` block listing deps in the order they appear in `Spec.Dependencies`; tag inferred deps with ` (inferred from env <NAME>)` where the env var name comes from `edges` matched by `(Consumer.Name, Target.Kind, Target.Name)`.
+
+- [X] T015 Wire `formatDeployPlan` into `internal/handler/dryrun.go`. After `Plan()` succeeds (Error == nil), write `formatDeployPlan(result.Steps, result.ManifestSet, result.InferredEdges)` to the command's stdout before calling `engine.ExecuteDeploy`. On Plan() failure, do not render the summary — fall through to the existing error path that prints `result.Error.Error()` to stderr with non-zero exit.
+
+- [X] T016 Verify error propagation in `internal/handler/deploy.go`, `internal/handler/dryrun.go`, `internal/handler/apply_single.go`: confirm each path checks `result.Error != nil` and writes `result.Error.Error()` to ErrOut + returns a non-zero exit. Add or extend a unit test in `internal/handler/deploy_test.go` (or the equivalent existing test file) that constructs a fake `PlanResult{Error: &planner.EnrichmentError{...}}` and asserts the error message lands on stderr with a non-zero exit code.
+
+**Checkpoint**: Foundation ready. `Plan()` runs the chain (with no-op rule bodies), the failure path is wired end-to-end, the dry-run summary header renders. User story work can now begin.
+
+---
+
+## Phase 3: User Story 1 — Application sequenced after same-team Resource (Priority: P1) 🎯 MVP
+
+**Goal**: Filling in the `enrichValueFromResource` rule body so the planner orders a same-team `Resource` strictly before a same-team `Application` whose env contains `valueFrom: resource.<X>.<output>`. This is the original bug fix.
+
+**Independent Test**: Place a same-owner Application + Resource pair in a fresh specs directory where the Application's env uses `valueFrom: resource.<resource-name>.<output>` and the Application has no `spec.dependencies` block. Run `shrine deploy team <owner>`. The plan emits the Resource step before the Application step (US1 AS1). Run `shrine deploy team <owner> --dry-run`. The Application step shows its dependency on `Resource:<X>` tagged `(inferred from env DB_CONNECTION_URL)` (US1 AS2). Add an explicit `spec.dependencies` entry for the same Resource: the plan is identical (no duplicate edge) and the explicit `owner` is preserved (US1 AS3).
+
+### Tests for US1 (TDD — write FIRST)
+
+- [X] T017 [P] [US1] Write failing integration test `TestDeployTeam_SequencesAppAfterSameTeamResource` in `tests/integration/deploy_team_infer_test.go` using `NewDockerSuite`. Set up the `ops_bot` Application + `ops-bot-db` Resource from `quickstart.md` Part A. Run `shrine deploy team ops_bot --dry-run` as a subprocess. Assert: stdout contains `Deploy order:`, `Resource:ops-bot-db` appears before `Application:ops-bot`, and the `Application:ops-bot` step's `depends on:` block lists `Resource:ops-bot-db (inferred from env DB_CONNECTION_URL)`. Add a second assertion in the same test (or a sibling test) that runs the real `shrine deploy team ops_bot`, asserts a clean Docker rollout, and asserts `git status specs/` reports no diff (SC-006).
+
+- [X] T018 [P] [US1] Write failing unit tests for `enrichValueFromResource` in `internal/planner/enrich_valuefrom_test.go`. Cover: same-team resource ref adds the expected inferred edge with `EnvVar` populated from declaration order; cross-team resource ref with no explicit dep raises `*EnrichmentError`; absent-target resource ref with no explicit dep raises `*EnrichmentError`; explicit `spec.dependencies` entry with matching `(Kind, Name)` short-circuits the failure check and skips the inferred edge; an env var with `valueFrom: application.X.Y` is left to the application rule (this rule does NOT touch it); vault and literal env vars are silently skipped (no edge, no error).
+
+### Implementation for US1
+
+- [X] T019 [US1] Fill in `enrichValueFromResource.Enrich(set *ManifestSet)` in `internal/planner/enrich_valuefrom.go`. Replace the no-op stub with a single call to `applyEnrichmentRule(set, manifest.ResourceKind, lookupResourceOwner(set), parseResourceRef)` where `lookupResourceOwner(set)` returns a closure reading from `set.Resources` and `parseResourceRef(s)` calls `parseValueFromRef(s)` and filters to refs where `Kind == "resource"`. T018 unit tests must pass after this task.
+
+- [X] T020 [US1] Verify the integration test from T017 passes end-to-end (`go test -tags integration ./tests/integration/ -run TestDeployTeam_SequencesAppAfterSameTeamResource`). If the dry-run summary text differs from the contract's expected format, fix `formatDeployPlan` in `internal/handler/deploy_plan_format.go` rather than the test.
+
+**Checkpoint**: US1 ships — the original bug is fixed. MVP achieved. The platform can be deployed in this state and the `shrine deploy team ops_bot` reproduction case from the spec now orders correctly.
+
+---
+
+## Phase 4: User Story 2 — App-to-app inference within a team (Priority: P2)
+
+**Goal**: Filling in the `enrichValueFromApplication` rule body so a same-team Application that reads a built-in value from another same-team Application via `valueFrom: application.<other>.<built-in>` is deployed strictly after the producer.
+
+**Independent Test**: Set up two same-owner Applications A and B where A's env contains `valueFrom: application.B.<built-in>` and A has no `spec.dependencies`. Run `shrine deploy team <owner>`. The plan lists `Application:B` strictly before `Application:A` (US2 AS1). The dry-run lists `Application:B` tagged as inferred from the relevant env var (US2 AS2).
+
+### Tests for US2 (TDD — write FIRST)
+
+- [X] T021 [P] [US2] Write failing integration test `TestDeployTeam_SequencesAppAfterSameTeamApplication` in `tests/integration/deploy_team_infer_test.go`. Set up two `ops_bot`-owned Applications where one reads the other's built-in hostname via `valueFrom: application.<producer>.HOST` and has no explicit deps. Run `shrine deploy team ops_bot --dry-run`. Assert the producer's step ordinal is strictly less than the consumer's; assert the consumer's `depends on:` block tags the producer as `(inferred from env <NAME>)`.
+
+- [X] T022 [P] [US2] Write failing unit tests for `enrichValueFromApplication` in `internal/planner/enrich_valuefrom_test.go`. Cover: same-team app-to-app reference adds the expected inferred edge; cross-team app-to-app reference with no explicit dep raises `*EnrichmentError`; absent-target app-to-app reference raises `*EnrichmentError`; explicit `spec.dependencies` entry short-circuits the failure check; an env var with `valueFrom: resource.X.Y` is left to the resource rule (this rule does NOT touch it).
+
+### Implementation for US2
+
+- [X] T023 [US2] Fill in `enrichValueFromApplication.Enrich(set *ManifestSet)` in `internal/planner/enrich_valuefrom.go`. Replace the no-op stub with a single call to `applyEnrichmentRule(set, manifest.ApplicationKind, lookupApplicationOwner(set), parseApplicationRef)` where `lookupApplicationOwner(set)` returns a closure reading from `set.Applications` and `parseApplicationRef(s)` calls `parseValueFromRef(s)` and filters to refs where `Kind == "application"`. T022 unit tests must pass after this task.
+
+- [X] T024 [US2] Verify the integration test from T021 passes end-to-end (`go test -tags integration ./tests/integration/ -run TestDeployTeam_SequencesAppAfterSameTeamApplication`).
+
+**Checkpoint**: US2 ships — both production enrichment rules are active. Any same-team `valueFrom` reference (resource or application) is now inferred as a deploy-order edge.
+
+---
+
+## Phase 5: User Story 3 — Cross-team valueFrom without explicit dependency fails the deploy (Priority: P3)
+
+**Goal**: Demonstrate end-to-end that a `valueFrom` reference whose target is not same-team — whether truly cross-team or absent from the loaded set — fails the planner with the FR-010 error, unless an explicit `spec.dependencies` entry covers the reference. The failure logic itself is implemented in Foundational (T009) and exercised through both rules (US1/US2). US3 is the integration-level verification of that behaviour plus the determinism guarantee.
+
+**Independent Test**: Set up a Resource owned by `team-b` with `metadata.access` granting `team-a`, and an Application owned by `team-a` whose env contains `valueFrom: resource.<team-b-resource>.<output>` and no explicit dep (US3 AS1). Run `shrine deploy team team-a`. The planner fails with the `enrichment: app "..." env "..." references resource "..." which is not owned by team "..."` error on stderr, non-zero exit, and no Docker side-effects. Add the explicit `spec.dependencies` entry — re-run; the deploy succeeds and the dry-run summary shows the dep without an `(inferred ...)` tag (US3 AS2).
+
+### Tests for US3 (TDD — write FIRST)
+
+- [X] T025 [P] [US3] Write failing integration test `TestDeployTeam_FailsOnCrossTeamValueFromWithoutExplicitDep` in `tests/integration/deploy_team_infer_test.go`. Set up the `team_b`-owned `shared-cache` Resource (with `access: [ops_bot]`) and an `ops_bot`-owned Application with `valueFrom: resource.shared-cache.HOST` and no explicit deps. Run `shrine deploy team ops_bot --dry-run`. Assert non-zero exit; assert stderr contains the exact `enrichment: app "ops-bot" env "CACHE_HOST" references resource "shared-cache.HOST" which is not owned by team "ops_bot"; add an explicit spec.dependencies entry (kind: Resource, name: shared-cache) to declare this dependency` line; assert no `[DOCKER]` lines appear on stdout; assert no Docker containers / networks / volumes were created (use the suite's leftover-state assertion).
+
+- [X] T026 [P] [US3] Write failing integration test `TestDeployTeam_SucceedsOnCrossTeamValueFromWithExplicitDep` in `tests/integration/deploy_team_infer_test.go`. Same setup as T025 but with an explicit `spec.dependencies: [{kind: Resource, name: shared-cache, owner: team_b}]` on `ops-bot`. Run `shrine deploy team ops_bot --dry-run`. Assert zero exit; assert the dry-run summary lists `Resource:shared-cache` under `Application:ops-bot`'s deps WITHOUT the `(inferred ...)` tag (SC-004); assert no `enrichment:` error appears on stderr.
+
+- [X] T027 [P] [US3] Write failing integration test `TestDeployTeam_FailsOnAbsentTargetReference` in `tests/integration/deploy_team_infer_test.go`. Set up an `ops_bot`-owned Application with `valueFrom: resource.does-not-exist.HOST` and no explicit deps. Run `shrine deploy team ops_bot --dry-run`. Assert non-zero exit; assert stderr's `enrichment:` line names `does-not-exist` as the unresolved target (Q2 clarification — absent target treated identically to cross-team).
+
+- [X] T028 [P] [US3] Write failing integration test `TestDeployTeam_FailsFastOnFirstOffendingRef` in `tests/integration/deploy_team_infer_test.go`. Set up two `ops_bot`-owned Applications, each with multiple bad refs (mixing cross-team and absent). Run `shrine deploy team ops_bot --dry-run` twice. Assert: exactly one `enrichment:` line appears on stderr per run (fail-fast, Q3); the line is identical byte-for-byte across both runs (FR-013 failure-path determinism); the offending consumer is the first Application by `metadata.name` sort order and the offending env var is the first one in that Application's declaration order (Decision 8).
+
+### Implementation for US3
+
+- [X] T029 [US3] No new production code expected — the FR-010 failure behaviour is delivered by `applyEnrichmentRule` (T009) plus the rule wrappers (T019, T023). Verify each of T025–T028 passes end-to-end (`go test -tags integration ./tests/integration/ -run TestDeployTeam_(FailsOnCrossTeam|Succeeds|FailsOnAbsent|FailsFast)`). If any test fails due to a formatting drift (e.g., the error message in `(*EnrichmentError).Error()` differs from the contract), fix the source in `internal/planner/enrich.go` rather than the test. If the absent-target case fails because the target's owner cannot be determined when the manifest is not in the set, confirm `applyEnrichmentRule`'s `lookupOwner` returns `("", false)` for missing names and that the failure branch fires on `!exists` — both conditions must hit the same error path.
+
+**Checkpoint**: All three user stories shipped. The original bug is fixed, app-to-app same-team inference works, and silent under-specification of cross-team coupling is impossible.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Invariant tests that span all three stories, documentation refresh, and the constitution's Principle V gate.
+
+- [X] T030 [P] Add a no-disk-write invariant unit test in `internal/planner/plan_test.go` (new test `TestPlan_DoesNotWriteToDisk`). Construct an in-memory `ManifestSet` via test fixtures, snapshot the mtime of the working directory, run `Plan()`, assert the mtime is unchanged. Run the same assertion on the failure path (a cross-team setup that triggers FR-010). Covers SC-006.
+
+- [X] T031 [P] Add an input-immutability invariant unit test in `internal/planner/plan_test.go` (new test `TestPlan_DoesNotMutateInputSet`). Snapshot every Application's `len(Spec.Dependencies)` and the slice's contents before calling `Plan()` and assert they are byte-identical after, on both the success path and the FR-010 failure path. Covers SC-007 + invariant 1 from data-model.md.
+
+- [X] T032 [P] Walk through `specs/020-infer-valuefrom-deps/quickstart.md` Part A scenarios manually against the built binary (`go build -o /tmp/shrine ./cmd/shrine` then run each `shrine deploy team ops_bot ...` invocation). Confirm the printed output matches the quickstart's expected blocks. Any discrepancy → fix code (preferred) or update quickstart (only if the design genuinely changed).
+
+- [X] T033 [P] Update `AGENTS.md` with one line under the planner section noting same-team-only enrichment for `valueFrom: resource.*` and `valueFrom: application.*` references and the fail-fast cross-team behaviour, with a pointer to `specs/020-infer-valuefrom-deps/spec.md` and `specs/020-infer-valuefrom-deps/quickstart.md`.
+
+- [X] T034 Run the integration gate (Principle V hard gate): `go test -tags integration ./tests/integration/...` from repo root. All `TestDeployTeam_*` tests from this feature must pass; no pre-existing integration tests should regress.
+
+- [X] T035 Run `graphify update .` to refresh the knowledge graph after the enrichment-layer additions (per project CLAUDE.md "After modifying code, run graphify update").
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. BLOCKS all user stories. The TDD tests (T002–T005) gate the implementation tasks (T006–T016) by Principle V's "tests before implementation" rule.
+- **User Stories (Phase 3–5)**: All depend on Foundational completion.
+  - US1 and US2 can be developed in parallel — they edit disjoint `Enrich()` bodies in `enrich_valuefrom.go` (T019, T023). Their unit-test additions to `enrich_valuefrom_test.go` and their integration-test additions to `deploy_team_infer_test.go` are also disjoint test functions, mergeable independently.
+  - US3 has no new production code; its tests (T025–T028) can be written in parallel with US1/US2's tests, but T029 (verify-and-fix) requires both US1's and US2's rule bodies to be in place.
+- **Polish (Phase 6)**: Depends on US1 + US2 + US3 being complete.
+
+### Within Each Phase
+
+- Tests (T002–T005, T017–T018, T021–T022, T025–T028) MUST be written and failing before the corresponding implementation tasks.
+- Within Foundational: T006 (types) before T007/T008/T009/T010/T011 (which use them); T012 (PlanResult field) before T013 (Plan() wiring uses InferredEdges); T013/T014 before T015 (DryRun handler wiring); T013 before T016 (handler error propagation verification).
+
+### Parallel Opportunities
+
+- **In Foundational tests**: T002 [P] (different file) parallel with T003/T004/T005 (same file, sequential among themselves).
+- **In Foundational implementation**: T008 [P] (enrich_valuefrom.go) parallel with T006/T007 (enrich.go); T012 [P] (plan.go) parallel with all enrich.go/enrich_valuefrom.go work; T014 [P] (deploy_plan_format.go) parallel with most of Foundational once T006 defines `InferredEdge`.
+- **Across US1 + US2**: T017 [P] T018 [P] T021 [P] T022 [P] — all four can be written by different developers in parallel. T019 and T023 edit disjoint Enrich bodies and can land in parallel commits.
+- **US3 tests**: T025–T028 are four independent integration test functions in the same file; can be drafted in parallel but committed sequentially to avoid merge churn.
+- **Polish**: T030, T031, T032, T033 are all [P] (disjoint files).
+
+---
+
+## Parallel Example: Foundational Tests
+
+```bash
+# Four developers can draft these failing tests at the same time:
+T002 [P] — parseValueFromRef tests in enrich_valuefrom_test.go
+T003     — copyManifestSetShallow/cloneApplicationWithDeps/hasExplicitDependency tests in enrich_test.go
+T004     — ChainEnrich tests in enrich_test.go (after T003 merges to avoid same-file conflict)
+T005     — applyEnrichmentRule failure-path tests in enrich_test.go (after T004 merges)
+```
+
+## Parallel Example: User Stories 1 + 2
+
+```bash
+# Once Foundational is done, two developers can work in parallel:
+Developer A (US1): T017 [P] → T018 [P] → T019 → T020
+Developer B (US2): T021 [P] → T022 [P] → T023 → T024
+
+# US3's tests can be drafted concurrently by either developer:
+T025 [P], T026 [P], T027 [P], T028 [P] (sequential commits, parallel drafts)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Complete Phase 1: Setup (T001).
+2. Complete Phase 2: Foundational (T002–T016). This is the bulk of the work; budget for it accordingly.
+3. Complete Phase 3: US1 (T017–T020).
+4. **STOP and VALIDATE**: The original bug from the feature input is fixed. Same-team `valueFrom: resource.*` references are inferred as deploy-order edges.
+5. Optionally deploy / demo / ship.
+
+### Incremental Delivery
+
+1. Foundational + US1 → MVP ships. Cross-team failure protection is already active (lives in `applyEnrichmentRule`, T009), so even though only the resource rule is wired, any cross-team `valueFrom: resource.*` already fails appropriately.
+2. Add US2 → app-to-app same-team inference now works too.
+3. Add US3 → integration-level coverage of the failure path (no new production code; just tests).
+4. Polish → invariants, docs, integration gate, graph refresh.
+
+### Parallel Team Strategy
+
+Once Foundational (Phase 2) is done:
+- Developer A: US1 (rule wrapper + tests).
+- Developer B: US2 (rule wrapper + tests).
+- Developer C: US3 (failure-mode integration tests) + Polish (T030–T033).
+- All three merge together; T029 (verify US3 tests pass) gates on US1 + US2 being in.
+
+---
+
+## Notes
+
+- `[P]` strictly means "different file, no upstream dependency"; tasks in the same file are listed without `[P]` even when the underlying changes are logically independent, to avoid merge-conflict surprises.
+- The fail-fast same-team check (FR-010) lives in `applyEnrichmentRule` (T009) and is therefore active from the moment Foundational lands — even before US1/US2 fill in their rule bodies. The empty rule stubs from T011 simply return `(set, nil)`, so no `valueFrom` is parsed until the bodies are filled in T019 / T023; cross-team rejection then activates for resource refs (US1) and application refs (US2) as those rules ship.
+- Run `graphify update .` (T035) after the implementation to keep the knowledge graph current — CLAUDE.md asks for it after any code modification.
+- Constitution Principle V: integration tests via `NewDockerSuite` against the real shrine binary. All `TestDeployTeam_*` tests in this feature MUST use that harness; in-process testing of `cmd.Execute()` belongs in `cmd/cmd_test.go`, not in `tests/integration/`.

--- a/tests/integration/deploy_team_infer_test.go
+++ b/tests/integration/deploy_team_infer_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	. "github.com/CarlosHPlata/shrine/tests/integration/testutils"
+)
+
+func deployTeamInferFixturesPath(parts ...string) string {
+	_, f, _, _ := runtime.Caller(0)
+	base := filepath.Join(filepath.Dir(f), "..", "..", "tests", "testdata", "deploy_team_infer")
+	return filepath.Join(append([]string{base}, parts...)...)
+}
+
+const (
+	inferTeamA = "shrine-team-a"
+	inferTeamB = "shrine-team-b"
+)
+
+// TestDeployTeam_Inference covers US1, US2, and US3: same-team valueFrom
+// inference and the cross-team / absent-target fail-fast contract.
+func TestDeployTeam_Inference(t *testing.T) {
+	s := NewDockerSuite(t, inferTeamA)
+
+	s.BeforeEach(func(tc *TestCase) {
+		CleanupTeam(tc, inferTeamB)
+		tc.StateDir = tc.TempDir()
+		SeedSubnetState(tc)
+		tc.Run("apply", "teams",
+			"--path", deployTeamInferFixturesPath("teams"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+	})
+
+	s.AfterEach(func(tc *TestCase) {
+		CleanupTeam(tc, inferTeamB)
+	})
+
+	// ---- US1 ----
+
+	s.Test("US1: dry-run orders Resource before Application via inferred edge", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us1"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess().
+			AssertOutputContains("Deploy order:").
+			AssertOutputContains("Resource:ops-bot-db").
+			AssertOutputContains("Application:ops-bot").
+			AssertOutputContains("Resource:ops-bot-db (inferred from env DB_CONNECTION_URL)")
+
+		out := tc.RunResult().Stdout
+		idxRes := strings.Index(out, "Resource:ops-bot-db")
+		idxApp := strings.Index(out, "Application:ops-bot")
+		if idxRes < 0 || idxApp < 0 || idxRes >= idxApp {
+			tc.Fatalf("expected Resource before Application in plan summary\n%s", out)
+		}
+	})
+
+	s.Test("US1: real deploy succeeds and creates containers in inferred order", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--path", deployTeamInferFixturesPath("us1"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		tc.AssertContainerRunning(inferTeamA + ".ops-bot-db")
+		tc.AssertContainerRunning(inferTeamA + ".ops-bot")
+	})
+
+	s.Test("US1: explicit dep produces no duplicate edge and no inferred tag", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us1_explicit"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess().
+			AssertOutputContains("Resource:ops-bot-db")
+
+		out := tc.RunResult().Stdout
+		// Explicit dep means the line for the dep does NOT carry an inferred tag.
+		appBlock := afterSubstring(out, "Application:ops-bot")
+		if strings.Contains(appBlock, "inferred from env") {
+			tc.Fatalf("explicit dep must not be tagged as inferred:\n%s", appBlock)
+		}
+		if strings.Count(appBlock, "Resource:ops-bot-db") > 1 {
+			tc.Fatalf("expected exactly one Resource:ops-bot-db line under Application:ops-bot, got:\n%s", appBlock)
+		}
+	})
+
+	// ---- US2 ----
+
+	s.Test("US2: dry-run orders producer Application before consumer Application", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us2"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess().
+			AssertOutputContains("Application:producer").
+			AssertOutputContains("Application:consumer").
+			AssertOutputContains("Application:producer (inferred from env PROD_HOST)")
+
+		out := tc.RunResult().Stdout
+		// The step lines look like "  1. Application:producer" / "  2. Application:consumer".
+		// We want producer's STEP line to come before consumer's STEP line.
+		idxProducerStep := strings.Index(out, ". Application:producer")
+		idxConsumerStep := strings.Index(out, ". Application:consumer")
+		if idxProducerStep < 0 || idxConsumerStep < 0 || idxProducerStep >= idxConsumerStep {
+			tc.Fatalf("expected producer step before consumer step in plan summary\n%s", out)
+		}
+	})
+
+	// ---- US3 ----
+
+	s.Test("US3: cross-team reference without explicit dep fails with enrichment error", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us3_crossteam"),
+			"--state-dir", tc.StateDir,
+		).AssertFailure().
+			AssertStderrContains(`enrichment: app "ops-bot" env "CACHE_HOST" references resource "shared-cache.HOST" which is not owned by team "shrine-team-a"`).
+			AssertStderrContains(`add an explicit spec.dependencies entry (kind: Resource, name: shared-cache)`)
+
+		// No Docker side-effects.
+		tc.AssertContainerNotExists(inferTeamA + ".ops-bot")
+	})
+
+	s.Test("US3: cross-team reference WITH explicit dep succeeds and is not tagged inferred", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us3_crossteam_explicit"),
+			"--state-dir", tc.StateDir,
+		).AssertSuccess()
+
+		out := tc.RunResult().Stdout
+		if strings.Contains(out, "enrichment:") {
+			tc.Fatalf("expected no enrichment error, got stderr/out:\n%s\n%s", tc.RunResult().Stdout, tc.RunResult().Stderr)
+		}
+		appBlock := afterSubstring(out, "Application:ops-bot")
+		if !strings.Contains(appBlock, "Resource:shared-cache") {
+			tc.Fatalf("expected explicit Resource:shared-cache dep, got:\n%s", appBlock)
+		}
+		if strings.Contains(appBlock, "Resource:shared-cache (inferred") {
+			tc.Fatalf("explicit dep must not be tagged inferred:\n%s", appBlock)
+		}
+	})
+
+	s.Test("US3: absent target reference fails with enrichment error naming the missing target", func(tc *TestCase) {
+		tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us3_absent"),
+			"--state-dir", tc.StateDir,
+		).AssertFailure().
+			AssertStderrContains(`enrichment:`).
+			AssertStderrContains(`does-not-exist`)
+	})
+
+	s.Test("US3: fail-fast reports first offending ref deterministically across runs", func(tc *TestCase) {
+		first := tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us3_failfast"),
+			"--state-dir", tc.StateDir,
+		).AssertFailure().RunResult().Stderr
+
+		second := tc.Run("deploy", "team", inferTeamA,
+			"--dry-run",
+			"--path", deployTeamInferFixturesPath("us3_failfast"),
+			"--state-dir", tc.StateDir,
+		).AssertFailure().RunResult().Stderr
+
+		firstLine := firstEnrichmentLine(first)
+		secondLine := firstEnrichmentLine(second)
+		if firstLine == "" {
+			tc.Fatalf("no enrichment line in stderr:\n%s", first)
+		}
+		if firstLine != secondLine {
+			tc.Fatalf("non-deterministic first error\nrun 1: %s\nrun 2: %s", firstLine, secondLine)
+		}
+		// Sorted-by-name: alpha < beta, declaration order: A1 first.
+		if !strings.Contains(firstLine, `app "alpha"`) || !strings.Contains(firstLine, `env "A1"`) {
+			tc.Fatalf("expected first error on alpha/A1, got: %s", firstLine)
+		}
+		// Fail-fast: exactly one enrichment line per run.
+		if strings.Count(first, "enrichment:") != 1 {
+			tc.Fatalf("expected exactly one enrichment line, got %d:\n%s",
+				strings.Count(first, "enrichment:"), first)
+		}
+	})
+}
+
+// afterSubstring returns the slice of s starting right after the FIRST
+// occurrence of needle, up to the next "  N. " step ordinal or end of string.
+// Used to scope assertions to one step's "depends on:" block.
+func afterSubstring(s, needle string) string {
+	idx := strings.Index(s, needle)
+	if idx < 0 {
+		return ""
+	}
+	tail := s[idx:]
+	// Find the next "\n  " followed by a digit and ". " — i.e. next step.
+	for i := 1; i < len(tail)-4; i++ {
+		if tail[i] == '\n' && tail[i+1] == ' ' && tail[i+2] == ' ' &&
+			tail[i+3] >= '0' && tail[i+3] <= '9' {
+			return tail[:i]
+		}
+	}
+	return tail
+}
+
+func firstEnrichmentLine(stderr string) string {
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.Contains(line, "enrichment:") {
+			return line
+		}
+	}
+	return ""
+}

--- a/tests/integration/testutils/testsuite.go
+++ b/tests/integration/testutils/testsuite.go
@@ -84,6 +84,17 @@ func (tc *TestCase) Setenv(key, value string) {
 	tc.t.Setenv(key, value)
 }
 
+// RunResult returns the captured Result from the most recent Run call.
+func (tc *TestCase) RunResult() *Result { return tc.result }
+
+// Fatalf delegates to the underlying *testing.T's Fatalf, marking this test
+// as a helper. Use it when an assertion needs custom formatting that the
+// built-in Assert* helpers don't cover.
+func (tc *TestCase) Fatalf(format string, args ...interface{}) {
+	tc.t.Helper()
+	tc.t.Fatalf(format, args...)
+}
+
 func (tc *TestCase) Skip(reason string) {
 	tc.t.Helper()
 	tc.t.Skip(reason)

--- a/tests/testdata/deploy_team_infer/teams/shrine-team-a.yml
+++ b/tests/testdata/deploy_team_infer/teams/shrine-team-a.yml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-team-a
+spec:
+  displayName: "Shrine Team A"
+  contact: "a@shrine-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy_team_infer/teams/shrine-team-b.yml
+++ b/tests/testdata/deploy_team_infer/teams/shrine-team-b.yml
@@ -1,0 +1,11 @@
+apiVersion: shrine/v1
+kind: Team
+metadata:
+  name: shrine-team-b
+spec:
+  displayName: "Shrine Team B"
+  contact: "b@shrine-test.com"
+  quotas:
+    maxApps: 10
+    maxResources: 10
+  registryUser: shrine-test

--- a/tests/testdata/deploy_team_infer/us1/app.yml
+++ b/tests/testdata/deploy_team_infer/us1/app.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: ops-bot
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  env:
+    - name: DB_CONNECTION_URL
+      valueFrom: resource.ops-bot-db.DB_CONNECTION_URL

--- a/tests/testdata/deploy_team_infer/us1/db.yml
+++ b/tests/testdata/deploy_team_infer/us1/db.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: ops-bot-db
+  owner: shrine-team-a
+spec:
+  type: postgres
+  version: "16"
+  image: traefik/whoami
+  outputs:
+    - name: DB_CONNECTION_URL
+      value: "postgres://example"

--- a/tests/testdata/deploy_team_infer/us1_explicit/app.yml
+++ b/tests/testdata/deploy_team_infer/us1_explicit/app.yml
@@ -1,0 +1,16 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: ops-bot
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  dependencies:
+    - kind: Resource
+      name: ops-bot-db
+      owner: shrine-team-a
+  env:
+    - name: DB_CONNECTION_URL
+      valueFrom: resource.ops-bot-db.DB_CONNECTION_URL

--- a/tests/testdata/deploy_team_infer/us1_explicit/db.yml
+++ b/tests/testdata/deploy_team_infer/us1_explicit/db.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: ops-bot-db
+  owner: shrine-team-a
+spec:
+  type: postgres
+  version: "16"
+  image: traefik/whoami
+  outputs:
+    - name: DB_CONNECTION_URL
+      value: "postgres://example"

--- a/tests/testdata/deploy_team_infer/us2/consumer.yml
+++ b/tests/testdata/deploy_team_infer/us2/consumer.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: consumer
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  env:
+    - name: PROD_HOST
+      valueFrom: application.producer.host

--- a/tests/testdata/deploy_team_infer/us2/producer.yml
+++ b/tests/testdata/deploy_team_infer/us2/producer.yml
@@ -1,0 +1,9 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: producer
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1

--- a/tests/testdata/deploy_team_infer/us3_absent/app.yml
+++ b/tests/testdata/deploy_team_infer/us3_absent/app.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: ops-bot
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  env:
+    - name: BAD_REF
+      valueFrom: resource.does-not-exist.HOST

--- a/tests/testdata/deploy_team_infer/us3_crossteam/app.yml
+++ b/tests/testdata/deploy_team_infer/us3_crossteam/app.yml
@@ -1,0 +1,12 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: ops-bot
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  env:
+    - name: CACHE_HOST
+      valueFrom: resource.shared-cache.HOST

--- a/tests/testdata/deploy_team_infer/us3_crossteam/shared.yml
+++ b/tests/testdata/deploy_team_infer/us3_crossteam/shared.yml
@@ -1,0 +1,14 @@
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: shared-cache
+  owner: shrine-team-b
+  access: [shrine-team-a]
+spec:
+  type: redis
+  version: "7"
+  networking:
+    exposeToPlatform: true
+  outputs:
+    - name: HOST
+      value: "shared-cache.svc"

--- a/tests/testdata/deploy_team_infer/us3_crossteam_explicit/app.yml
+++ b/tests/testdata/deploy_team_infer/us3_crossteam_explicit/app.yml
@@ -1,0 +1,16 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: ops-bot
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  dependencies:
+    - kind: Resource
+      name: shared-cache
+      owner: shrine-team-b
+  env:
+    - name: CACHE_HOST
+      valueFrom: resource.shared-cache.HOST

--- a/tests/testdata/deploy_team_infer/us3_crossteam_explicit/shared.yml
+++ b/tests/testdata/deploy_team_infer/us3_crossteam_explicit/shared.yml
@@ -1,0 +1,14 @@
+apiVersion: shrine/v1
+kind: Resource
+metadata:
+  name: shared-cache
+  owner: shrine-team-b
+  access: [shrine-team-a]
+spec:
+  type: redis
+  version: "7"
+  networking:
+    exposeToPlatform: true
+  outputs:
+    - name: HOST
+      value: "shared-cache.svc"

--- a/tests/testdata/deploy_team_infer/us3_failfast/alpha.yml
+++ b/tests/testdata/deploy_team_infer/us3_failfast/alpha.yml
@@ -1,0 +1,14 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: alpha
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  env:
+    - name: A1
+      valueFrom: resource.missing-a1.HOST
+    - name: A2
+      valueFrom: resource.missing-a2.HOST

--- a/tests/testdata/deploy_team_infer/us3_failfast/beta.yml
+++ b/tests/testdata/deploy_team_infer/us3_failfast/beta.yml
@@ -1,0 +1,14 @@
+apiVersion: shrine/v1
+kind: Application
+metadata:
+  name: beta
+  owner: shrine-team-a
+spec:
+  image: traefik/whoami
+  port: 80
+  replicas: 1
+  env:
+    - name: B1
+      valueFrom: resource.missing-b1.HOST
+    - name: B2
+      valueFrom: resource.missing-b2.HOST


### PR DESCRIPTION
## What

`shrine deploy` (and `--dry-run`) now derives implicit deploy-order edges for an Application from its env vars whose `valueFrom` references another same-team manifest — so a Resource referenced via `valueFrom: resource.<X>.<output>` is always deployed before the consumer Application without requiring an explicit `spec.dependencies` block. Cross-team or absent references without an explicit dep now fail the planner with a clear `enrichment: …` error on stderr and a non-zero exit; vault refs and literal values are silently skipped.

## Why

Operators kept hitting deploy failures where an Application referenced a same-team Resource via env `valueFrom` but Shrine started both in parallel because no explicit `spec.dependencies` entry existed. The reference was already on disk and machine-readable; forcing operators to also restate it as a dependency was redundant. Silent cross-team coupling, on the other hand, hid lifecycle dependencies between teams — so cross-team references now require an explicit dep on pain of planner failure, making the coupling visible in code review. See `specs/020-infer-valuefrom-deps/spec.md` for the full user stories.

## How to test

- `go test ./...` — unit gate (covers `internal/planner` enrich tests, `internal/handler` plan-format tests, and the no-disk-write / input-immutability invariants).
- `go test -tags integration -run TestDeployTeam_Inference ./tests/integration/...` — exercises US1/US2/US3 end-to-end against the real shrine binary via `NewDockerSuite` (same-team Resource ordering, same-team app-to-app ordering, cross-team failure with and without explicit dep, absent-target failure, fail-fast determinism).
- Manual walkthrough from `specs/020-infer-valuefrom-deps/quickstart.md` Part A:
  - Apply teams, drop the `ops-bot` + `ops-bot-db` fixtures, run `shrine deploy team ops_bot --dry-run` — output begins with `Deploy order:` and tags the inferred dep `(inferred from env DB_CONNECTION_URL)`.
  - Add a `valueFrom: resource.shared-cache.HOST` for a `team_b`-owned Resource without an explicit dep — planner exits non-zero with the `enrichment: app "ops-bot" env "CACHE_HOST" references resource "shared-cache.HOST" …` line.

## Checklist

- [x] Tests added or updated
- [x] `go test ./...` passes locally
- [x] Documentation updated (if behaviour changed)
- [ ] This is a breaking change (manifest schema, CLI flags, or config format changed)